### PR TITLE
Reduce training epochs

### DIFF
--- a/examples/ci.json
+++ b/examples/ci.json
@@ -51,7 +51,7 @@
             "denormalize_output": "False"
         },
         "Training": {
-            "num_epoch": 150,
+            "num_epoch": 100,
             "perc_train": 0.7,
             "learning_rate": 0.02,
             "batch_size": 32

--- a/examples/ci_multihead.json
+++ b/examples/ci_multihead.json
@@ -49,7 +49,7 @@
             "denormalize_output": "False"
         },
         "Training": {
-            "num_epoch": 200,
+            "num_epoch": 100,
             "perc_train": 0.7,
             "learning_rate": 0.01,
             "batch_size": 32


### PR DESCRIPTION
Just testing. I don't see any cases locally that need more iterations