### PR TITLE
rotational invariance added

### DIFF
--- a/examples/md17/md17.py
+++ b/examples/md17/md17.py
@@ -57,7 +57,7 @@ hydragnn.utils.setup_log(log_name)
 # Filter function above used to run quick example.
 # NOTE: data is moved to the device in the pre-transform.
 # NOTE: transforms/filters will NOT be re-run unless the qm9/processed/ directory is removed.
-compute_edges = hydragnn.preprocess.get_radius_graph(arch_config)
+compute_edges = hydragnn.preprocess.get_radius_graph_config(arch_config)
 dataset = torch_geometric.datasets.MD17(
     root="dataset/md17",
     name="uracil",

--- a/hydragnn/preprocess/__init__.py
+++ b/hydragnn/preprocess/__init__.py
@@ -1,5 +1,5 @@
 from .dataset_descriptors import AtomFeatures, StructureFeatures
-from .utils import check_if_graph_size_variable
+from .utils import check_if_graph_size_variable, get_radius_graph_config
 from .load_data import (
     dataset_loading_and_splitting,
     create_dataloaders,
@@ -10,7 +10,6 @@ from .load_data import (
 from .serialized_dataset_loader import (
     SerializedDataLoader,
     update_predicted_values,
-    get_radius_graph,
 )
 from .raw_dataset_loader import RawDataLoader
 from .compositional_data_splitting import compositional_stratified_splitting

--- a/hydragnn/preprocess/serialized_dataset_loader.py
+++ b/hydragnn/preprocess/serialized_dataset_loader.py
@@ -15,9 +15,10 @@ from sklearn.model_selection import StratifiedShuffleSplit
 
 import torch
 from torch_geometric.data import Data
-from torch_geometric.transforms import RadiusGraph, Distance, NormalizeRotation
+from torch_geometric.transforms import Distance, NormalizeRotation
 
 from .dataset_descriptors import AtomFeatures
+from hydragnn.preprocess import get_radius_graph_config
 from hydragnn.utils.distributed import get_device
 from hydragnn.utils.print_utils import print_distributed, iterate_tqdm
 
@@ -64,7 +65,7 @@ class SerializedDataLoader:
             dataset = pickle.load(f)
 
         rotational_invariance = NormalizeRotation(max_points=-1, sort=False)
-        compute_edges = get_radius_graph(config["NeuralNetwork"]["Architecture"])
+        compute_edges = get_radius_graph_config(config["NeuralNetwork"]["Architecture"])
         compute_edge_lengths = Distance(norm=False, cat=True)
 
         if config["Dataset"]["rotational_invariance"]:
@@ -169,14 +170,6 @@ class SerializedDataLoader:
             subsample.append(dataset[index])
 
         return subsample
-
-
-def get_radius_graph(config):
-    return RadiusGraph(
-        r=config["radius"],
-        loop=False,
-        max_num_neighbors=config["max_neighbours"],
-    )
 
 
 def update_predicted_values(type: list, index: list, data: Data):

--- a/hydragnn/preprocess/serialized_dataset_loader.py
+++ b/hydragnn/preprocess/serialized_dataset_loader.py
@@ -15,7 +15,7 @@ from sklearn.model_selection import StratifiedShuffleSplit
 
 import torch
 from torch_geometric.data import Data
-from torch_geometric.transforms import RadiusGraph, Distance
+from torch_geometric.transforms import RadiusGraph, Distance, NormalizeRotation
 
 from .dataset_descriptors import AtomFeatures
 from hydragnn.utils.distributed import get_device
@@ -63,8 +63,12 @@ class SerializedDataLoader:
             _ = pickle.load(f)
             dataset = pickle.load(f)
 
+        rotational_invariance = NormalizeRotation(max_points=-1, sort=False)
         compute_edges = get_radius_graph(config["NeuralNetwork"]["Architecture"])
         compute_edge_lengths = Distance(norm=False, cat=True)
+
+        if config["Dataset"]["rotational_invariance"]:
+            dataset[:] = [rotational_invariance(data) for data in dataset]
 
         dataset[:] = [compute_edges(data) for data in dataset]
         dataset[:] = [compute_edge_lengths(data) for data in dataset]

--- a/hydragnn/preprocess/utils.py
+++ b/hydragnn/preprocess/utils.py
@@ -9,6 +9,9 @@
 # SPDX-License-Identifier: BSD-3-Clause                                      #
 ##############################################################################
 
+import torch
+from torch_geometric.transforms import RadiusGraph
+
 
 def check_if_graph_size_variable(train_loader, val_loader, test_loader):
     graph_size_variable = False
@@ -20,3 +23,30 @@ def check_if_graph_size_variable(train_loader, val_loader, test_loader):
                 graph_size_variable = True
                 return graph_size_variable
     return graph_size_variable
+
+
+def check_data_samples_equivalence(data1, data2, tol):
+    x_bool = data1.x.shape == data2.x.shape
+    pos_bool = data1.pos.shape == data2.pos.shape
+    y_bool = data1.y.shape == data2.y.shape
+
+    found = [False for i in range(data1.edge_index.shape[1])]
+    for i in range(data1.edge_index.shape[1]):
+        for j in range(data1.edge_index.shape[1]):
+            if torch.equal(data1.edge_index[:, i], data2.edge_index[:, j]):
+                found[i] = True
+                # Due to numerics, the assert check fails for discrepancies below 1e-6
+                assert torch.norm(data1.edge_attr[i] - data2.edge_attr[j]) < tol
+                break
+
+    edge_bool = all(found)
+
+    return x_bool and pos_bool and y_bool and edge_bool
+
+
+def get_radius_graph_config(config, loop=False):
+    return RadiusGraph(
+        r=config["radius"],
+        loop=loop,
+        max_num_neighbors=config["max_neighbours"],
+    )

--- a/tests/inputs/ci.json
+++ b/tests/inputs/ci.json
@@ -5,6 +5,8 @@
     "Dataset": {
         "name": "unit_test_singlehead",
         "format": "unit_test",
+        "compositional_stratified_splitting": true,
+        "rotational_invariance": false,
         "path": {
             "train": "dataset/unit_test_singlehead_train",
             "test": "dataset/unit_test_singlehead_test",

--- a/tests/inputs/ci_multihead.json
+++ b/tests/inputs/ci_multihead.json
@@ -6,6 +6,7 @@
         "name": "unit_test_multihead",
         "format": "unit_test",
         "compositional_stratified_splitting": true,
+        "rotational_invariance": false,
         "path": {
             "total": "dataset/unit_test_multihead"
         },

--- a/tests/inputs/ci_rotational_invariance.json
+++ b/tests/inputs/ci_rotational_invariance.json
@@ -1,0 +1,6 @@
+{
+    "Architecture": {
+        "radius": 7.0,
+        "max_neighbours": 100000
+    }
+}

--- a/tests/test_rotational_invariance.py
+++ b/tests/test_rotational_invariance.py
@@ -1,0 +1,127 @@
+##############################################################################
+# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import sys, os, json
+import pytest
+
+import torch
+from torch_geometric.data import Data
+from torch_geometric.transforms import Distance, NormalizeRotation
+from hydragnn.preprocess.utils import (
+    get_radius_graph_config,
+)
+
+from hydragnn.preprocess.utils import (
+    check_data_samples_equivalence,
+)
+
+torch.set_default_tensor_type(torch.DoubleTensor)
+
+
+def unittest_rotational_invariance():
+    config_file = "./tests/inputs/ci_rotational_invariance.json"
+    config = {}
+    with open(config_file, "r") as f:
+        config = json.load(f)
+    compute_edges = get_radius_graph_config(config["Architecture"], loop=False)
+    compute_edge_lengths = Distance(norm=False, cat=True)
+    rotation = NormalizeRotation(max_points=-1, sort=False)
+
+    # Create BCT lattice structure with 32 nodes
+    data = Data()
+
+    data.pos = torch.tensor(
+        [
+            [0.000000000000000, 0.000000000000000, 0.000000000000000],
+            [2.609000000000000, 2.609000000000000, 3.529000000000000],
+            [5.218000000000000, 0.000000000000000, 0.000000000000000],
+            [7.827000000000000, 2.609000000000000, 3.529000000000000],
+            [0.000000000000000, 5.218000000000000, 0.000000000000000],
+            [2.609000000000000, 7.827000000000000, 3.529000000000000],
+            [5.218000000000000, 5.218000000000000, 0.000000000000000],
+            [7.827000000000000, 7.827000000000000, 3.529000000000000],
+            [0.000000000000000, 0.000000000000000, 7.058000000000000],
+            [2.609000000000000, 2.609000000000000, 10.587000000000000],
+            [5.218000000000000, 0.000000000000000, 7.058000000000000],
+            [7.827000000000000, 2.609000000000000, 10.587000000000000],
+            [0.000000000000000, 5.218000000000000, 7.058000000000000],
+            [2.609000000000000, 7.827000000000000, 10.587000000000000],
+            [5.218000000000000, 5.218000000000000, 7.058000000000000],
+            [7.827000000000000, 7.827000000000000, 10.587000000000000],
+            [10.436000000000000, 0.000000000000000, 0.000000000000000],
+            [13.045000000000000, 2.609000000000000, 3.529000000000000],
+            [15.654000000000000, 0.000000000000000, 0.000000000000000],
+            [18.262999999999998, 2.609000000000000, 3.529000000000000],
+            [10.436000000000000, 5.218000000000000, 0.000000000000000],
+            [13.045000000000000, 7.827000000000000, 3.529000000000000],
+            [15.654000000000000, 5.218000000000000, 0.000000000000000],
+            [18.262999999999998, 7.827000000000000, 3.529000000000000],
+            [10.436000000000000, 0.000000000000000, 7.058000000000000],
+            [13.045000000000000, 2.609000000000000, 10.587000000000000],
+            [15.654000000000000, 0.000000000000000, 7.058000000000000],
+            [18.262999999999998, 2.609000000000000, 10.587000000000000],
+            [10.436000000000000, 5.218000000000000, 7.058000000000000],
+            [13.045000000000000, 7.827000000000000, 10.587000000000000],
+            [15.654000000000000, 5.218000000000000, 7.058000000000000],
+            [18.262999999999998, 7.827000000000000, 10.587000000000000],
+        ]
+    )
+
+    # Create random nodal features
+    data.x = torch.randn(32, 1)
+
+    # Create arbitrary global feature
+    data.y = torch.tensor([[99]])
+
+    # Create a copy of the same data sample that is going to be rotated
+    data_rotated = data.clone()
+
+    data = compute_edges(data)
+    data = compute_edge_lengths(data)
+
+    # Rotate clone data
+    data_rotated = rotation(data_rotated)
+
+    data_rotated = compute_edges(data_rotated)
+    data_rotated = compute_edge_lengths(data_rotated)
+
+    assert check_data_samples_equivalence(data, data_rotated, 1e-14)
+
+    # Repeat the same check on 10 graphs randomly generated
+    for num_random_graphs in range(10):
+        data = Data()
+
+        # The position of the nodes in the graph is random
+        data.pos = 3 * torch.randn(10, 3)
+
+        # Create random nodal features
+        data.x = torch.randn_like(data.pos)
+
+        # Create arbitrary global feature
+        data.y = torch.randn(1, 1)
+
+        # Create a copy of the same data sample that is going to be rotated
+        data_rotated = data.clone()
+
+        data = compute_edges(data)
+        data = compute_edge_lengths(data)
+
+        # Rotate clone data
+        data_rotated = rotation(data_rotated)
+
+        data_rotated = compute_edges(data_rotated)
+        data_rotated = compute_edge_lengths(data_rotated)
+
+        assert check_data_samples_equivalence(data, data_rotated, 1e-14)
+
+
+def pytest_train_model():
+    unittest_rotational_invariance()

--- a/tests/test_rotational_invariance.py
+++ b/tests/test_rotational_invariance.py
@@ -15,72 +15,43 @@ import pytest
 import torch
 from torch_geometric.data import Data
 from torch_geometric.transforms import Distance, NormalizeRotation
-from hydragnn.preprocess.utils import (
-    get_radius_graph_config,
-)
+from hydragnn.preprocess.utils import get_radius_graph_config
 
 from hydragnn.preprocess.utils import (
     check_data_samples_equivalence,
 )
 
-torch.set_default_tensor_type(torch.DoubleTensor)
 
-
-def unittest_rotational_invariance():
-    config_file = "./tests/inputs/ci_rotational_invariance.json"
-    config = {}
-    with open(config_file, "r") as f:
-        config = json.load(f)
-    compute_edges = get_radius_graph_config(config["Architecture"], loop=False)
-    compute_edge_lengths = Distance(norm=False, cat=True)
-    rotation = NormalizeRotation(max_points=-1, sort=False)
-
+def create_bct_sample():
     # Create BCT lattice structure with 32 nodes
+    uc_x = 4
+    uc_y = 2
+    uc_z = 2
+    lxy = 5.218
+    lz = 7.058
+    count = 0
+    number_nodes = 2 * uc_x * uc_y * uc_z
+    positions = torch.zeros(number_nodes, 3)
+    for x in range(uc_x):
+        for y in range(uc_y):
+            for z in range(uc_z):
+                positions[count][0] = x * lxy
+                positions[count][1] = y * lxy
+                positions[count][2] = z * lz
+                count += 1
+                positions[count][0] = (x + 0.5) * lxy
+                positions[count][1] = (y + 0.5) * lxy
+                positions[count][2] = (z + 0.5) * lz
+                count += 1
+
     data = Data()
+    data.pos = positions
+    return data
 
-    data.pos = torch.tensor(
-        [
-            [0.000000000000000, 0.000000000000000, 0.000000000000000],
-            [2.609000000000000, 2.609000000000000, 3.529000000000000],
-            [5.218000000000000, 0.000000000000000, 0.000000000000000],
-            [7.827000000000000, 2.609000000000000, 3.529000000000000],
-            [0.000000000000000, 5.218000000000000, 0.000000000000000],
-            [2.609000000000000, 7.827000000000000, 3.529000000000000],
-            [5.218000000000000, 5.218000000000000, 0.000000000000000],
-            [7.827000000000000, 7.827000000000000, 3.529000000000000],
-            [0.000000000000000, 0.000000000000000, 7.058000000000000],
-            [2.609000000000000, 2.609000000000000, 10.587000000000000],
-            [5.218000000000000, 0.000000000000000, 7.058000000000000],
-            [7.827000000000000, 2.609000000000000, 10.587000000000000],
-            [0.000000000000000, 5.218000000000000, 7.058000000000000],
-            [2.609000000000000, 7.827000000000000, 10.587000000000000],
-            [5.218000000000000, 5.218000000000000, 7.058000000000000],
-            [7.827000000000000, 7.827000000000000, 10.587000000000000],
-            [10.436000000000000, 0.000000000000000, 0.000000000000000],
-            [13.045000000000000, 2.609000000000000, 3.529000000000000],
-            [15.654000000000000, 0.000000000000000, 0.000000000000000],
-            [18.262999999999998, 2.609000000000000, 3.529000000000000],
-            [10.436000000000000, 5.218000000000000, 0.000000000000000],
-            [13.045000000000000, 7.827000000000000, 3.529000000000000],
-            [15.654000000000000, 5.218000000000000, 0.000000000000000],
-            [18.262999999999998, 7.827000000000000, 3.529000000000000],
-            [10.436000000000000, 0.000000000000000, 7.058000000000000],
-            [13.045000000000000, 2.609000000000000, 10.587000000000000],
-            [15.654000000000000, 0.000000000000000, 7.058000000000000],
-            [18.262999999999998, 2.609000000000000, 10.587000000000000],
-            [10.436000000000000, 5.218000000000000, 7.058000000000000],
-            [13.045000000000000, 7.827000000000000, 10.587000000000000],
-            [15.654000000000000, 5.218000000000000, 7.058000000000000],
-            [18.262999999999998, 7.827000000000000, 10.587000000000000],
-        ]
-    )
 
-    # Create random nodal features
-    data.x = torch.randn(32, 1)
-
-    # Create arbitrary global feature
-    data.y = torch.tensor([[99]])
-
+def check_rotational_invariance(
+    data, compute_edges, compute_edge_lengths, compute_rotation, tolerance
+):
     # Create a copy of the same data sample that is going to be rotated
     data_rotated = data.clone()
 
@@ -88,12 +59,35 @@ def unittest_rotational_invariance():
     data = compute_edge_lengths(data)
 
     # Rotate clone data
-    data_rotated = rotation(data_rotated)
+    data_rotated = compute_rotation(data_rotated)
 
     data_rotated = compute_edges(data_rotated)
     data_rotated = compute_edge_lengths(data_rotated)
 
-    assert check_data_samples_equivalence(data, data_rotated, 1e-14)
+    assert check_data_samples_equivalence(data, data_rotated, tolerance)
+
+
+def unittest_rotational_invariance(tol=1e-14):
+    config_file = "./tests/inputs/ci_rotational_invariance.json"
+    config = {}
+    with open(config_file, "r") as f:
+        config = json.load(f)
+    compute_edges = get_radius_graph_config(config["Architecture"], loop=False)
+    compute_edge_lengths = Distance(norm=False, cat=True)
+    compute_rotation = NormalizeRotation(max_points=-1, sort=False)
+
+    # Run first with single BCT structure.
+    data = create_bct_sample()
+
+    # Create random nodal features
+    data.x = torch.randn(32, 1)
+
+    # Create arbitrary global feature
+    data.y = torch.tensor([[99]])
+
+    check_rotational_invariance(
+        data, compute_edges, compute_edge_lengths, compute_rotation, tol
+    )
 
     # Repeat the same check on 10 graphs randomly generated
     for num_random_graphs in range(10):
@@ -108,20 +102,16 @@ def unittest_rotational_invariance():
         # Create arbitrary global feature
         data.y = torch.randn(1, 1)
 
-        # Create a copy of the same data sample that is going to be rotated
-        data_rotated = data.clone()
-
-        data = compute_edges(data)
-        data = compute_edge_lengths(data)
-
-        # Rotate clone data
-        data_rotated = rotation(data_rotated)
-
-        data_rotated = compute_edges(data_rotated)
-        data_rotated = compute_edge_lengths(data_rotated)
-
-        assert check_data_samples_equivalence(data, data_rotated, 1e-14)
+        check_rotational_invariance(
+            data, compute_edges, compute_edge_lengths, compute_rotation, tol
+        )
 
 
-def pytest_train_model():
+@pytest.mark.mpi_skip()
+def pytest_rotational_invariance():
+    # Test with (default) single precision
+    unittest_rotational_invariance(tol=1e-4)
+
+    # Test with double precision
+    torch.set_default_tensor_type(torch.DoubleTensor)
     unittest_rotational_invariance()


### PR DESCRIPTION
I am using the PyTorch Geometric transformation called `NormalizeRotation` 
https://pytorch-geometric.readthedocs.io/en/latest/_modules/torch_geometric/transforms/normalize_rotation.html#NormalizeRotation

This transformation computes the eigenvectors if the point could, and transforms data.pos by applying a rotation with respect to the eigenvectors. 

This transformation ensures that data.pos is rotational invariant. Any rotation applied to the graph affects the eigenvectors of the point cloud, but **the relative coordinates of data.pos with respect to the eigenvectors DO NOT CHANGE**

Part of #2 