### PR TITLE
Fix: no return value of get_summary_writer

### DIFF
--- a/hydragnn/utils/model.py
+++ b/hydragnn/utils/model.py
@@ -73,9 +73,11 @@ def save_model(model, optimizer, name, path="./logs/"):
 
 def get_summary_writer(name, path="./logs/"):
     _, world_rank = get_comm_size_and_rank()
+    writer = None
     if world_rank == 0:
         path_name = os.path.join(path, name)
         writer = SummaryWriter(path_name)
+    return writer
 
 
 def load_existing_model_config(model, config, path="./logs/", optimizer=None):


### PR DESCRIPTION
`get_summary_writer()` in the current main branch has no return value so the tensorboard log file will never be written:

Current implementation in [hydragnn/utils/model.py](https://github.com/ORNL/HydraGNN/blob/5c4dcf4ef10cdc3ec97c1ec6e97ba922cc177fd6/hydragnn/utils/model.py#L74):

```python
def get_summary_writer(name, path="./logs/"):
    _, world_rank = get_comm_size_and_rank()
    if world_rank == 0:
        path_name = os.path.join(path, name)
        writer = SummaryWriter(path_name)
```

Example use case in [examples/ogb/train_gap.py](https://github.com/ORNL/HydraGNN/blob/5c4dcf4ef10cdc3ec97c1ec6e97ba922cc177fd6/examples/ogb/train_gap.py#L305):

```python
  writer = hydragnn.utils.get_summary_writer(log_name)
```