### PR TITLE
Remove sampler_list as separate data object

### DIFF
--- a/examples/md17/md17.py
+++ b/examples/md17/md17.py
@@ -72,12 +72,7 @@ dataset = torch_geometric.datasets.MD17(
 train, val, test = hydragnn.preprocess.split_dataset(
     dataset, config["NeuralNetwork"]["Training"]["perc_train"], False
 )
-(
-    train_loader,
-    val_loader,
-    test_loader,
-    sampler_list,
-) = hydragnn.preprocess.create_dataloaders(
+(train_loader, val_loader, test_loader,) = hydragnn.preprocess.create_dataloaders(
     train, val, test, config["NeuralNetwork"]["Training"]["batch_size"]
 )
 
@@ -106,7 +101,6 @@ hydragnn.train.train_validate_test(
     train_loader,
     val_loader,
     test_loader,
-    sampler_list,
     writer,
     scheduler,
     config["NeuralNetwork"],

--- a/examples/qm9/qm9.py
+++ b/examples/qm9/qm9.py
@@ -66,12 +66,7 @@ dataset = torch_geometric.datasets.QM9(
 train, val, test = hydragnn.preprocess.split_dataset(
     dataset, config["NeuralNetwork"]["Training"]["perc_train"], False
 )
-(
-    train_loader,
-    val_loader,
-    test_loader,
-    sampler_list,
-) = hydragnn.preprocess.create_dataloaders(
+(train_loader, val_loader, test_loader,) = hydragnn.preprocess.create_dataloaders(
     train, val, test, config["NeuralNetwork"]["Training"]["batch_size"]
 )
 
@@ -100,7 +95,6 @@ hydragnn.train.train_validate_test(
     train_loader,
     val_loader,
     test_loader,
-    sampler_list,
     writer,
     scheduler,
     config["NeuralNetwork"],

--- a/hydragnn/preprocess/load_data.py
+++ b/hydragnn/preprocess/load_data.py
@@ -51,7 +51,6 @@ def dataset_loading_and_splitting(config: {}):
 
 
 def create_dataloaders(trainset, valset, testset, batch_size):
-    sampler_list = []
     if dist.is_initialized():
 
         train_sampler = torch.utils.data.distributed.DistributedSampler(trainset)
@@ -67,7 +66,6 @@ def create_dataloaders(trainset, valset, testset, batch_size):
         test_loader = DataLoader(
             testset, batch_size=batch_size, shuffle=False, sampler=test_sampler
         )
-        sampler_list = [train_sampler, val_sampler, test_sampler]
 
     else:
 
@@ -83,7 +81,7 @@ def create_dataloaders(trainset, valset, testset, batch_size):
             shuffle=True,
         )
 
-    return train_loader, val_loader, test_loader, sampler_list
+    return train_loader, val_loader, test_loader
 
 
 def split_dataset(

--- a/hydragnn/run_prediction.py
+++ b/hydragnn/run_prediction.py
@@ -48,9 +48,7 @@ def _(config: dict):
 
     world_size, world_rank = setup_ddp()
 
-    train_loader, val_loader, test_loader, sampler_list = dataset_loading_and_splitting(
-        config=config
-    )
+    train_loader, val_loader, test_loader = dataset_loading_and_splitting(config=config)
 
     config = update_config(config, train_loader, val_loader, test_loader)
 

--- a/hydragnn/run_training.py
+++ b/hydragnn/run_training.py
@@ -62,9 +62,7 @@ def _(config: dict):
     setup_log(get_log_name_config(config))
     world_size, world_rank = setup_ddp()
 
-    train_loader, val_loader, test_loader, sampler_list = dataset_loading_and_splitting(
-        config=config
-    )
+    train_loader, val_loader, test_loader = dataset_loading_and_splitting(config=config)
 
     config = update_config(config, train_loader, val_loader, test_loader)
     plot_init_solution = config["Visualization"]["plot_init_solution"]
@@ -105,7 +103,6 @@ def _(config: dict):
         train_loader,
         val_loader,
         test_loader,
-        sampler_list,
         writer,
         scheduler,
         config["NeuralNetwork"],

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -35,7 +35,6 @@ def train_validate_test(
     train_loader,
     val_loader,
     test_loader,
-    sampler_list,
     writer,
     scheduler,
     config,
@@ -93,8 +92,9 @@ def train_validate_test(
 
     for epoch in range(0, num_epoch):
         profiler.set_current_epoch(epoch)
-        for sampler in sampler_list:
-            sampler.set_epoch(epoch)
+        for dataloader in [train_loader, val_loader, test_loader]:
+            if getattr(dataloader.sampler, "set_epoch", None) is not None:
+                dataloader.sampler.set_epoch(epoch)
 
         with profiler as prof:
             train_loss, train_taskserr = train(

--- a/tests/test_model_loadpred.py
+++ b/tests/test_model_loadpred.py
@@ -22,7 +22,6 @@ def unittest_model_prediction(config):
         train_loader,
         val_loader,
         test_loader,
-        sampler_list,
     ) = hydragnn.preprocess.load_data.dataset_loading_and_splitting(config=config)
 
     model = hydragnn.models.create.create_model_config(


### PR DESCRIPTION
Simplifying https://github.com/ORNL/HydraGNN/pull/98. There is no need to pass sampler_list around separately, since sampler is a variable of DataLoader class.