### PR TITLE
Add edge lengths

### DIFF
--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -194,7 +194,11 @@ class Base(Module):
         )
         ### encoder part ####
         for conv, batch_norm in zip(self.convs, self.batch_norms):
-            if data.edge_attr is not None:
+            if (data.edge_attr is not None) and (
+                hasattr(self, "edge_dim")
+                and self.edge_dim is not None
+                and self.edge_dim > 0
+            ):
                 c = conv(x=x, edge_index=edge_index, edge_attr=data.edge_attr)
             else:
                 c = conv(x=x, edge_index=edge_index)

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -206,12 +206,14 @@ class Base(Module):
             use_edge_attr = True
 
         ### encoder part ####
-        for conv, batch_norm in zip(self.convs, self.batch_norms):
-            if use_edge_attr:
+        if use_edge_attr:
+            for conv, batch_norm in zip(self.convs, self.batch_norms):
                 c = conv(x=x, edge_index=edge_index, edge_attr=data.edge_attr)
-            else:
+                x = F.relu(batch_norm(c))
+        else:
+            for conv, batch_norm in zip(self.convs, self.batch_norms):
                 c = conv(x=x, edge_index=edge_index)
-            x = F.relu(batch_norm(c))
+                x = F.relu(batch_norm(c))
 
         #### multi-head decoder part####
         # shared dense layers for graph level output

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -194,7 +194,12 @@ class Base(Module):
         )
         ### encoder part ####
         for conv, batch_norm in zip(self.convs, self.batch_norms):
-            x = F.relu(batch_norm(conv(x=x, edge_index=edge_index)))
+            if data.edge_attr is not None:
+                c = conv(x=x, edge_index=edge_index, edge_attr=data.edge_attr)
+            else:
+                c = conv(x=x, edge_index=edge_index)
+            x = F.relu(batch_norm(c))
+
         #### multi-head decoder part####
         # shared dense layers for graph level output
         x_graph = global_mean_pool(x, batch)

--- a/hydragnn/models/PNAStack.py
+++ b/hydragnn/models/PNAStack.py
@@ -26,6 +26,7 @@ class PNAStack(Base):
         num_nodes: int,
         hidden_dim: int,
         config_heads: {},
+        edge_dim: list = None,
         dropout: float = 0.25,
         num_conv_layers: int = 16,
         ilossweights_hyperp: int = 1,  # if =1, considering weighted losses for different tasks and treat the weights as hyper parameters
@@ -42,6 +43,7 @@ class PNAStack(Base):
             "linear",
         ]
         self.deg = deg
+        self.edge_dim = edge_dim
 
         super().__init__(
             input_dim,
@@ -64,6 +66,7 @@ class PNAStack(Base):
             aggregators=self.aggregators,
             scalers=self.scalers,
             deg=self.deg,
+            edge_dim=self.edge_dim,
             pre_layers=1,
             post_layers=1,
             divide_input=False,

--- a/hydragnn/models/PNAStack.py
+++ b/hydragnn/models/PNAStack.py
@@ -26,7 +26,7 @@ class PNAStack(Base):
         num_nodes: int,
         hidden_dim: int,
         config_heads: {},
-        edge_dim: list = None,
+        edge_dim: int = None,
         dropout: float = 0.25,
         num_conv_layers: int = 16,
         ilossweights_hyperp: int = 1,  # if =1, considering weighted losses for different tasks and treat the weights as hyper parameters

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -51,6 +51,10 @@ def create(
             model_type in edge_models
         ), "Edge features can only be used with PNA and CGCNN."
         edge_dim = len(config["edge_features"])
+    elif model_type == "CGCNN":
+        # CG always needs an integer edge_dim
+        # PNA would fail with integer edge_dim without edge_attr
+        edge_dim = 0
 
     if model_type == "GIN":
         model = GINStack(

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -44,6 +44,14 @@ def create(
     # i.e., self.node_NN_type = "mlp_per_node"
     num_atoms = dataset[0].num_nodes
 
+    edge_dim = None
+    edge_models = ["PNA", "CGCNN"]
+    if "edge_features" in config and config["edge_features"]:
+        assert (
+            model_type in edge_models
+        ), "Edge features can only be used with PNA and CGCNN."
+        edge_dim = len(config["edge_features"])
+
     if model_type == "GIN":
         model = GINStack(
             input_dim=input_dim,
@@ -71,6 +79,7 @@ def create(
             output_type=config["output_type"],
             config_heads=config["output_heads"],
             loss_weights=config["task_weights"],
+            edge_dim=edge_dim,
         ).to(device)
 
     elif model_type == "GAT":
@@ -107,6 +116,7 @@ def create(
             config_heads=config["output_heads"],
             loss_weights=config["task_weights"],
         ).to(device)
+
     elif model_type == "CGCNN":
         model = CGCNNStack(
             input_dim=input_dim,
@@ -116,6 +126,7 @@ def create(
             output_type=config["output_type"],
             config_heads=config["output_heads"],
             loss_weights=config["task_weights"],
+            edge_dim=edge_dim,
         ).to(device)
     else:
         raise ValueError("Unknown model_type: {0}".format(model_type))

--- a/hydragnn/preprocess/serialized_dataset_loader.py
+++ b/hydragnn/preprocess/serialized_dataset_loader.py
@@ -69,9 +69,19 @@ class SerializedDataLoader:
         )
         compute_edge_lengths = Distance(norm=False, cat=True)
 
+        dataset[:] = [compute_edges(data) for data in dataset]
+        dataset[:] = [compute_edge_lengths(data) for data in dataset]
+
+        max_edge_length = torch.Tensor([float("-inf")])
+
         for data in dataset:
-            data = compute_edges(data)
-            data = compute_edge_lengths(data)
+            max_edge_length = torch.max(max_edge_length, torch.max(data.edge_attr))
+
+        # Normalization of the edges
+        for data in dataset:
+            data.edge_attr = data.edge_attr / max_edge_length
+
+        for data in dataset:
             self.__update_predicted_values(
                 config["Variables_of_interest"]["type"],
                 config["Variables_of_interest"]["output_index"],

--- a/hydragnn/preprocess/serialized_dataset_loader.py
+++ b/hydragnn/preprocess/serialized_dataset_loader.py
@@ -15,7 +15,7 @@ from sklearn.model_selection import StratifiedShuffleSplit
 
 import torch
 from torch_geometric.data import Data
-from torch_geometric.transforms import RadiusGraph
+from torch_geometric.transforms import RadiusGraph, Distance
 
 from .dataset_descriptors import AtomFeatures
 from hydragnn.utils.print_utils import print_distributed, iterate_tqdm
@@ -67,9 +67,11 @@ class SerializedDataLoader:
             loop=False,
             max_num_neighbors=config["Architecture"]["max_neighbours"],
         )
+        compute_edge_lengths = Distance(norm=True, cat=True)
 
         for data in dataset:
             data = compute_edges(data)
+            data = compute_edge_lengths(data)
             self.__update_predicted_values(
                 config["Variables_of_interest"]["type"],
                 config["Variables_of_interest"]["output_index"],

--- a/hydragnn/preprocess/serialized_dataset_loader.py
+++ b/hydragnn/preprocess/serialized_dataset_loader.py
@@ -67,7 +67,7 @@ class SerializedDataLoader:
             loop=False,
             max_num_neighbors=config["Architecture"]["max_neighbours"],
         )
-        compute_edge_lengths = Distance(norm=True, cat=True)
+        compute_edge_lengths = Distance(norm=False, cat=True)
 
         for data in dataset:
             data = compute_edges(data)


### PR DESCRIPTION
(From GCNN:)
With @pzhanggit 's help I have found:
- Only PNA and CGConv support
- GIN has an additional version GINE for edges
~~PNA currently breaks because we don't define the `edge_encoder`~~
~~GINE currently breaks because dimensions that don't agree (but I think actually do based on what I've checked)~~

Only implemented for PNA and CG (GINE does not have robust enough support to justify adding). New test only calls for these two models with edge lengths

Part of #2