### PR TITLE
Init examples on cpu for memory pinning

### DIFF
--- a/examples/md17/md17.py
+++ b/examples/md17/md17.py
@@ -20,8 +20,7 @@ def md17_pre_transform(data):
     graph_features_dim = [1]
     node_feature_dim = [1]
     data = compute_edges(data)
-    device = hydragnn.utils.get_device()
-    return data.to(device)
+    return data
 
 
 # Randomly select ~1000 samples

--- a/examples/qm9/qm9.py
+++ b/examples/qm9/qm9.py
@@ -19,8 +19,7 @@ def qm9_pre_transform(data):
     data.y = data.y[:, 10] / len(data.x)
     graph_features_dim = [1]
     node_feature_dim = [1]
-    device = hydragnn.utils.get_device()
-    return data.to(device)
+    return data
 
 
 def qm9_pre_filter(data):

--- a/tests/test_model_loadpred.py
+++ b/tests/test_model_loadpred.py
@@ -43,7 +43,7 @@ def unittest_model_prediction(config):
     )
     # 2.check a random selected sample
     isample = random.randrange(len(test_loader.dataset))
-    graph_sample = test_loader.dataset[isample]
+    graph_sample = test_loader.dataset[isample].to(model.device)
     true_sample = graph_sample.y.squeeze()
     predicted_sample = model(graph_sample)
     yloc = graph_sample.y_loc.squeeze()


### PR DESCRIPTION
Keep examples on cpu in the pre_transform, so that they properly interact with memory pinning when being migrated to the gpu.