### PR TITLE
absolute path added to dirpwd

### DIFF
--- a/examples/csce/train_gap.py
+++ b/examples/csce/train_gap.py
@@ -177,7 +177,7 @@ if __name__ == "__main__":
 
     graph_feature_names = ["GAP"]
     graph_feature_dim = [1]
-    dirpwd = os.path.dirname(__file__)
+    dirpwd = os.path.dirname(os.path.abspath(__file__))
     datafile = os.path.join(dirpwd, "dataset/csce_gap_synth.csv")
     ##################################################################################################################
     inputfilesubstr = args.inputfilesubstr

--- a/examples/ising_model/train_ising.py
+++ b/examples/ising_model/train_ising.py
@@ -135,7 +135,7 @@ if __name__ == "__main__":
     )
     args = parser.parse_args()
 
-    dirpwd = os.path.dirname(__file__)
+    dirpwd = os.path.dirname(os.path.abspath(__file__))
     input_filename = os.path.join(dirpwd, "ising_model.json")
     with open(input_filename, "r") as f:
         config = json.load(f)

--- a/examples/lsms/lsms.py
+++ b/examples/lsms/lsms.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    dirpwd = os.path.dirname(__file__)
+    dirpwd = os.path.dirname(os.path.abspath(__file__))
     input_filename = os.path.join(dirpwd, args.inputfile)
     with open(input_filename, "r") as f:
         config = json.load(f)

--- a/examples/ogb/train_gap.py
+++ b/examples/ogb/train_gap.py
@@ -194,7 +194,7 @@ if __name__ == "__main__":
 
     graph_feature_names = ["GAP"]
     graph_feature_dim = [1]
-    dirpwd = os.path.dirname(__file__)
+    dirpwd = os.path.dirname(os.path.abspath(__file__))
     datafile = os.path.join(dirpwd, "dataset/pcqm4m_gap.csv")
     ##################################################################################################################
     inputfilesubstr = args.inputfilesubstr

--- a/examples/qm9/qm9.py
+++ b/examples/qm9/qm9.py
@@ -36,7 +36,7 @@ except:
 num_samples = 1000
 
 # Configurable run choices (JSON file that accompanies this example script).
-filename = os.path.join(os.path.dirname(__file__), "qm9.json")
+filename = os.path.join(os.path.dirname(os.path.abspath(__file__)), "qm9.json")
 with open(filename, "r") as f:
     config = json.load(f)
 verbosity = config["Verbosity"]["level"]


### PR DESCRIPTION
In the examples folder, the variable `dirpwd` was set up with a relative path. 
`dirpwd = os.path.dirname(__file__)`
Everything worked fine on my laptop, OLCF Summit, and NERSC Perlmutter. However, I noticed that the serialized_dataset directory was alway created in the wrong place when the code was running on a docker on the DGX machine. The reason was that dirpwd was empty when the code was running on the docker. 
I googled and found this discussion:
https://stackoverflow.com/questions/7783308/os-path-dirname-file-returns-empty

Replacing the line above with 
`dirpwd = os.path.dirname(os.path.abspath(__file__))`
fixed the problem
