### PR TITLE
delayed transfer of data from host to device

### DIFF
--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -15,6 +15,7 @@ import torch.nn.functional as F
 from torch_geometric.nn import global_mean_pool, BatchNorm
 from torch.nn import GaussianNLLLoss
 import sys
+from hydragnn.utils.distributed import get_device
 
 
 class Base(Module):
@@ -35,6 +36,7 @@ class Base(Module):
         num_nodes: int = None,
     ):
         super().__init__()
+        self.device = get_device()
         self.input_dim = input_dim
         self.hidden_dim = hidden_dim
         self.dropout = dropout
@@ -223,6 +225,7 @@ class Base(Module):
             self.heads_NN.append(head_NN)
 
     def forward(self, data):
+        data.to(self.device)
         x, edge_index, batch = (
             data.x,
             data.edge_index,

--- a/hydragnn/preprocess/serialized_dataset_loader.py
+++ b/hydragnn/preprocess/serialized_dataset_loader.py
@@ -137,7 +137,7 @@ class SerializedDataLoader:
         # Move data to the device, if used. # FIXME: this does not respect the choice set by use_gpu
         device = get_device(verbosity_level=self.verbosity)
         for data in dataset:
-            #data.to(device)
+            # data.to(device)
             update_predicted_values(
                 self.variables_type,
                 self.output_index,

--- a/hydragnn/preprocess/serialized_dataset_loader.py
+++ b/hydragnn/preprocess/serialized_dataset_loader.py
@@ -137,7 +137,7 @@ class SerializedDataLoader:
         # Move data to the device, if used. # FIXME: this does not respect the choice set by use_gpu
         device = get_device(verbosity_level=self.verbosity)
         for data in dataset:
-            data.to(device)
+            #data.to(device)
             update_predicted_values(
                 self.variables_type,
                 self.output_index,

--- a/hydragnn/utils/model.py
+++ b/hydragnn/utils/model.py
@@ -69,6 +69,7 @@ def load_existing_model(model, model_name, path="./logs/"):
 def calculate_PNA_degree(dataset: [Data], max_neighbours):
     deg = torch.zeros(max_neighbours + 1, dtype=torch.long).to(get_device())
     for data in dataset:
+        data.to(get_device())
         d = degree(data.edge_index[1], num_nodes=data.num_nodes, dtype=torch.long)
         deg += torch.bincount(d, minlength=deg.numel())
     return deg

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -17,9 +17,9 @@ import shutil
 
 import hydragnn, tests
 
+
 # Main unit test function called by pytest wrappers.
 def unittest_train_model(model_type, ci_input, use_lengths, overwrite_data=False):
-
     world_size, rank = hydragnn.utils.get_comm_size_and_rank()
 
     os.environ["SERIALIZED_DATA_PATH"] = os.getcwd()


### PR DESCRIPTION
Delaying transfer of data from host to device is needed when the dataset is too large to fit entirely onto a single GPU. 