### PR TITLE
skip connection option added

### DIFF
--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -135,7 +135,7 @@ class Base(Module):
       
         self.layers = ModuleList()
         for i, (conv, batch_norm) in enumerate(zip(self.convs, self.batch_norms)):
-            if i > 0 and self.skip_connection:
+            if self.skip_connection:
                 self.layers.append(SkipConv(conv, batch_norm))
             else:
                 self.layers.append(Conv(conv, batch_norm))

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -18,7 +18,38 @@ from hydragnn.utils.model import loss_function_selection
 import sys
 from hydragnn.utils.distributed import get_device
 
+class Conv(torch.nn.Module):
+    """ conv module """
+    def __init__(self, conv, batch_norm, act=torch.nn.ReLU()):
+        super().__init__()
+        self.conv = conv
+        self.batch_norm = batch_norm
+        self.act = act
 
+    def forward(self, x=None, edge_index=None, edge_attr=None):
+        c = self.conv(x=x, edge_index=edge_index, edge_attr=edge_attr)
+        return self.act(self.batch_norm(c))
+
+class SkipConv(torch.nn.Module):
+    """ conv module with skip connection """
+    def __init__(self, conv, batch_norm, act=torch.nn.ReLU()):
+        super().__init__()
+        self.conv = conv
+        self.batch_norm = batch_norm
+        self.act = act
+
+    def forward(self, x=None, edge_index=None, edge_attr=None):
+        identity = x
+        c = self.conv(x=x, edge_index=edge_index, edge_attr=edge_attr)
+        return self.act(self.batch_norm(c)) + identity
+
+class ConvSequential(torch.nn.Sequential):
+    """ Extention to use graph inputs """
+    def forward(self, x=None, edge_index=None, edge_attr=None):
+        for module in self:
+            x = module(x=x, edge_index=edge_index, edge_attr=edge_attr)
+        return x
+    
 class Base(Module):
     def __init__(
         self,
@@ -101,6 +132,15 @@ class Base(Module):
         self._multihead()
         if self.initial_bias is not None:
             self._set_bias()
+      
+        self.layers = ModuleList()
+        for i, (conv, batch_norm) in enumerate(zip(self.convs, self.batch_norms)):
+            if i > 0 and self.skip_connection:
+                self.layers.append(SkipConv(conv, batch_norm))
+            else:
+                self.layers.append(Conv(conv, batch_norm))
+
+        self.conv_shared = ConvSequential(*self.layers)
 
     def _init_conv(self):
         self.convs.append(self.get_conv(self.input_dim, self.hidden_dim))

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -18,8 +18,10 @@ from hydragnn.utils.model import loss_function_selection
 import sys
 from hydragnn.utils.distributed import get_device
 
+
 class Conv(torch.nn.Module):
-    """ conv module """
+    """conv module"""
+
     def __init__(self, conv, batch_norm, act=torch.nn.ReLU()):
         super().__init__()
         self.conv = conv
@@ -30,8 +32,10 @@ class Conv(torch.nn.Module):
         c = self.conv(x=x, edge_index=edge_index, edge_attr=edge_attr)
         return self.act(self.batch_norm(c))
 
+
 class SkipConv(torch.nn.Module):
-    """ conv module with skip connection """
+    """conv module with skip connection"""
+
     def __init__(self, conv, batch_norm, act=torch.nn.ReLU()):
         super().__init__()
         self.conv = conv
@@ -43,13 +47,16 @@ class SkipConv(torch.nn.Module):
         c = self.conv(x=x, edge_index=edge_index, edge_attr=edge_attr)
         return self.act(self.batch_norm(c)) + identity
 
+
 class ConvSequential(torch.nn.Sequential):
-    """ Extention to use graph inputs """
+    """Extention to use graph inputs"""
+
     def forward(self, x=None, edge_index=None, edge_attr=None):
         for module in self:
             x = module(x=x, edge_index=edge_index, edge_attr=edge_attr)
         return x
-    
+
+
 class Base(Module):
     def __init__(
         self,
@@ -132,7 +139,7 @@ class Base(Module):
         self._multihead()
         if self.initial_bias is not None:
             self._set_bias()
-      
+
         self.layers = ModuleList()
         for i, (conv, batch_norm) in enumerate(zip(self.convs, self.batch_norms)):
             if self.skip_connection:

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -36,6 +36,7 @@ class Base(Module):
         dropout: float = 0.25,
         num_conv_layers: int = 16,
         num_nodes: int = None,
+        skip_connection: bool = False,
     ):
         super().__init__()
         self.device = get_device()
@@ -58,6 +59,7 @@ class Base(Module):
         self.batch_norms_node_hidden = ModuleList()
         self.convs_node_output = ModuleList()
         self.batch_norms_node_output = ModuleList()
+        self.skip_connection = skip_connection
 
         self.loss_function = loss_function_selection(loss_function_type)
         self.ilossweights_nll = ilossweights_nll
@@ -243,6 +245,8 @@ class Base(Module):
 
     def forward(self, data):
         x = data.x
+
+        count_conv_layers = 0
 
         ### encoder part ####
         conv_args = self._conv_args(data)

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -141,7 +141,7 @@ class Base(Module):
             self._set_bias()
 
         self.layers = ModuleList()
-        for i, (conv, batch_norm) in enumerate(zip(self.convs, self.batch_norms)):
+        for conv, batch_norm in zip(self.convs, self.batch_norms):
             if self.skip_connection:
                 self.layers.append(SkipConv(conv, batch_norm))
             else:
@@ -292,8 +292,6 @@ class Base(Module):
 
     def forward(self, data):
         x = data.x
-
-        count_conv_layers = 0
 
         ### encoder part ####
         conv_args = self._conv_args(data)

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -211,6 +211,7 @@ def create_model(
             initial_bias=initial_bias,
             num_conv_layers=num_conv_layers,
             num_nodes=num_nodes,
+            skip_connection=skip_connection,
         )
 
     else:

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -140,7 +140,6 @@ def create_model(
             initial_bias=initial_bias,
             num_conv_layers=num_conv_layers,
             num_nodes=num_nodes,
-            skip_connection=skip_connection,
         )
 
     elif model_type == "MFC":

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -50,6 +50,7 @@ def create_model_config(
         config["Architecture"]["num_gaussians"],
         config["Architecture"]["num_filters"],
         config["Architecture"]["radius"],
+        config["Architecture"]["skip_connection"],
         verbosity,
         use_gpu,
     )
@@ -75,6 +76,7 @@ def create_model(
     num_gaussians: int = None,
     num_filters: int = None,
     radius: float = None,
+    skip_connection: bool = False,
     verbosity: int = 0,
     use_gpu: bool = True,
 ):
@@ -98,6 +100,7 @@ def create_model(
             initial_bias=initial_bias,
             num_conv_layers=num_conv_layers,
             num_nodes=num_nodes,
+            skip_connection=skip_connection,
         )
 
     elif model_type == "PNA":
@@ -116,6 +119,7 @@ def create_model(
             initial_bias=initial_bias,
             num_conv_layers=num_conv_layers,
             num_nodes=num_nodes,
+            skip_connection=skip_connection,
         )
 
     elif model_type == "GAT":
@@ -136,6 +140,7 @@ def create_model(
             initial_bias=initial_bias,
             num_conv_layers=num_conv_layers,
             num_nodes=num_nodes,
+            skip_connection=skip_connection,
         )
 
     elif model_type == "MFC":
@@ -153,6 +158,7 @@ def create_model(
             initial_bias=initial_bias,
             num_conv_layers=num_conv_layers,
             num_nodes=num_nodes,
+            skip_connection=skip_connection,
         )
 
     elif model_type == "CGCNN":
@@ -168,6 +174,7 @@ def create_model(
             initial_bias=initial_bias,
             num_conv_layers=num_conv_layers,
             num_nodes=num_nodes,
+            skip_connection=skip_connection,
         )
 
     elif model_type == "SAGE":
@@ -182,6 +189,7 @@ def create_model(
             freeze_conv=freeze_conv,
             num_conv_layers=num_conv_layers,
             num_nodes=num_nodes,
+            skip_connection=skip_connection,
         )
 
     elif model_type == "SchNet":

--- a/hydragnn/utils/config_utils.py
+++ b/hydragnn/utils/config_utils.py
@@ -55,6 +55,9 @@ def update_config(config, train_loader, val_loader, test_loader):
         config["NeuralNetwork"]["Architecture"]
     )
 
+    if "skip_connection" not in config["NeuralNetwork"]["Architecture"]:
+        config["NeuralNetwork"]["Architecture"]["skip_connection"] = False
+
     if "freeze_conv_layers" not in config["NeuralNetwork"]["Architecture"]:
         config["NeuralNetwork"]["Architecture"]["freeze_conv_layers"] = False
     if "initial_bias" not in config["NeuralNetwork"]["Architecture"]:

--- a/tests/inputs/ci.json
+++ b/tests/inputs/ci.json
@@ -26,6 +26,7 @@
     "NeuralNetwork": {
         "Architecture": {
             "model_type": "PNA",
+            "skip_connection": false,
             "radius": 2.0,
             "max_neighbours": 100,
             "num_gaussians": 50,

--- a/tests/inputs/ci_multihead.json
+++ b/tests/inputs/ci_multihead.json
@@ -24,6 +24,7 @@
     "NeuralNetwork": {
         "Architecture": {
             "model_type": "PNA",
+            "skip_connection": false,
             "radius": 2.0,
             "max_neighbours": 100,
             "num_gaussians": 50,

--- a/tests/inputs/ci_vectoroutput.json
+++ b/tests/inputs/ci_vectoroutput.json
@@ -24,6 +24,7 @@
     "NeuralNetwork": {
         "Architecture": {
             "model_type": "PNA",
+            "skip_connection": false,
             "radius": 2.0,
             "max_neighbours": 100,
             "periodic_boundary_conditions": false,

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -141,6 +141,8 @@ def unittest_train_model(
         thresholds["PNA"] = [0.10, 0.10]
     if use_lengths and "vector" in ci_input:
         thresholds["PNA"] = [0.2, 0.15]
+    if skip_connection:
+        thresholds["PNA"] = [0.8, 0.7]
     verbosity = 2
 
     for ihead in range(len(true_values)):

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -187,10 +187,6 @@ def pytest_train_model(model_type, skip_connection, ci_input, overwrite_data=Fal
 
 # Test only models
 @pytest.mark.parametrize("model_type", ["PNA", "CGCNN", "SchNet"])
-def pytest_train_model_lengths(model_type, overwrite_data=False):
-    unittest_train_model(model_type, "ci.json", True, overwrite_data)
-
-
 @pytest.mark.parametrize("skip_connection", [False, True])
 def pytest_train_model_lengths(model_type, skip_connection, overwrite_data=False):
     unittest_train_model(model_type, skip_connection, "ci.json", True, overwrite_data)

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -189,6 +189,8 @@ def pytest_train_model(model_type, skip_connection, ci_input, overwrite_data=Fal
 @pytest.mark.parametrize("model_type", ["PNA", "CGCNN", "SchNet"])
 def pytest_train_model_lengths(model_type, overwrite_data=False):
     unittest_train_model(model_type, "ci.json", True, overwrite_data)
+
+
 @pytest.mark.parametrize("skip_connection", [False, True])
 def pytest_train_model_lengths(model_type, skip_connection, overwrite_data=False):
     unittest_train_model(model_type, skip_connection, "ci.json", True, overwrite_data)


### PR DESCRIPTION
As the name suggests, the skip connections in deep architecture bypass some of the neural network layers and feed the output of one layer as the input to the following levels. It is a standard module and provides an alternative path for the gradient with backpropagation.

Skip Connections were originally created to tackle various difficulties in various architectures and were introduced even before residual networks. In the case of residual networks or ResNets, skip connections were used to solve the degradation problems (e.g., vanishing gradient), and in the case of dense networks or DenseNets, it ensured feature reusability.

Since the residual block with the skip connection was shown to benefit the training of CNN, I thought it would be good providing it as optional also to stabilize the GNN (after all, the GNN architecture is a generalization of the CNN).