### PR TITLE
Enhancement: model-agnostic layer-wise checkpointing

### DIFF
--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -18,6 +18,7 @@ from torch.utils.checkpoint import checkpoint
 from hydragnn.utils.model import activation_function_selection, loss_function_selection
 import sys
 from hydragnn.utils.distributed import get_device
+from hydragnn.utils.print_utils import print_master
 
 import inspect
 
@@ -282,7 +283,7 @@ class Base(Module):
             self.heads_NN.append(head_NN)
 
     def enable_conv_checkpointing(self):
-        print("Enabling checkpointing")
+        print_master("Enabling checkpointing")
         self.conv_checkpointing = True
 
     def forward(self, data):

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -14,6 +14,7 @@ from torch.nn import ModuleList, Sequential, ReLU, Linear, Module
 import torch.nn.functional as F
 from torch_geometric.nn import global_mean_pool, BatchNorm
 from torch.nn import GaussianNLLLoss
+from torch.utils.checkpoint import checkpoint
 from hydragnn.utils.model import activation_function_selection, loss_function_selection
 import sys
 from hydragnn.utils.distributed import get_device
@@ -107,6 +108,8 @@ class Base(Module):
         self._multihead()
         if self.initial_bias is not None:
             self._set_bias()
+
+        self.conv_checkpointing = False
 
     def _init_conv(self):
         self.graph_convs.append(self.get_conv(self.input_dim, self.hidden_dim))
@@ -278,6 +281,10 @@ class Base(Module):
                 )
             self.heads_NN.append(head_NN)
 
+    def enable_conv_checkpointing(self):
+        print("Enabling checkpointing")
+        self.conv_checkpointing = True
+
     def forward(self, data):
         x = data.x
         pos = data.pos
@@ -285,7 +292,12 @@ class Base(Module):
         ### encoder part ####
         conv_args = self._conv_args(data)
         for conv, feat_layer in zip(self.graph_convs, self.feature_layers):
-            c, pos = conv(x=x, pos=pos, **conv_args)
+            if not self.conv_checkpointing:
+                c, pos = conv(x=x, pos=pos, **conv_args)
+            else:
+                c, pos = checkpoint(
+                    conv, use_reentrant=False, x=x, pos=pos, **conv_args
+                )
             x = self.activation_function(feat_layer(c))
 
         #### multi-head decoder part####

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -62,6 +62,7 @@ def create_model_config(
         config["Architecture"]["num_filters"],
         config["Architecture"]["radius"],
         config["Architecture"]["equivariance"],
+        config["Training"]["conv_checkpointing"],
         verbosity,
         use_gpu,
     )
@@ -97,6 +98,7 @@ def create_model(
     num_filters: int = None,
     radius: float = None,
     equivariance: bool = False,
+    conv_checkopinting: bool = False,
     verbosity: int = 0,
     use_gpu: bool = True,
 ):
@@ -301,6 +303,9 @@ def create_model(
 
     else:
         raise ValueError("Unknown model_type: {0}".format(model_type))
+
+    if conv_checkopinting:
+        model.enable_conv_checkpointing()
 
     timer.stop()
 

--- a/hydragnn/utils/config_utils.py
+++ b/hydragnn/utils/config_utils.py
@@ -102,6 +102,9 @@ def update_config(config, train_loader, val_loader, test_loader):
 
     if "SyncBatchNorm" not in config["NeuralNetwork"]["Architecture"]:
         config["NeuralNetwork"]["Architecture"]["SyncBatchNorm"] = False
+
+    if "conv_checkpointing" not in config["NeuralNetwork"]["Training"]:
+        config["NeuralNetwork"]["Training"]["conv_checkpointing"] = False
     return config
 
 


### PR DESCRIPTION
[Checkpointing](https://pytorch.org/docs/stable/checkpoint.html) is a widely used technique (i.e. in [deepspeed](https://github.com/microsoft/DeepSpeed/blob/f4cb866c2eba60a72d79c3741d12d098fe4e45b8/deepspeed/runtime/activation_checkpointing/checkpointing.py#L725)) to reduce peak GPU memory consumption. It achieves this by recomputing intermediate activations during the backward pass instead of storing them from the forward pass.

This enhancement leverages PyTorch's official checkpoint implementation and applies it at a per convolution layer granuality.

Key features include:

+ Model agnosticism: It can be used with any type of message-passing layers.
+ Significant memory reduction: An 18-layer, 512-dimension PNA network (with batch_size=128) shows a peak memory usage reduction of approximately 58%.

Usage: config["NeuralNetwork"]["Training"]["conv_checkpointing"] = True

Overhead: With an 18-layer, 512-dimension PNA network, recomputing activations introduces an extra training time of ~28.6%, as observed on an 8x A5000 server.

Raw profiling results: Attached are the memory consumption and latency profiling results ([google_drive](https://drive.google.com/drive/folders/1xGRj8AouAFfV_kUnnNDR8AoF-WfaDeFQ?usp=sharing)). For visualization, please refer to [pytorch.org/memory_viz](https://pytorch.org/memory_viz) and [ui.perfetto.dev/](https://ui.perfetto.dev/), respectively.