### PR TITLE
Removed pickle5 requirement from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ def read(fname):
 
 
 install_requires = [
-    "pickle5",
     "matplotlib",
     "tqdm",
     "tensorboard",


### PR DESCRIPTION
pickle5 is replaced with pickle for python > 3.7, thus pickle5 requirement is not needed.