### PR TITLE
Pass full config when loading serialized data

### DIFF
--- a/hydragnn/preprocess/load_data.py
+++ b/hydragnn/preprocess/load_data.py
@@ -123,7 +123,7 @@ def load_train_val_test_sets(config):
         loader = SerializedDataLoader(config["Verbosity"]["level"])
         dataset = loader.load_serialized_data(
             dataset_path=files_dir,
-            config=config["NeuralNetwork"],
+            config=config,
         )
         dataset_list.append(dataset)
         datasetname_list.append(dataset_name)

--- a/hydragnn/preprocess/serialized_dataset_loader.py
+++ b/hydragnn/preprocess/serialized_dataset_loader.py
@@ -63,7 +63,7 @@ class SerializedDataLoader:
             _ = pickle.load(f)
             dataset = pickle.load(f)
 
-        compute_edges = get_radius_graph(config["Architecture"])
+        compute_edges = get_radius_graph(config["NeuralNetwork"]["Architecture"])
         compute_edge_lengths = Distance(norm=False, cat=True)
 
         dataset[:] = [compute_edges(data) for data in dataset]
@@ -83,18 +83,22 @@ class SerializedDataLoader:
         for data in dataset:
             data.to(device)
             update_predicted_values(
-                config["Variables_of_interest"]["type"],
-                config["Variables_of_interest"]["output_index"],
+                config["NeuralNetwork"]["Variables_of_interest"]["type"],
+                config["NeuralNetwork"]["Variables_of_interest"]["output_index"],
                 data,
             )
             self.__update_atom_features(
-                config["Variables_of_interest"]["input_node_features"], data
+                config["NeuralNetwork"]["Variables_of_interest"]["input_node_features"],
+                data,
             )
 
-        if "subsample_percentage" in config["Variables_of_interest"].keys():
+        if (
+            "subsample_percentage"
+            in config["NeuralNetwork"]["Variables_of_interest"].keys()
+        ):
             return self.__stratified_sampling(
                 dataset=dataset,
-                subsample_percentage=config["Variables_of_interest"][
+                subsample_percentage=config["NeuralNetwork"]["Variables_of_interest"][
                     "subsample_percentage"
                 ],
             )


### PR DESCRIPTION
Simplifies, for example, #94 PBC boolean user input (which should reasonably be in "Dataset") and #102 for rotational invariance (which should also reasonably be in "Dataset")