### PR TITLE
correct number of samples in loss calculation

### DIFF
--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -211,11 +211,11 @@ def train(
 ):
     if profiler is None:
         profiler = Profiler()
-    tasks_error = np.zeros(model.num_heads)
-
-    model.train()
 
     total_error = 0
+    tasks_error = np.zeros(model.num_heads)
+    num_samples_local = 0
+    model.train()
     for data in iterate_tqdm(loader, verbosity):
         with record_function("zero_grad"):
             opt.zero_grad()
@@ -229,12 +229,12 @@ def train(
         opt.step()
         profiler.step()
         total_error += loss.item() * data.num_graphs
+        num_samples_local += data.num_graphs
         for itask in range(len(tasks_rmse)):
             tasks_error[itask] += tasks_rmse[itask].item() * data.num_graphs
-
     return (
-        total_error / len(loader.dataset),
-        tasks_error / len(loader.dataset),
+        total_error / num_samples_local,
+        tasks_error / num_samples_local,
     )
 
 
@@ -243,6 +243,7 @@ def validate(loader, model, verbosity):
 
     total_error = 0
     tasks_error = np.zeros(model.num_heads)
+    num_samples_local = 0
     model.eval()
     for data in iterate_tqdm(loader, verbosity):
         head_index = get_head_indices(model, data)
@@ -250,12 +251,13 @@ def validate(loader, model, verbosity):
         pred = model(data)
         error, tasks_rmse = model.loss_rmse(pred, data.y, head_index)
         total_error += error.item() * data.num_graphs
+        num_samples_local += data.num_graphs
         for itask in range(len(tasks_rmse)):
             tasks_error[itask] += tasks_rmse[itask].item() * data.num_graphs
 
     return (
-        total_error / len(loader.dataset),
-        tasks_error / len(loader.dataset),
+        total_error / num_samples_local,
+        tasks_error / num_samples_local,
     )
 
 
@@ -264,6 +266,7 @@ def test(loader, model, verbosity):
 
     total_error = 0
     tasks_error = np.zeros(model.num_heads)
+    num_samples_local = 0
     model.eval()
     true_values = [[] for _ in range(model.num_heads)]
     predicted_values = [[] for _ in range(model.num_heads)]
@@ -280,6 +283,7 @@ def test(loader, model, verbosity):
         pred = model(data)
         error, tasks_rmse = model.loss_rmse(pred, data.y, head_index)
         total_error += error.item() * data.num_graphs
+        num_samples_local += data.num_graphs
         for itask in range(len(tasks_rmse)):
             tasks_error[itask] += tasks_rmse[itask].item() * data.num_graphs
         ytrue = data.y
@@ -294,8 +298,8 @@ def test(loader, model, verbosity):
             predicted_values[ihead].extend(pred[ihead].tolist())
 
     return (
-        total_error / len(loader.dataset),
-        tasks_error / len(loader.dataset),
+        total_error / num_samples_local,
+        tasks_error / num_samples_local,
         true_values,
         predicted_values,
     )


### PR DESCRIPTION
Total number of samples (n_tot) in the dataset was used in calculating losses. This was fine in single rank runs.
But when multiple ranks were involved in DDP, the loss calculated would be less that the actual loss, since actual samples were split to each rank and the number of samples on each rank should be smaller (n_tot/n_ranks), but still the total number (n_tot) were used. 
This (probably) partially explains the large loss difference in multiple GPUs vs single GPU.