### PR TITLE
Shared model initialization

### DIFF
--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -36,10 +36,10 @@ class Base(torch.nn.Module):
         self._init_model()
 
     def _init_model(self):
-        self.convs.append(self.get_conv(self.input_dim))
+        self.convs.append(self.get_conv(self.input_dim, self.hidden_dim))
         self.batch_norms.append(BatchNorm(self.hidden_dim))
         for _ in range(self.num_conv_layers - 1):
-            conv = self.get_conv(self.hidden_dim)
+            conv = self.get_conv(self.hidden_dim, self.hidden_dim)
             self.convs.append(conv)
             self.batch_norms.append(BatchNorm(self.hidden_dim))
 

--- a/hydragnn/models/CGCNNStack.py
+++ b/hydragnn/models/CGCNNStack.py
@@ -46,9 +46,9 @@ class CGCNNStack(Base):
             ilossweights_nll,
         )
 
-    def get_conv(self, dim):
+    def get_conv(self, input_dim, _):
         return CGConv(
-            channels=dim,
+            channels=input_dim,
             dim=self.edge_dim,
             aggr="add",
             batch_norm=False,

--- a/hydragnn/models/GATStack.py
+++ b/hydragnn/models/GATStack.py
@@ -52,20 +52,20 @@ class GATStack(Base):
         )
 
     def _init_model(self):
-        self.convs.append(self.get_conv(self.input_dim, True))
+        self.convs.append(self.get_conv(self.input_dim, self.hidden_dim, True))
         self.batch_norms.append(BatchNorm(self.hidden_dim * self.heads))
         for _ in range(self.num_conv_layers - 2):
-            conv = self.get_conv(self.hidden_dim * self.heads, True)
+            conv = self.get_conv(self.hidden_dim * self.heads, self.hidden_dim, True)
             self.convs.append(conv)
             self.batch_norms.append(BatchNorm(self.hidden_dim * self.heads))
-        conv = self.get_conv(self.hidden_dim * self.heads, False)
+        conv = self.get_conv(self.hidden_dim * self.heads, self.hidden_dim, False)
         self.convs.append(conv)
         self.batch_norms.append(BatchNorm(self.hidden_dim))
 
-    def get_conv(self, in_channels, concat):
+    def get_conv(self, input_dim, output_dim, concat):
         return GATv2Conv(
-            in_channels=in_channels,
-            out_channels=self.hidden_dim,
+            in_channels=input_dim,
+            out_channels=output_dim,
             heads=self.heads,
             negative_slope=self.negative_slope,
             dropout=self.dropout,

--- a/hydragnn/models/GINStack.py
+++ b/hydragnn/models/GINStack.py
@@ -46,12 +46,12 @@ class GINStack(Base):
             ilossweights_nll,
         )
 
-    def get_conv(self, dim):
+    def get_conv(self, input_dim, output_dim):
         return GINConv(
             nn.Sequential(
-                nn.Linear(dim, self.hidden_dim),
+                nn.Linear(input_dim, output_dim),
                 nn.ReLU(),
-                nn.Linear(self.hidden_dim, self.hidden_dim),
+                nn.Linear(output_dim, output_dim),
             ),
             eps=100.0,
             train_eps=True,

--- a/hydragnn/models/MFCStack.py
+++ b/hydragnn/models/MFCStack.py
@@ -49,10 +49,10 @@ class MFCStack(Base):
             ilossweights_nll,
         )
 
-    def get_conv(self, dim):
+    def get_conv(self, input_dim, output_dim):
         return MFConv(
-            in_channels=dim,
-            out_channels=self.hidden_dim,
+            in_channels=input_dim,
+            out_channels=output_dim,
             max_degree=self.max_degree,
         )
 

--- a/hydragnn/models/PNAStack.py
+++ b/hydragnn/models/PNAStack.py
@@ -55,10 +55,10 @@ class PNAStack(Base):
             ilossweights_nll,
         )
 
-    def get_conv(self, dim):
+    def get_conv(self, input_dim, output_dim):
         return PNAConv(
-            in_channels=dim,
-            out_channels=self.hidden_dim,
+            in_channels=input_dim,
+            out_channels=output_dim,
             aggregators=self.aggregators,
             scalers=self.scalers,
             deg=self.deg,


### PR DESCRIPTION
Use a base `model_init` routine (except for GAT) that calls a new `get_model` to simplify models. This requires that all properties are stored in the inherited class

Will be even more important as features across all models get more complex (#12)