### PR TITLE
Check Cuda enabled for profiler

### DIFF
--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -204,7 +204,7 @@ def train(
     model,
     opt,
     verbosity,
-    profiler=contextlib.nullcontext(MagicMock(name="step")),
+    profiler=Profiler(),
 ):
     tasks_error = np.zeros(model.num_heads)
 

--- a/hydragnn/utils/profile.py
+++ b/hydragnn/utils/profile.py
@@ -5,7 +5,7 @@ from torch.profiler import profile, record_function, ProfilerActivity
 
 
 class Profiler(torch.profiler.profile):
-    def __init__(self, prefix, enable=False, target_epoch=0):
+    def __init__(self, prefix="", enable=False, target_epoch=0):
         self.prefix = prefix
         self.enable = enable
         self.target_epoch = target_epoch


### PR DESCRIPTION
This fix blocks #35 and, only for older versions of pytorch, requires that we check for cuda before enabling cuda profiling