### PR TITLE
Remove temporary unit test JSON

### DIFF
--- a/example.py
+++ b/example.py
@@ -1,3 +1,3 @@
 import hydragnn
 
-hydragnn.run_training()
+hydragnn.run_training("./examples/configuration.json")

--- a/hydragnn/run_prediction.py
+++ b/hydragnn/run_prediction.py
@@ -19,7 +19,7 @@ from hydragnn.models.create import create
 from hydragnn.train.train_validate_test import test
 
 
-def run_prediction(config_file: str = "./examples/configuration.json"):
+def run_prediction(config_file: str):
 
     config = {}
     with open(config_file, "r") as f:

--- a/hydragnn/run_prediction.py
+++ b/hydragnn/run_prediction.py
@@ -19,13 +19,16 @@ from hydragnn.models.create import create
 from hydragnn.train.train_validate_test import test
 
 
-def run_prediction(config_file: str = None, chosen_model: torch.nn.Module = None):
+def run_prediction(config_file: str = "./examples/configuration.json"):
 
-    if config_file is None:
-        raise RuntimeError("No configure file provided")
+    config = {}
+    with open(config_file, "r") as f:
+        config = json.load(f)
 
-    if chosen_model is None:
-        raise RuntimeError("No model type provided")
+    run_prediction(config)
+
+
+def run_prediction(config: {}):
 
     try:
         os.environ["SERIALIZED_DATA_PATH"]
@@ -33,10 +36,6 @@ def run_prediction(config_file: str = None, chosen_model: torch.nn.Module = None
         os.environ["SERIALIZED_DATA_PATH"] = os.getcwd()
 
     world_size, world_rank = setup_ddp()
-
-    config = {}
-    with open(config_file, "r") as f:
-        config = json.load(f)
 
     output_type = config["NeuralNetwork"]["Variables_of_interest"]["type"]
     output_index = config["NeuralNetwork"]["Variables_of_interest"]["output_index"]

--- a/hydragnn/run_prediction.py
+++ b/hydragnn/run_prediction.py
@@ -10,6 +10,7 @@
 ##############################################################################
 
 import json, os
+from functools import singledispatch
 
 import torch
 
@@ -19,7 +20,13 @@ from hydragnn.models.create import create
 from hydragnn.train.train_validate_test import test
 
 
-def run_prediction(config_file: str):
+@singledispatch
+def run_prediction(config):
+    raise TypeError("Input must be filename string or configuration dictionary.")
+
+
+@run_prediction.register
+def _(config_file: str):
 
     config = {}
     with open(config_file, "r") as f:
@@ -28,7 +35,8 @@ def run_prediction(config_file: str):
     run_prediction(config)
 
 
-def run_prediction(config: {}):
+@run_prediction.register
+def run_prediction(config: dict):
 
     try:
         os.environ["SERIALIZED_DATA_PATH"]

--- a/hydragnn/run_training.py
+++ b/hydragnn/run_training.py
@@ -11,6 +11,7 @@
 
 import sys, os, json
 import pickle
+from functools import singledispatch
 
 import torch
 import torch.distributed as dist
@@ -24,7 +25,13 @@ from hydragnn.models.create import create, get_device
 from hydragnn.train.train_validate_test import train_validate_test
 
 
-def run_training(config_file: str):
+@singledispatch
+def run_training(config):
+    raise TypeError("Input must be filename string or configuration dictionary.")
+
+
+@run_training.register
+def _(config_file: str):
 
     config = {}
     with open(config_file, "r") as f:
@@ -33,7 +40,8 @@ def run_training(config_file: str):
     run_training(config)
 
 
-def run_training(config: {}):
+@run_training.register
+def _(config: dict):
 
     try:
         os.environ["SERIALIZED_DATA_PATH"]

--- a/hydragnn/run_training.py
+++ b/hydragnn/run_training.py
@@ -24,7 +24,7 @@ from hydragnn.models.create import create, get_device
 from hydragnn.train.train_validate_test import train_validate_test
 
 
-def run_training(config_file: str = "./examples/configuration.json"):
+def run_training(config_file: str):
 
     config = {}
     with open(config_file, "r") as f:

--- a/hydragnn/run_training.py
+++ b/hydragnn/run_training.py
@@ -24,7 +24,16 @@ from hydragnn.models.create import create, get_device
 from hydragnn.train.train_validate_test import train_validate_test
 
 
-def run_training(config_file="./examples/configuration.json"):
+def run_training(config_file: str = "./examples/configuration.json"):
+
+    config = {}
+    with open(config_file, "r") as f:
+        config = json.load(f)
+
+    run_training(config)
+
+
+def run_training(config: {}):
 
     try:
         os.environ["SERIALIZED_DATA_PATH"]
@@ -32,10 +41,6 @@ def run_training(config_file="./examples/configuration.json"):
         os.environ["SERIALIZED_DATA_PATH"] = os.getcwd()
 
     world_size, world_rank = setup_ddp()
-
-    config = {}
-    with open(config_file, "r") as f:
-        config = json.load(f)
 
     verbosity = config["Verbosity"]["level"]
     train_loader, val_loader, test_loader = dataset_loading_and_splitting(

--- a/hydragnn/unit_tests/test_graphs.py
+++ b/hydragnn/unit_tests/test_graphs.py
@@ -31,6 +31,7 @@ def pytest_train_model(model_type, ci_input, overwrite_data=False):
     config = {}
     with open(config_file, "r") as f:
         config = json.load(f)
+    config["NeuralNetwork"]["Architecture"]["model_type"] = model_type
 
     if rank == 0:
         num_samples_tot = 500
@@ -70,12 +71,7 @@ def pytest_train_model(model_type, ci_input, overwrite_data=False):
                         data_path, number_configurations=num_samples
                     )
 
-    tmp_file = "./tmp.json"
-    config["NeuralNetwork"]["Architecture"]["model_type"] = model_type
-    with open(tmp_file, "w") as f:
-        json.dump(config, f)
-
-    hydragnn.run_training(tmp_file)
+    hydragnn.run_training(config)
 
     (
         error,
@@ -83,7 +79,7 @@ def pytest_train_model(model_type, ci_input, overwrite_data=False):
         error_rmse_task,
         true_values,
         predicted_values,
-    ) = hydragnn.run_prediction(tmp_file, model_type)
+    ) = hydragnn.run_prediction(config)
 
     # Set RMSE and sample error thresholds
     thresholds = {

--- a/hydragnn/unit_tests/test_graphs.py
+++ b/hydragnn/unit_tests/test_graphs.py
@@ -71,7 +71,12 @@ def pytest_train_model(model_type, ci_input, overwrite_data=False):
                         data_path, number_configurations=num_samples
                     )
 
-    hydragnn.run_training(config)
+    # Since the config file uses PNA already, test the file overload here.
+    # All the other models need to use the locally modified dictionary.
+    if model_type == "PNA":
+        hydragnn.run_training(config_file)
+    else:
+        hydragnn.run_training(config)
 
     (
         error,


### PR DESCRIPTION
@jychoi-hpc pointed out that multiple processes writing to the `tmp.json` file was likely causing the semi-regular MPI failures 

This adds overloads for `run_training` and `run_predict` that directly pass the config dictionary (modified during the test instead)

Also cleans up the interface for `run_predict`: config should be a required input and `chosen_model` was unused 