### PR TITLE
gather_deg_dist needs to map 'deg' variable to GPUs before calling NCCL gathering operations

### DIFF
--- a/hydragnn/preprocess/utils.py
+++ b/hydragnn/preprocess/utils.py
@@ -195,18 +195,20 @@ def gather_deg(dataset):
 def gather_deg_dist(dataset):
     import torch.distributed as dist
     from hydragnn.utils.print_utils import iterate_tqdm
+    from hydragnn.utils.distributed import get_device
 
     max_deg = 0
     for data in iterate_tqdm(dataset, 2, desc="Degree max"):
         d = degree(data.edge_index[1], num_nodes=data.num_nodes, dtype=torch.long)
         max_deg = max(max_deg, int(d.max()))
-    max_deg = torch.tensor(max_deg)
+    max_deg = torch.tensor(max_deg).to(get_device())
     dist.all_reduce(max_deg, op=dist.ReduceOp.MAX)
 
     deg = torch.zeros(max_deg.item() + 1, dtype=torch.long)
     for data in iterate_tqdm(dataset, 2, desc="Degree bincount"):
         d = degree(data.edge_index[1], num_nodes=data.num_nodes, dtype=torch.long)
         deg += torch.bincount(d, minlength=deg.numel())
+    deg = torch.tensor(deg).to(get_device())
     dist.all_reduce(deg, op=dist.ReduceOp.SUM)
     return deg.cpu().detach().numpy()
 

--- a/hydragnn/preprocess/utils.py
+++ b/hydragnn/preprocess/utils.py
@@ -201,14 +201,14 @@ def gather_deg_dist(dataset):
     for data in iterate_tqdm(dataset, 2, desc="Degree max"):
         d = degree(data.edge_index[1], num_nodes=data.num_nodes, dtype=torch.long)
         max_deg = max(max_deg, int(d.max()))
-    max_deg = torch.tensor(max_deg).to(get_device())
+    max_deg = torch.tensor(max_deg, requires_grad=False).to(get_device())
     dist.all_reduce(max_deg, op=dist.ReduceOp.MAX)
 
     deg = torch.zeros(max_deg.item() + 1, dtype=torch.long)
     for data in iterate_tqdm(dataset, 2, desc="Degree bincount"):
         d = degree(data.edge_index[1], num_nodes=data.num_nodes, dtype=torch.long)
         deg += torch.bincount(d, minlength=deg.numel())
-    deg = torch.tensor(deg).to(get_device())
+    deg = torch.tensor(deg, requires_grad=False).to(get_device())
     dist.all_reduce(deg, op=dist.ReduceOp.SUM)
     return deg.cpu().detach().numpy()
 

--- a/hydragnn/preprocess/utils.py
+++ b/hydragnn/preprocess/utils.py
@@ -204,11 +204,11 @@ def gather_deg_dist(dataset):
     max_deg = torch.tensor(max_deg, requires_grad=False).to(get_device())
     dist.all_reduce(max_deg, op=dist.ReduceOp.MAX)
 
-    deg = torch.zeros(max_deg.item() + 1, dtype=torch.long)
+    deg = torch.zeros(max_deg.item() + 1, requires_grad=False, dtype=torch.long)
     for data in iterate_tqdm(dataset, 2, desc="Degree bincount"):
         d = degree(data.edge_index[1], num_nodes=data.num_nodes, dtype=torch.long)
         deg += torch.bincount(d, minlength=deg.numel())
-    deg = torch.tensor(deg, requires_grad=False).to(get_device())
+    deg = deg.clone().detach().to(get_device())
     dist.all_reduce(deg, op=dist.ReduceOp.SUM)
     return deg.cpu().detach().numpy()
 


### PR DESCRIPTION
All the data loaders use the `pin_memory=True`, which can work only if the data is stored on CPUs. 
If the entire data were stored on the GPU, `pin_memory=True` would make the code crash

Since all our data is stored on CPU, the `max_de`g and `deg ` variables are also stored on the CPU. Therefore, the NCCL gathering operations crash because they require the variables to be on the device. 

This PR fixed this problem. 
