### PR TITLE
Enhancement: Deepspeed Launch Template & Now Compatible with GPU Binding

### DIFF
--- a/examples/ogb/train_gap.py
+++ b/examples/ogb/train_gap.py
@@ -485,7 +485,10 @@ if __name__ == "__main__":
         # create deepspeed model
         model, optimizer, _, _ = deepspeed.initialize(
             args=get_deepspeed_init_args(),
-            model=model, config=ds_config, dist_init_required=False, optimizer=optimizer
+            model=model,
+            config=ds_config,
+            dist_init_required=False,
+            optimizer=optimizer,
         )  # scheduler is not managed by deepspeed because it is per-epoch instead of per-step
 
         hydragnn.utils.load_existing_model_config(

--- a/examples/ogb/train_gap.py
+++ b/examples/ogb/train_gap.py
@@ -25,6 +25,7 @@ from hydragnn.utils.smiles_utils import (
     generate_graphdata_from_smilestr,
 )
 from hydragnn.utils.config_utils import parse_deepspeed_config
+from hydragnn.utils.distributed import get_deepspeed_init_args
 from hydragnn.utils import nsplit
 
 import numpy as np
@@ -483,6 +484,7 @@ if __name__ == "__main__":
 
         # create deepspeed model
         model, optimizer, _, _ = deepspeed.initialize(
+            args=get_deepspeed_init_args(),
             model=model, config=ds_config, dist_init_required=False, optimizer=optimizer
         )  # scheduler is not managed by deepspeed because it is per-epoch instead of per-step
 

--- a/hydragnn/utils/distributed.py
+++ b/hydragnn/utils/distributed.py
@@ -233,13 +233,15 @@ def get_device_name(use_gpu=True, rank_per_model=1, verbosity_level=0, no_prefix
 
     return device_name
 
+
 def get_deepspeed_init_args():
     class Obj(object):
         pass
-    
+
     obj = Obj()
     obj.device_rank = int(get_device_name(no_prefix=True))
     return obj
+
 
 def get_local_rank():
     localrank = 0

--- a/hydragnn/utils/distributed.py
+++ b/hydragnn/utils/distributed.py
@@ -198,7 +198,7 @@ def get_device_list():
     return available_gpus
 
 
-def get_device_name(use_gpu=True, rank_per_model=1, verbosity_level=0):
+def get_device_name(use_gpu=True, rank_per_model=1, verbosity_level=0, no_prefix=False):
 
     available_gpus = get_device_list()
     if not use_gpu or not available_gpus:
@@ -226,10 +226,20 @@ def get_device_name(use_gpu=True, rank_per_model=1, verbosity_level=0):
                 % (localrank, torch.cuda.device_count())
             )
 
-    device_name = "cuda:" + str(localrank)
+    if no_prefix:
+        device_name = str(localrank)
+    else:
+        device_name = "cuda:" + str(localrank)
 
     return device_name
 
+def get_deepspeed_init_args():
+    class Obj(object):
+        pass
+    
+    obj = Obj()
+    obj.device_rank = int(get_device_name(no_prefix=True))
+    return obj
 
 def get_local_rank():
     localrank = 0

--- a/job-frontier-ogb-deepspeed.sh
+++ b/job-frontier-ogb-deepspeed.sh
@@ -39,6 +39,8 @@ export PYTHONPATH=/lustre/orion/cph161/world-shared/mlupopa/ADIOS_frontier/insta
 export PYTHONPATH=$PWD:$PYTHONPATH
 
 
-#srun -N$SLURM_JOB_NUM_NODES -n$((SLURM_JOB_NUM_NODES*8)) -c7 --gpus-per-task=1 --gpu-bind=closest \
-srun -N$SLURM_JOB_NUM_NODES -n$((SLURM_JOB_NUM_NODES*8)) -c7 --gpus-per-task=1 --gpu-bind=closest \
-    python -u ./examples/ogb/train_gap.py gap --adios --use_deepspeed
+# both commands should work
+srun -N$SLURM_JOB_NUM_NODES -n$((SLURM_JOB_NUM_NODES*8)) -c7 --gres=gpu:8 \
+   python -u ./examples/ogb/train_gap.py gap --adios --use_deepspeed
+# srun -N$SLURM_JOB_NUM_NODES -n$((SLURM_JOB_NUM_NODES*8)) -c7 --gpus-per-task=1 --gpu-bind=closest \
+#     python -u ./examples/ogb/train_gap.py gap --adios --use_deepspeed

--- a/run_deepspeed_template.sh
+++ b/run_deepspeed_template.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#SBATCH -A LRN031
+#SBATCH -J HydraGNN
+#SBATCH -o job-%j.out
+#SBATCH -e job-%j.out
+#SBATCH -t 01:00:00
+#SBATCH -p batch
+#SBATCH -q debug
+#SBATCH -N 8
+#SBATCH -S 1
+
+ulimit -n 65536
+
+export MPICH_ENV_DISPLAY=0
+export MPICH_VERSION_DISPLAY=0
+export MIOPEN_DISABLE_CACHE=1
+export NCCL_PROTO=Simple
+
+export OMP_NUM_THREADS=7
+export HYDRAGNN_NUM_WORKERS=0
+export HYDRAGNN_USE_VARIABLE_GRAPH_SIZE=1
+export HYDRAGNN_AGGR_BACKEND=mpi
+export HYDRAGNN_VALTEST=0 
+export NCCL_P2P_LEVEL=NVL
+export NCCL_P2P_DISABLE=1
+
+export MPICH_GPU_SUPPORT_ENABLED=1
+export MPICH_GPU_MANAGED_MEMORY_SUPPORT_ENABLED=1
+export MPICH_OFI_NIC_POLICY=GPU
+
+
+source /lustre/orion/cph161/world-shared/mlupopa/module-to-load-frontier.sh
+
+source /lustre/orion/cph161/world-shared/mlupopa/max_conda_envs_frontier/bin/activate
+conda activate hydragnn
+
+export PYTHONPATH=/lustre/orion/cph161/world-shared/mlupopa/ADIOS_frontier/install/lib/python3.8/site-packages/:$PYTHONPATH
+
+export PYTHONPATH=$PWD:$PYTHONPATH
+
+
+#srun -N$SLURM_JOB_NUM_NODES -n$((SLURM_JOB_NUM_NODES*8)) -c7 --gpus-per-task=1 --gpu-bind=closest \
+srun -N$SLURM_JOB_NUM_NODES -n$((SLURM_JOB_NUM_NODES*8)) -c7 --gpus-per-task=1 --gpu-bind=closest \
+    python -u ./examples/ogb/train_gap.py gap --adios --use_deepspeed


### PR DESCRIPTION
As noted by @jychoi-hpc in the [previous pull request](https://github.com/ORNL/HydraGNN/pull/264#issuecomment-2237505680), the DeepSpeed backend fails to initialize when a rank has only one visible GPU (e.g., when launched with --`gpus-per-task=1`).

The root cause is that DeepSpeed defaults to determining GPU ordinals based on the `LOCAL_RANK` environment variable if no `device_rank` is passed, but with one visible GPU per rank, only device ordinal 0 is valid, which makes all ranks except local_rank 0 fails. 

Although this default mapping works when granting visibility of all GPUs to all ranks, it may not be optimal considering the [heterogeneous connectivity](https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#frontier-compute-nodes) between CPU caches and GPUs on Frontier. For optimal performance, it is recommended to use `--gpus-per-task=1 --gpu-bind=closest`, as outlined [here](https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#gpu-mapping).

In this pull request, I have addressed the issue by explicitly specifying which GPU to use (i.e. passing a `device_rank=0` to deepspeed if only having one visible GPU). This ensures that the DeepSpeed backend functions correctly with both one visible GPU per rank (e.g., launched with `--gpus-per-task=1`) and all GPUs visible to all ranks (e.g., launched with `--gres=gpu:8`).

Additionally, I have included a bash template to facilitate running the DeepSpeed backend on Frontier.
