### PR TITLE
Improve neighbor computing

### DIFF
--- a/examples/configuration.json
+++ b/examples/configuration.json
@@ -22,7 +22,7 @@
         "Architecture": {
             "model_type": "PNA",
             "radius": 7,
-            "max_neighbours": 5,
+            "max_neighbours": 100000,
             "hidden_dim": 5,
             "num_conv_layers": 6,
             "output_heads": {

--- a/hydragnn/preprocess/serialized_dataset_loader.py
+++ b/hydragnn/preprocess/serialized_dataset_loader.py
@@ -64,7 +64,7 @@ class SerializedDataLoader:
 
         compute_edges = RadiusGraph(
             r=config["Architecture"]["radius"],
-            loop=True,
+            loop=False,
             max_num_neighbors=config["Architecture"]["max_neighbours"],
         )
 

--- a/tests/inputs/ci.json
+++ b/tests/inputs/ci.json
@@ -26,7 +26,7 @@
         "Architecture": {
             "model_type": "PNA",
             "radius": 2.0,
-            "max_neighbours": 4,
+            "max_neighbours": 100,
             "hidden_dim": 4,
             "num_conv_layers": 2,
             "output_heads": {

--- a/tests/inputs/ci_multihead.json
+++ b/tests/inputs/ci_multihead.json
@@ -24,7 +24,7 @@
         "Architecture": {
             "model_type": "PNA",
             "radius": 2.0,
-            "max_neighbours": 3,
+            "max_neighbours": 100,
             "hidden_dim": 4,
             "num_conv_layers": 3,
             "output_heads": {


### PR DESCRIPTION
Related to GraphRadius implemented in https://github.com/ORNL/HydraGNN/pull/30
Two changes:

1. set `loop` to be `False` in `RadiusGraph` to disable self-loops
2. Set `max_neighbours` in input files to be a large number to disable its constraint on maximum number of neighbors. After this change, the number of neighbors is purely determined by `radius`.