### PR TITLE
Enable user specified backend

### DIFF
--- a/hydragnn/run_prediction.py
+++ b/hydragnn/run_prediction.py
@@ -25,28 +25,28 @@ from hydragnn.postprocess.postprocess import output_denormalize
 
 
 @singledispatch
-def run_prediction(config):
+def run_prediction(config, backend=None):
     raise TypeError("Input must be filename string or configuration dictionary.")
 
 
 @run_prediction.register
-def _(config_file: str):
+def _(config_file: str, backend=None):
 
     with open(config_file, "r") as f:
         config = json.load(f)
 
-    run_prediction(config)
+    run_prediction(config, backend)
 
 
 @run_prediction.register
-def _(config: dict):
+def _(config: dict, backend=None):
 
     try:
         os.environ["SERIALIZED_DATA_PATH"]
     except:
         os.environ["SERIALIZED_DATA_PATH"] = os.getcwd()
 
-    world_size, world_rank = setup_ddp()
+    world_size, world_rank = setup_ddp(backend)
 
     train_loader, val_loader, test_loader, sampler_list = dataset_loading_and_splitting(
         config=config

--- a/hydragnn/run_training.py
+++ b/hydragnn/run_training.py
@@ -37,21 +37,21 @@ from hydragnn.train.train_validate_test import train_validate_test
 
 
 @singledispatch
-def run_training(config):
+def run_training(config, backend=None):
     raise TypeError("Input must be filename string or configuration dictionary.")
 
 
 @run_training.register
-def _(config_file: str):
+def _(config_file: str, backend=None):
 
     with open(config_file, "r") as f:
         config = json.load(f)
 
-    run_training(config)
+    run_training(config, backend)
 
 
 @run_training.register
-def _(config: dict):
+def _(config: dict, backend=None):
 
     try:
         os.environ["SERIALIZED_DATA_PATH"]
@@ -59,7 +59,7 @@ def _(config: dict):
         os.environ["SERIALIZED_DATA_PATH"] = os.getcwd()
 
     setup_log(get_log_name_config(config))
-    world_size, world_rank = setup_ddp()
+    world_size, world_rank = setup_ddp(backend)
 
     verbosity = config["Verbosity"]["level"]
     train_loader, val_loader, test_loader, sampler_list = dataset_loading_and_splitting(


### PR DESCRIPTION
Allow the user to choose the backend, still defaulting to `nccl`, and adding `mpi`

I previously ran multiple separate instances on one node with `mpi`, but that relied on the machine mapping each run to each device. We probably want to explicitly do that in `get_device_name`

This also removes checking for the backend being available, allowing torch to error on its own

Closes #101 