### PR TITLE
Fix for runtime error for missing host-to-device copy

### DIFF
--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -474,7 +474,8 @@ def train(
         with record_function("forward"):
             if trace_level > 0:
                 tr.start("h2d", **syncopt)
-                data = data.to(get_device())
+            data = data.to(get_device())
+            if trace_level > 0:
                 tr.stop("h2d", **syncopt)
             pred = model(data)
             loss, tasks_loss = model.module.loss(pred, data.y, head_index)


### PR DESCRIPTION
A quick fix for
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
```

I found my previous commit has a problem. I missed host-to-device copying. This will be a fix.