### PR TITLE
Fixup tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,5 +50,5 @@ jobs:
           # FIXME: install
           export PYTHONPATH=$PYTHONPATH:~/HydraGNN
           pip list
-          python -m pytest -rfEP -W error -W ignore::DeprecationWarning
-          mpirun -n 2 python -m pytest -rfEP -W error -W ignore::DeprecationWarning --with-mpi
+          python -m pytest -rfEP -W error -W ignore::DeprecationWarning --tb=native
+          mpirun -n 2 python -m pytest -rfEP -W error -W ignore::DeprecationWarning --tb=native --with-mpi

--- a/tests/deterministic_graph_data.py
+++ b/tests/deterministic_graph_data.py
@@ -23,7 +23,7 @@ def deterministic_graph_data(
     number_unit_cell_x_range: list = [1, 3],
     number_unit_cell_y_range: list = [1, 3],
     number_unit_cell_z_range: list = [1, 2],
-    number_clusters: int = 3,
+    number_types: int = 3,
     number_neighbors: int = 2,
 ):
     ###############################################################################################
@@ -90,36 +90,36 @@ def deterministic_graph_data(
         node_ids = torch.tensor([int(i) for i in range(0, number_nodes)]).reshape(
             (number_nodes, 1)
         )
-        cluster_ids_x = torch.randint(0, number_clusters, (number_nodes, 1))
+        node_output_x = torch.randint(0, number_types, (number_nodes, 1))
 
-        node_feature = cluster_ids_x
-        cluster_ids_x_square = node_feature ** 2
-        cluster_ids_x_cube = node_feature ** 3
+        node_feature = node_output_x
+        node_output_x_square = node_feature ** 2
+        node_output_x_cube = node_feature ** 3
 
         # We use a K neraest neighbor model to average nodal features and simulate a message passing between neighboring nodes
         knn = KNeighborsRegressor(number_neighbors)
         knn.fit(positions, node_feature)
         node_feature = torch.Tensor(knn.predict(positions))
-        cluster_ids_x_square = node_feature ** 2
-        cluster_ids_x_cube = node_feature ** 3
+        node_output_x_square = node_feature ** 2
+        node_output_x_cube = node_feature ** 3
 
         updated_table = torch.cat(
             (
                 node_feature,
                 node_ids,
                 positions,
-                cluster_ids_x,
-                cluster_ids_x_square,
-                cluster_ids_x_cube,
+                node_output_x,
+                node_output_x_square,
+                node_output_x_cube,
             ),
             1,
         )
         numpy_updated_table = updated_table.detach().numpy()
 
         total_value = (
-            torch.sum(cluster_ids_x)
-            + torch.sum(cluster_ids_x_square)
-            + torch.sum(cluster_ids_x_cube)
+            torch.sum(node_output_x)
+            + torch.sum(node_output_x_square)
+            + torch.sum(node_output_x_cube)
         )
         numpy_total_value = total_value.detach().numpy()
         numpy_string_total_value = numpy.array2string(numpy_total_value)

--- a/tests/deterministic_graph_data.py
+++ b/tests/deterministic_graph_data.py
@@ -90,18 +90,14 @@ def deterministic_graph_data(
         node_ids = torch.tensor([int(i) for i in range(0, number_nodes)]).reshape(
             (number_nodes, 1)
         )
-        node_output_x = torch.randint(0, number_types, (number_nodes, 1))
-
-        node_feature = node_output_x
-        node_output_x_square = node_feature ** 2
-        node_output_x_cube = node_feature ** 3
+        node_feature = torch.randint(0, number_types, (number_nodes, 1))
 
         # We use a K neraest neighbor model to average nodal features and simulate a message passing between neighboring nodes
         knn = KNeighborsRegressor(number_neighbors)
         knn.fit(positions, node_feature)
-        node_feature = torch.Tensor(knn.predict(positions))
-        node_output_x_square = node_feature ** 2
-        node_output_x_cube = node_feature ** 3
+        node_output_x = torch.Tensor(knn.predict(positions))
+        node_output_x_square = node_output_x ** 2
+        node_output_x_cube = node_output_x ** 3
 
         updated_table = torch.cat(
             (

--- a/tests/inputs/ci.json
+++ b/tests/inputs/ci.json
@@ -1,6 +1,6 @@
 {
     "Verbosity": {
-        "level": 1
+        "level": 0
     },
     "Dataset": {
         "name": "unit_test_singlehead",

--- a/tests/inputs/ci_multihead.json
+++ b/tests/inputs/ci_multihead.json
@@ -1,6 +1,6 @@
 {
     "Verbosity": {
-        "level": 1
+        "level": 0
     },
     "Dataset": {
         "name": "unit_test_multihead",

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -122,12 +122,12 @@ def unittest_train_model(model_type, ci_input, use_lengths, overwrite_data=False
 
     # Set RMSE and sample error thresholds
     thresholds = {
-        "PNA": [0.10, 0.25],
-        "MFC": [0.10, 0.50],
-        "GIN": [0.15, 0.90],
-        "GAT": [0.80, 0.95],
+        "PNA": [0.20, 0.75],
+        "MFC": [0.20, 0.99],
+        "GIN": [0.25, 0.75],
+        "GAT": [0.60, 0.99],
         # fixme: error for cgcnn will be reduced after edge attributes being implemented
-        "CGCNN": [0.30, 0.95],
+        "CGCNN": [0.50, 0.95],
     }
     verbosity = 2
 

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -126,9 +126,11 @@ def unittest_train_model(model_type, ci_input, use_lengths, overwrite_data=False
         "MFC": [0.20, 0.99],
         "GIN": [0.25, 0.75],
         "GAT": [0.60, 0.99],
-        # fixme: error for cgcnn will be reduced after edge attributes being implemented
         "CGCNN": [0.50, 0.95],
     }
+    if use_lengths:
+        thresholds["CGCNN"] = [0.10, 0.30]
+        thresholds["PNA"] = [0.10, 0.40]
     verbosity = 2
 
     for ihead in range(len(true_values)):


### PR DESCRIPTION
This PR does 2 main things:

- Updates unit test to set node features to "type" (integers) and node outputs to KNN aggregated features (previously only the linear values were not updated)
- Sets separate thresholds for CG with and without edge lengths (intended to be done when added...)

~~Adds pytest step to remove all datasets (attempting to make sure we no longer have consistent failures on a given PR due to a particularly difficult to predict datset)~~
Will revisit this later. I don't know how to avoid random hangs

The rest is small cleanup ("clusters" is now "types", etc.)