### PR TITLE
Cleaner way to fail if ADIOS is not installed. #205

### DIFF
--- a/hydragnn/utils/adiosdataset.py
+++ b/hydragnn/utils/adiosdataset.py
@@ -86,7 +86,6 @@ class AdiosWriter:
         comm: MPI_comm
             MPI communicator to use for Adios parallel writing
         """
-
         # Test import of adios2. Let it fail with an ImportError if ADIOS2 is not installed
         import adios2
 
@@ -315,7 +314,6 @@ class AdiosDataset(AbstractBaseDataset):
         ddstore: bool, optional
             Option to use Distributed Data Store
         """
-        
         # Test import of adios2. Let it fail with an ImportError if ADIOS2 is not installed
         import adios2
 

--- a/hydragnn/utils/adiosdataset.py
+++ b/hydragnn/utils/adiosdataset.py
@@ -86,6 +86,10 @@ class AdiosWriter:
         comm: MPI_comm
             MPI communicator to use for Adios parallel writing
         """
+
+        # Test import of adios2. Let it fail with an ImportError if ADIOS2 is not installed
+        import adios2
+
         self.filename = filename
         self.comm = comm
         self.rank = comm.Get_rank()
@@ -311,6 +315,10 @@ class AdiosDataset(AbstractBaseDataset):
         ddstore: bool, optional
             Option to use Distributed Data Store
         """
+        
+        # Test import of adios2. Let it fail with an ImportError if ADIOS2 is not installed
+        import adios2
+
         self.filename = filename
         self.label = label
         self.comm = comm


### PR DESCRIPTION
This adds a check to see if ADIOS is installed. It will fail with an ImportError if ADIOS is not found. We don't need to add any more error handling here.

Without this line, we get 
```
NameError: name 'ad2' is not defined
```
which is not intuitive.