### PR TITLE
Black + Click Version Controlling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,4 @@ repos:
     rev: 21.5b1
     hooks:
       - id: black
+        additional_dependencies: ['click==8.0.0']


### PR DESCRIPTION
This PR aims to resolve the first issue described in PR https://github.com/ORNL/HydraGNN/pull/178#issuecomment-1588027702 by pinning the `click` version in the setup of `pre-commit`.

I tested manually installing `black==21.5b1` and `click==8.0.0` as illustrated below, but encountered the same compatibility issue.

![ClickBlackVersions](https://github.com/ORNL/HydraGNN/assets/13757858/9be80b5f-57c3-40e2-90f2-3ba1a0130e70)


These compatibility issues are resolved using the `additional_dependencies` argument. *Notice:* I used `click==8.0.0` consistent with the version in https://github.com/ORNL/HydraGNN/blob/main/requirements.txt