### PR TITLE
Remove multi_process_list option in multidataset

### DIFF
--- a/examples/multidataset/train.py
+++ b/examples/multidataset/train.py
@@ -186,9 +186,7 @@ if __name__ == "__main__":
             imax = np.argmax(process_list)
             process_list[imax] = process_list[imax] - (np.sum(process_list) - comm_size)
             process_list = process_list.tolist()
-            comm.bcast(process_list)
-        else:
-            process_list = comm.bcast(None)
+        process_list = comm.bcast(process_list)
         assert comm_size == sum(process_list)
 
         colorlist = list()

--- a/examples/multidataset/train.py
+++ b/examples/multidataset/train.py
@@ -186,7 +186,7 @@ if __name__ == "__main__":
             imax = np.argmax(process_list)
             process_list[imax] = process_list[imax] - (np.sum(process_list) - comm_size)
             process_list = process_list.tolist()
-        process_list = comm.bcast(process_list)
+        process_list = comm.bcast(process_list, root=0)
         assert comm_size == sum(process_list)
 
         colorlist = list()

--- a/examples/multidataset/train.py
+++ b/examples/multidataset/train.py
@@ -186,6 +186,8 @@ if __name__ == "__main__":
             imax = np.argmax(process_list)
             process_list[imax] = process_list[imax] - (np.sum(process_list) - comm_size)
             process_list = process_list.tolist()
+        else:
+            process_list = None
         process_list = comm.bcast(process_list, root=0)
         assert comm_size == sum(process_list)
 


### PR DESCRIPTION
Remove multi_process_list option in multidataset. It calculates number of processes per dataset based on the number of molecules in the files.