### PR TITLE
Add `precommit`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,8 +5,8 @@ repos:
       - id: check-merge-conflict
       - id: trailing-whitespace
       - id: end-of-file-fixer
-  
+
   - repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 21.5b1
     hooks:
-      - id: black 
+      - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+      - id: check-merge-conflict
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  
+  - repo: https://github.com/psf/black
+    rev: 19.3b0
+    hooks:
+      - id: black 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,18 @@ Additional dependencies are needed for formatting and testing:
 pip install -r requirements-dev.txt
 ```
 
+## Automatic commit checking
+
+You can use `pre-install` to ensure everything is ready to be submitted in a
+pull request. Once `pip` installed, `pre-commit` must be installed once (only
+the first time being used): `pre-commit install`. Formatting checks are then
+run for every commit.
+
+`PRE_COMMIT_ALLOW_NO_CONFIG=1 git commit ...` can be used to selectively skip
+these checks.
+
+Checks can instead be done manually, described below.
+
 ## Code formatting
 
 HydraGNN is formatted with `black`. You should run `black .` from the top level

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black
+black==21.5b1
 pre-commit
 pytest
 pytest-mpi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 black
+pre-commit
 pytest
 pytest-mpi


### PR DESCRIPTION
Fixes #75.

Based on the feedback provided by @streeve I've added `black` among some other miscellaneous checks to the `.pre-commit-config.yaml`. I've also added `pre-commit` to the `requirements-dev.txt` file in order to aid new contributors.

I have not added `pytest` as of right now based on the feedback provided but more than happy to take that up again. 

I'd also recommend adding instructions on how to install pre-commit hooks to the [**`CONTRIBUTING.md`**](https://github.com/ORNL/HydraGNN/blob/main/CONTRIBUTING.md) file.