### PR TITLE
Remove num_nodes_list

### DIFF
--- a/hydragnn/preprocess/raw_dataset_loader.py
+++ b/hydragnn/preprocess/raw_dataset_loader.py
@@ -166,7 +166,6 @@ class RawDataLoader:
 
         data_object.pos = tensor(node_position_matrix)
         data_object.x = tensor(node_feature_matrix)
-        data_object.num_nodes_list = data_object.pos.shape[0]
         return data_object
 
     def __charge_density_update_for_LSMS(self, data_object: Data):

--- a/hydragnn/preprocess/utils.py
+++ b/hydragnn/preprocess/utils.py
@@ -14,8 +14,8 @@ def check_if_graph_size_constant(train_loader, val_loader, test_loader):
     graph_size_variable = False
     nodes_num_list = []
     for loader in [train_loader, val_loader, test_loader]:
-        for data in loader:
-            nodes_num_list.extend(data.num_nodes_list.tolist())
+        for data in loader.dataset:
+            nodes_num_list.append(data.num_nodes)
             if len(list(set(nodes_num_list))) > 1:
                 graph_size_variable = True
                 return graph_size_variable

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -59,9 +59,9 @@ def train_validate_test(
     ## collecting node feature
     node_feature = []
     nodes_num_list = []
-    for data in test_loader:
+    for data in test_loader.dataset:
         node_feature.extend(data.x.tolist())
-        nodes_num_list.extend(data.num_nodes_list.tolist())
+        nodes_num_list.append(data.num_nodes)
 
     visualizer = Visualizer(
         model_with_config_name,


### PR DESCRIPTION
This simplifies creating the histogram of nodes per graph, by using built-in `num_nodes` instead. Blocks #35 