### PR TITLE
Graph heads ci tests

### DIFF
--- a/hydragnn/models/DIMEStack.py
+++ b/hydragnn/models/DIMEStack.py
@@ -102,6 +102,7 @@ class DIMEStack(Base):
             out_channels=output_dim,
             num_layers=1,
             act=SiLU(),
+            output_initializer="glorot_orthogonal",
         )
         return Sequential(
             "x, pos, rbf, sbf, i, j, idx_kj, idx_ji",

--- a/requirements-pyg.txt
+++ b/requirements-pyg.txt
@@ -1,4 +1,4 @@
-torch_geometric==2.3.1
+torch_geometric==2.5.2
 pyg_lib==0.4.0
 torch_scatter==2.1.2
 torch_sparse==0.6.18

--- a/tests/inputs/ci_conv_head.json
+++ b/tests/inputs/ci_conv_head.json
@@ -1,0 +1,79 @@
+{
+    "Verbosity": {
+        "level": 0
+    },
+    "Dataset": {
+        "name": "unit_test_singlehead",
+        "format": "unit_test",
+        "compositional_stratified_splitting": true,
+        "rotational_invariance": false,
+        "path": {
+            "train": "dataset/unit_test_singlehead_train",
+            "test": "dataset/unit_test_singlehead_test",
+            "validate": "dataset/unit_test_singlehead_validate"
+        },
+        "node_features": {
+            "name": ["x","x2","x3"],
+            "dim": [1, 1, 1],
+            "column_index": [0, 6, 7]
+        },
+        "graph_features":{
+            "name": [ "sum_x_x2_x3"],
+            "dim": [1],
+            "column_index": [0]
+        }
+    },
+    "NeuralNetwork": {
+        "Architecture": {
+            "model_type": "PNA",
+            "radius": 2.0,
+            "max_neighbours": 100,
+            "num_gaussians": 50,
+            "envelope_exponent": 5,
+            "int_emb_size": 64,
+            "basis_emb_size": 8,
+            "out_emb_size": 128,
+            "num_after_skip": 2,
+            "num_before_skip": 1,
+            "num_radial": 6,
+            "num_spherical": 7,
+            "num_filters": 126,
+            "periodic_boundary_conditions": false,
+            "hidden_dim": 50,
+            "num_conv_layers": 4,
+            "output_heads": {
+                "node": {
+                    "num_headlayers": 2,
+                    "dim_headlayers": [50,50],
+                     "type": "conv"
+                }
+            },
+            "task_weights": [1.0]
+        },
+        "Variables_of_interest": {
+            "input_node_features": [0],
+            "output_names": ["x"],
+            "output_index": [0],
+            "type": ["node"],
+            "denormalize_output": false
+        },
+        "Training": {
+            "num_epoch": 100,
+            "perc_train": 0.7,
+	    "EarlyStopping": true,
+	    "patience": 10,
+            "loss_function_type": "mse",
+            "batch_size": 1,
+            "Optimizer": {
+                "type": "AdamW",
+                "use_zero_redundancy": false,
+                "learning_rate": 0.02
+            }
+        }
+    },
+    "Visualization": {
+        "plot_init_solution": true,
+        "plot_hist_solution": false,
+        "create_plots": true
+    }
+}

--- a/tests/inputs/ci_conv_head.json
+++ b/tests/inputs/ci_conv_head.json
@@ -39,12 +39,12 @@
             "num_spherical": 7,
             "num_filters": 126,
             "periodic_boundary_conditions": false,
-            "hidden_dim": 50,
-            "num_conv_layers": 4,
+            "hidden_dim": 20,
+            "num_conv_layers": 2,
             "output_heads": {
                 "node": {
                     "num_headlayers": 2,
-                    "dim_headlayers": [50,50],
+                    "dim_headlayers": [20,10],
                      "type": "conv"
                 }
             },
@@ -60,10 +60,10 @@
         "Training": {
             "num_epoch": 100,
             "perc_train": 0.7,
-	    "EarlyStopping": true,
-	    "patience": 10,
+	        "EarlyStopping": false,
+	        "patience": 10,
             "loss_function_type": "mse",
-            "batch_size": 1,
+            "batch_size": 32,
             "Optimizer": {
                 "type": "AdamW",
                 "use_zero_redundancy": false,

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -142,7 +142,7 @@ def unittest_train_model(model_type, ci_input, use_lengths, overwrite_data=False
     if ci_input == "ci_conv_head.json":
         thresholds["PNA"] = [0.3, 0.3]
         thresholds["EGNN"] = [0.5, 0.5]
-        thresholds["SchNet"] = [0.5, 0.5]
+        thresholds["SchNet"] = [0.6, 0.6]
     verbosity = 2
 
     for ihead in range(len(true_values)):

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -139,6 +139,9 @@ def unittest_train_model(model_type, ci_input, use_lengths, overwrite_data=False
         thresholds["PNA"] = [0.10, 0.10]
     if use_lengths and "vector" in ci_input:
         thresholds["PNA"] = [0.2, 0.15]
+    if ci_input == "ci_conv_head.json":
+        thresholds["GIN"] = [0.25, 0.40]
+
     verbosity = 2
 
     for ihead in range(len(true_values)):

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -202,8 +202,7 @@ def pytest_train_model_vectoroutput(model_type, overwrite_data=False):
 
 
 @pytest.mark.parametrize(
-    "model_type",
-    ["SAGE", "GIN", "GAT", "MFC", "PNA", "SchNet", "DimeNet", "EGNN"]
+    "model_type", ["SAGE", "GIN", "GAT", "MFC", "PNA", "SchNet", "DimeNet", "EGNN"]
 )
 def pytest_train_model_conv_head(model_type, overwrite_data=False):
     unittest_train_model(model_type, "ci_conv_head.json", False, overwrite_data)

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -141,8 +141,8 @@ def unittest_train_model(model_type, ci_input, use_lengths, overwrite_data=False
         thresholds["PNA"] = [0.2, 0.15]
     if ci_input == "ci_conv_head.json":
         thresholds["PNA"] = [0.3, 0.3]
-        thresholds["EGNN"] = [0.4, 0.4]
-        thresholds["SchNet"] = [0.4, 0.4]
+        thresholds["EGNN"] = [0.5, 0.5]
+        thresholds["SchNet"] = [0.5, 0.5]
     verbosity = 2
 
     for ihead in range(len(true_values)):

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -139,6 +139,10 @@ def unittest_train_model(model_type, ci_input, use_lengths, overwrite_data=False
         thresholds["PNA"] = [0.10, 0.10]
     if use_lengths and "vector" in ci_input:
         thresholds["PNA"] = [0.2, 0.15]
+    if ci_input == "ci_conv_head.json":
+        thresholds["PNA"] = [0.3, 0.3]
+        thresholds["EGNN"] = [0.4, 0.4]
+        thresholds["SchNet"] = [0.4, 0.4]
     verbosity = 2
 
     for ihead in range(len(true_values)):
@@ -199,3 +203,11 @@ def pytest_train_equivariant_model(model_type, overwrite_data=False):
 @pytest.mark.parametrize("model_type", ["PNA"])
 def pytest_train_model_vectoroutput(model_type, overwrite_data=False):
     unittest_train_model(model_type, "ci_vectoroutput.json", True, overwrite_data)
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    ["PNA", "EGNN", "SchNet"],
+)
+def pytest_train_model_conv_head(model_type, overwrite_data=False):
+    unittest_train_model(model_type, "ci_conv_head.json", True, overwrite_data)

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -139,10 +139,6 @@ def unittest_train_model(model_type, ci_input, use_lengths, overwrite_data=False
         thresholds["PNA"] = [0.10, 0.10]
     if use_lengths and "vector" in ci_input:
         thresholds["PNA"] = [0.2, 0.15]
-    if ci_input == "ci_conv_head.json":
-        thresholds["PNA"] = [0.3, 0.3]
-        thresholds["EGNN"] = [0.5, 0.5]
-        thresholds["SchNet"] = [0.6, 0.6]
     verbosity = 2
 
     for ihead in range(len(true_values)):
@@ -207,7 +203,7 @@ def pytest_train_model_vectoroutput(model_type, overwrite_data=False):
 
 @pytest.mark.parametrize(
     "model_type",
-    ["PNA", "EGNN", "SchNet"],
+    ["SAGE", "GIN", "GAT", "MFC", "PNA", "SchNet", "DimeNet", "EGNN"]
 )
 def pytest_train_model_conv_head(model_type, overwrite_data=False):
-    unittest_train_model(model_type, "ci_conv_head.json", True, overwrite_data)
+    unittest_train_model(model_type, "ci_conv_head.json", False, overwrite_data)


### PR DESCRIPTION
The capability to use a full stack of convolutional layers when only nodal predictions are needed was never tested in the code. 
This PR:

- updated pre-existing code to maintain support of `type="conv"` as a choice for nodal heads of HydraGNN
- has if-then-else conditions to make sure that `get_conv` is called with the proper number of arguments. All models except SCFStack take two input arguments. SCFStack takes also` last_layer`, which is a Boolean variable. 