### PR TITLE
Added SchNet model as SCFStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ There are many options for HydraGNN; the dataset and model type are particularly
 important:
  - `["Verbosity"]["level"]`: `0`, `1`, `2`, `3`, `4`
  - `["Dataset"]["name"]`: `CuAu_32atoms`, `FePt_32atoms`, `FeSi_1024atoms`
- - `["NeuralNetwork"]["Architecture"]["model_type"]`: `PNA`, `MFC`, `GIN`, `GAT`, `CGCNN`
+ - `["NeuralNetwork"]["Architecture"]["model_type"]`: `PNA`, `MFC`, `GIN`, `GAT`, `CGCNN`, `SchNet`
 
 ### Citations
 "HydraGNN: Distributed PyTorch implementation of multi-headed graph convolutional neural networks", Copyright ID#: 81929619

--- a/hydragnn/models/SCFStack.py
+++ b/hydragnn/models/SCFStack.py
@@ -1,0 +1,79 @@
+##############################################################################
+# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+from typing import Optional
+
+import torch
+from torch.nn import Linear, Sequential
+from torch_geometric.nn.models.schnet import (
+    CFConv,
+    GaussianSmearing,
+    RadiusInteractionGraph,
+    ShiftedSoftplus,
+)
+
+from .Base import Base
+
+
+class SCFStack(Base):
+    def __init__(
+        self,
+        num_filters: int,
+        num_gaussians: list,
+        radius: float,
+        *args,
+        max_neighbours: Optional[int] = None,
+        **kwargs,
+    ):
+        self.radius = radius
+        self.max_neighbours = max_neighbours
+        self.num_filters = num_filters
+        self.num_gaussians = num_gaussians
+
+        super().__init__(*args, **kwargs)
+
+        self.distance_expansion = GaussianSmearing(0.0, radius, num_gaussians)
+        self.interaction_graph = RadiusInteractionGraph(radius, max_neighbours)
+
+        pass
+
+    def get_conv(self, input_dim, output_dim):
+        mlp = Sequential(
+            Linear(self.num_gaussians, self.num_filters),
+            ShiftedSoftplus(),
+            Linear(self.num_filters, self.num_filters),
+        )
+
+        return CFConv(
+            in_channels=input_dim,
+            out_channels=output_dim,
+            nn=mlp,
+            num_filters=self.num_filters,
+            cutoff=self.radius,
+        )
+
+    def _conv_args(self, data):
+        if (data.edge_attr is not None) and (self.use_edge_attr):
+            edge_index = data.edge_index
+            edge_weight = data.edge_attr.norm(dim=-1)
+        else:
+            edge_index, edge_weight = self.interaction_graph(data.pos, data.batch)
+
+        conv_args = {
+            "edge_index": edge_index,
+            "edge_weight": edge_weight,
+            "edge_attr": self.distance_expansion(edge_weight),
+        }
+
+        return conv_args
+
+    def __str__(self):
+        return "SCFStack"

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -19,6 +19,7 @@ from hydragnn.models.GATStack import GATStack
 from hydragnn.models.MFCStack import MFCStack
 from hydragnn.models.CGCNNStack import CGCNNStack
 from hydragnn.models.SAGEStack import SAGEStack
+from hydragnn.models.SCFStack import SCFStack
 
 from hydragnn.utils.distributed import get_device
 from hydragnn.utils.print_utils import print_distributed
@@ -30,7 +31,6 @@ def create_model_config(
     verbosity: int = 0,
     use_gpu: bool = True,
 ):
-
     return create_model(
         config["Architecture"]["model_type"],
         config["Architecture"]["input_dim"],
@@ -47,6 +47,9 @@ def create_model_config(
         config["Architecture"]["max_neighbours"],
         config["Architecture"]["edge_dim"],
         config["Architecture"]["pna_deg"],
+        config["Architecture"]["num_gaussians"],
+        config["Architecture"]["num_filters"],
+        config["Architecture"]["radius"],
         verbosity,
         use_gpu,
     )
@@ -69,6 +72,9 @@ def create_model(
     max_neighbours: int = None,
     edge_dim: int = None,
     pna_deg: torch.tensor = None,
+    num_gaussians: int = None,
+    num_filters: int = None,
+    radius: float = None,
     verbosity: int = 0,
     use_gpu: bool = True,
 ):
@@ -174,6 +180,28 @@ def create_model(
             loss_function_type,
             loss_weights=task_weights,
             freeze_conv=freeze_conv,
+            num_conv_layers=num_conv_layers,
+            num_nodes=num_nodes,
+        )
+
+    elif model_type == "SchNet":
+        assert num_gaussians is not None, "SchNet requires num_guassians input."
+        assert num_filters is not None, "SchNet requires num_filters input."
+        assert radius is not None, "SchNet requires radius input."
+        model = SCFStack(
+            num_gaussians,
+            num_filters,
+            radius,
+            input_dim,
+            hidden_dim,
+            output_dim,
+            output_type,
+            output_heads,
+            loss_function_type,
+            max_neighbours=max_neighbours,
+            loss_weights=task_weights,
+            freeze_conv=freeze_conv,
+            initial_bias=initial_bias,
             num_conv_layers=num_conv_layers,
             num_nodes=num_nodes,
         )

--- a/hydragnn/utils/config_utils.py
+++ b/hydragnn/utils/config_utils.py
@@ -44,6 +44,13 @@ def update_config(config, train_loader, val_loader, test_loader):
     else:
         config["NeuralNetwork"]["Architecture"]["pna_deg"] = None
 
+    if "radius" not in config["NeuralNetwork"]["Architecture"]:
+        config["NeuralNetwork"]["Architecture"]["radius"] = None
+    if "num_gaussians" not in config["NeuralNetwork"]["Architecture"]:
+        config["NeuralNetwork"]["Architecture"]["num_gaussians"] = None
+    if "num_filters" not in config["NeuralNetwork"]["Architecture"]:
+        config["NeuralNetwork"]["Architecture"]["num_filters"] = None
+
     config["NeuralNetwork"]["Architecture"] = update_config_edge_dim(
         config["NeuralNetwork"]["Architecture"]
     )
@@ -65,9 +72,8 @@ def update_config(config, train_loader, val_loader, test_loader):
 
 
 def update_config_edge_dim(config):
-
     config["edge_dim"] = None
-    edge_models = ["PNA", "CGCNN"]
+    edge_models = ["PNA", "CGCNN", "SchNet"]
     if "edge_features" in config and config["edge_features"]:
         assert (
             config["model_type"] in edge_models
@@ -81,7 +87,6 @@ def update_config_edge_dim(config):
 
 
 def check_output_dim_consistent(data, config):
-
     output_type = config["NeuralNetwork"]["Variables_of_interest"]["type"]
     output_index = config["NeuralNetwork"]["Variables_of_interest"]["output_index"]
     if hasattr(data, "y_loc"):

--- a/tests/inputs/ci.json
+++ b/tests/inputs/ci.json
@@ -28,6 +28,8 @@
             "model_type": "PNA",
             "radius": 2.0,
             "max_neighbours": 100,
+            "num_gaussians": 50,
+            "num_filters": 126,
             "periodic_boundary_conditions": false,
             "hidden_dim": 8,
             "num_conv_layers": 2,

--- a/tests/inputs/ci_multihead.json
+++ b/tests/inputs/ci_multihead.json
@@ -26,6 +26,8 @@
             "model_type": "PNA",
             "radius": 2.0,
             "max_neighbours": 100,
+            "num_gaussians": 50,
+            "num_filters": 126,
             "periodic_boundary_conditions": false,
             "hidden_dim": 8,
             "num_conv_layers": 2,

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -19,9 +19,9 @@ import shutil
 
 import hydragnn, tests
 
+
 # Main unit test function called by pytest wrappers.
 def unittest_train_model(model_type, ci_input, use_lengths, overwrite_data=False):
-
     world_size, rank = hydragnn.utils.get_comm_size_and_rank()
 
     os.environ["SERIALIZED_DATA_PATH"] = os.getcwd()
@@ -130,6 +130,7 @@ def unittest_train_model(model_type, ci_input, use_lengths, overwrite_data=False
         "GIN": [0.25, 0.20],
         "GAT": [0.60, 0.70],
         "CGCNN": [0.50, 0.40],
+        "SchNet": [0.20, 0.20],
     }
     if use_lengths and ("vector" not in ci_input):
         thresholds["CGCNN"] = [0.175, 0.175]
@@ -171,14 +172,16 @@ def unittest_train_model(model_type, ci_input, use_lengths, overwrite_data=False
 
 
 # Test across all models with both single/multihead
-@pytest.mark.parametrize("model_type", ["SAGE", "GIN", "GAT", "MFC", "PNA", "CGCNN"])
+@pytest.mark.parametrize(
+    "model_type", ["SAGE", "GIN", "GAT", "MFC", "PNA", "CGCNN", "SchNet"]
+)
 @pytest.mark.parametrize("ci_input", ["ci.json", "ci_multihead.json"])
 def pytest_train_model(model_type, ci_input, overwrite_data=False):
     unittest_train_model(model_type, ci_input, False, overwrite_data)
 
 
 # Test only models
-@pytest.mark.parametrize("model_type", ["PNA", "CGCNN"])
+@pytest.mark.parametrize("model_type", ["PNA", "CGCNN", "SchNet"])
 def pytest_train_model_lengths(model_type, overwrite_data=False):
     unittest_train_model(model_type, "ci.json", True, overwrite_data)
 


### PR DESCRIPTION
This pull request introduces the [SchNet](https://arxiv.org/abs/1706.08566) model to HydraGNN. SchNet is a powerful deep learning model that can accurately predict molecular properties from 3D molecular structures. 

Using the configuration `"model_type": "SchNet"` will initialize a convolutional stack `SCFStack`. Notice that PyG only offers [SchNet](https://pytorch-geometric.readthedocs.io/en/latest/_modules/torch_geometric/nn/models/schnet.html#SchNet) as a `nn.model` and not as a `nn.conv`. The `SCFStack` is a generalization of `SchNet` designed for HydraGNN.

The objective of this generalization is to provide full support for the convolutional layers of SchNet in the latent space. Functionally this means removing the embedding, decoding and layer stacking aspects of the `SchNet` and `InteractionBlock` classes, and distilling the `GuassianSmearing`, mlp, and `RadiusInteractionGraph` components into the `CFConv`.

I want to emphasize that the functionality of `use_edge_attr` is preserved *and should be used* with SchNet to maintain good performance. In particular the `RadiusInteractionGraph` generates the normalized version of the edge weights generated by [RadiusGraph](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.transforms.RadiusGraph.html#torch_geometric.transforms.RadiusGraph). If `use_edge_attr` is not used, the radially connected graph will be computed *for each forward pass* which will impact performance.

#NOTE: this aspect of the PR is dependent on HydraGNN passing `edge_attrs` which are relative distances and does not preserve SchNet for arbitrary `edge_attr`

**Functionality**

For a comprehensive review of SchNet features please see [section 4](https://arxiv.org/abs/1706.08566).

Functional Differences
	+ Embedding: SchNet latent space embedding only operates on atomic number; HydraGNN offers its own latent embedding
	+ Decoding: Schnet decodes from the latent space to dipole prediction or property prediction; HydraGNN offers its own decoding mechanisms

Preserved Functionalities
	+ RadiusInteratcionGraph: Adjacency matrix edge_index and distance measure `edge_weights` are generated using a `radius cutoff` and `max_num_neighbors`. If HydraGNN `edge_weights` are passed then they are normalized. 
	+ mlp: SchNet uses a particular MLP including a custom ShiftedSoftplus function which is stored in torch_geometric.nn.models.schnet
	+ GaussainSmearing: The same gaussian smearing technique for filtering is applied.

**Features**

This PR introduces two new features, re-uses two existing features and disregards several features used by SchNet for embedding/decoding.

New HydraGNN SchNet Features:
	+ `num_gaussians`: (int) The number of Gaussians to use.
	+ `num_filters`: (int) The number of filters to use.

Cross-Over Features:
	+ `cutoff`(SchNet)|`radius`(HydraGNN): Radius for cutoff of interatomic interactions.
	+ `max_num_neighbors`(SchNet)|`max_neighbors`(HydraGNN):  The maximum number of neighbors to collect for each node within the cutoff distance.

Stripped PyG SchNet Features:
	Redundant:
	+ `hidden_channels`: (int, optional) Dimension of latent embedding. [consider setting input_dim=output_dim for SCFConv?]
	+ `num_interactions`: (int, optional) The number of convolutional layers.
	+ `interaction_graph`: (callable, optional) Convolutional layer that CFConv replaces.
	Unnecessary:
	+ `readout`: (str, optional) Aggregation scheme - was sum/add or max and now is fixed to add #NOTE: one may consider adding `agg` support.
	+ `mean`: (float, optional) The mean of the property to predict used in *decoding*
	+ `std`: (float, optional) The std of the property to predict used in *decoding*
	+ `atomref`: (torch.Tensor, optional) atomic property or "fingerprint" for *decoding*


**Testing**

Three new testing blocks are introduced based on `tests/test_graphs.py` which requires arguments to be added to `test/inputs/ci.json` and `test/inputs/ci_multihead.json`.

```
tests/test_graphs.py::pytest_train_model[ci.json-SchNet]
tests/test_graphs.py::pytest_train_model[ci_multihead.json-SchNet]
tests/test_graphs.py::pytest_train_model_lengths[SchNet]
```