### PR TITLE
yaml file updated

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.4.0
+    rev: v4.3.0
     hooks:
       - id: check-merge-conflict
       - id: trailing-whitespace
       - id: end-of-file-fixer
 
   - repo: https://github.com/psf/black
-    rev: 21.5b1
+    rev: 22.6.0
     hooks:
       - id: black


### PR DESCRIPTION
If I run from my laptop:
git commit -m

and I get this error:
from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click'

I need to run the following:
pre-commit clean
pre-commit autoupdate

Then, when I get this error:
bash-3.2$ git commit -m 'removed check on maximum error from test_graph'
[ERROR] Your pre-commit configuration is unstaged.
`git add .pre-commit-config.yaml` to fix this.

I need to run the following:
git add .pre-commit-config.yaml

and this ends up updating the YAML requirements for pre-commit
without performing the previous steps, the pre-commit rejects any commit I try to make, and therefore I cannot push