### PR TITLE
click version frozen to 8.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+click==8.0.0
 pickle5
 matplotlib
 torch>=1.8


### PR DESCRIPTION
Click 8.1.0 conflicts with black
For now, to avoid clashes between version of packages, I force the click version to be click==8.0.0 in the `requirements.txt` file

CI tests are failing for accuracy, but this is unrelated to the issue addressed in the PR. 