### PR TITLE
version of Ubuntu frozen to 20.04 

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python: [3.7, 3.8]


### PR DESCRIPTION
version of Ubuntu frozen to 20.04 to avoid errors on newer version of libffi that changed from 7 to 8 on Ubuntu-22.04