### PR TITLE
Use Adios BP4

### DIFF
--- a/examples/ising_model/train_ising.py
+++ b/examples/ising_model/train_ising.py
@@ -223,6 +223,7 @@ if __name__ == "__main__":
         3. Split into a train, valid, and test set (split_dataset)
         4. Save as Adios file in parallel
         """
+        sys.setrecursionlimit(1000000)
         dir = os.path.join(os.path.dirname(__file__), "./dataset/%s" % modelname)
         if rank == 0:
             if os.path.exists(dir):

--- a/hydragnn/utils/adiosdataset.py
+++ b/hydragnn/utils/adiosdataset.py
@@ -49,7 +49,6 @@ class AdiosWriter:
         self.attributes = dict()
         self.adios = ad2.ADIOS()
         self.io = self.adios.DeclareIO(self.filename)
-        self.io.SetEngine("BP4")
 
     def add_global(self, vname, arr):
         """
@@ -299,6 +298,7 @@ class AdiosDataset(AbstractBaseDataset):
             self.ddstore = dds.PyDDStore(self.ddstore_comm)
         log("Adios reading:", self.filename)
         with ad2.open(self.filename, "r", MPI.COMM_SELF) as f:
+            f.__next__()
             self.vars = f.available_variables()
             self.attrs = f.available_attributes()
             self.keys = f.read_attribute_string("%s/keys" % label)
@@ -421,6 +421,7 @@ class AdiosDataset(AbstractBaseDataset):
 
         if not self.preload and not self.shmem:
             self.f = ad2.open(self.filename, "r", MPI.COMM_SELF)
+            self.f.__next__()
 
     def len(self):
         """
@@ -534,6 +535,7 @@ class AdiosDataset(AbstractBaseDataset):
                 count[vdim] = self.variable_count[k][i : i + dn].sum()
 
                 with ad2.open(self.filename, "r", MPI.COMM_SELF) as f:
+                    f.__next__()
                     self._data[k] = f.read("%s/%s" % (self.label, k), start, count)
 
             filtered = filter(lambda x: x >= i and x < i + dn, self.preflight_list)

--- a/hydragnn/utils/adiosdataset.py
+++ b/hydragnn/utils/adiosdataset.py
@@ -49,6 +49,7 @@ class AdiosWriter:
         self.attributes = dict()
         self.adios = ad2.ADIOS()
         self.io = self.adios.DeclareIO(self.filename)
+        self.io.SetEngine("BP4")
 
     def add_global(self, vname, arr):
         """


### PR DESCRIPTION
Adios recently added new BP5 format. But, it is not compatible with what we are using in HydraGNN. 
We will use BP4 until we figure out the correct way to use BP5.

Another fix is about `sys.setrecursionlimit(1000000)`. It was needed when I create a large ising dataset.