### PR TITLE
Add Position Data to ADIOS-Formatted Molecular Dataset

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -1,0 +1,90 @@
+# Data Formats
+
+Inside HydraGNN, we use [torch_geometric.Data](https://pytorch-geometric.readthedocs.io/en/latest/generated/torch_geometric.data.Data.html) to store all graph properties.
+
+Node, edge, and graph-level attributes are divided into different
+variables as follows,
+
+    Data.x: node-level with shape [num_nodes, num_node_features]
+    Data.y: graph-level with shape [num_graph_features)
+    Data.edge_attr: edge-level with shape [num_edges, num_edge_features]
+
+We also make use of coordinates and edges,
+
+    Data.pos: node-level coordinates with shape [num_nodes, num_dimensions]
+    Data.edge_index: node indices for each edge with shape [2, num_edges]
+
+## Adios Storage Format
+
+The Adios data file maintains these names and shapes,
+but concatenates all data over all graphs.
+Adios data fields `Z.variable_count` and `Z.variable_offset`
+(where `Z` = `x`, `pos`, `y`, or `edge_addr`) allow parsing out
+the data pertaining to a specific graph
+by offset and count.  For example (using 0-based indexing),
+the starting node index for graph 0 is,
+
+    dataset.x.variable_offset[0]
+
+while the number of atoms in graph 0 is,
+
+    dataset.x.variable_count[0]
+
+To retrieve edge features for graph 20, we would use,
+
+    off = dataset.edge_attr.variable_offset[20]
+    count = dataset.edge_attr.variable_count[20]
+    dataset.edge_attr[off:off+count]
+
+Note: Since these offsets and counts index graphs,
+it would be more descriptive to have called these
+`graph_offset` and `graph_count`.
+
+### Metadata
+
+In order to describe names and dimensions of
+individual features, the Adios datafile contains
+supplementary fields `x_name`, `y_name`, and `edge_attr_name`.
+These also have `feature_count` and `feature_offset`,
+which are indexes into the feature dimensions of `x`, `y`, and `edge_attr`,
+respectively.
+
+So, for example, the *qm7x* dataset has:
+
+    x_name = ["atomic_number", "pos", "forces, "charge", "dipole", "volume_ratio"]
+
+    x_name.feature_count  = [1, 3, 3, 1, 3,  1]
+    x_name.feature_offset = [0, 1, 4, 7, 8, 11]
+
+## Selecting Features in the Model Configuration File
+
+When specifying a model, we provide a list of input
+and output node, edge, and graph-level features:
+
+    "inputs": {
+        "node": ["atomic_number", "pos"],
+        "edge": ["length"],
+        "graph": []
+    },
+
+    "outputs": [
+        { "type": "graph",
+          "layer_dims": [100, 100],
+          "features": ["energy"],
+          "loss": "mse"
+        },
+        { "type": "node",
+          "layer_dims": [128],
+          "features": ["charge", "volume_ratio"],
+          "loss": "mse"
+        }
+    ]
+
+    "loss": {
+        "type": "sum",
+        "weights": [0.001, 1.0]
+    }
+
+Note that each output head forms its own list element
+and has its own loss function.  The combined, total loss,
+is specified by the "loss" element.

--- a/hydragnn/utils/print_utils.py
+++ b/hydragnn/utils/print_utils.py
@@ -54,7 +54,9 @@ def print_distributed(verbosity_level, *args):
 
 
 def iterate_tqdm(iterator, verbosity_level, *args, **kwargs):
-    if (0 == dist.get_rank() and 2 == verbosity_level) or 4 == verbosity_level:
+    if not dist.is_initialized() \
+            or (0 == dist.get_rank() and 2 == verbosity_level) \
+            or 4 == verbosity_level:
         return tqdm(iterator, *args, **kwargs)
     else:
         return iterator

--- a/utils/README.md
+++ b/utils/README.md
@@ -14,7 +14,7 @@ Next, import your dataset into ADIOS2 format, using
 Then create a `config.json` file describing
 the topology of your ML model.
 
-    yaml_to_config.py descr.yaml config.json
+    yaml_to_config.py ../../../datasets/clintox.yaml clintox.json
 
 With both of these ingredients in-hand, you can run:
 

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,24 @@
+This directory contains utilities for
+wrangling datasets into useful
+shape for HydraGNN to operate on them.
+
+
+The first step is to describe your dataset
+using a `descr.yaml` file.
+The format of this file is given by example (FIXME).
+
+Next, import your dataset into ADIOS2 format, using
+
+    import_csv.py --input ../../../datasets/MolNet-ClinTox/clintox.csv --descr ../../../datasets/clintox.yaml --output data.bp
+
+Then create a `config.json` file describing
+the topology of your ML model.
+
+    yaml_to_config.py descr.yaml config.json
+
+With both of these ingredients in-hand, you can run:
+
+    train.py config.json data.bp
+
+to produce trained model weights and predictions.
+

--- a/utils/config.py
+++ b/utils/config.py
@@ -1,0 +1,37 @@
+from pydantic import BaseModel
+
+# parse example:
+# Optimizer.model_validate_json( '{ "learn_rate": 0.0001, "batch_size": 128 }' )
+class OptimizerModel(BaseModel):
+    learning_rate : float
+    batch_size : int
+
+class TrainingModel(BaseModel):
+    Optimizer : OptimizerModel
+
+class NeuralNetworkModel(BaseModel):
+    layers : int
+
+class Config(BaseModel):
+    NeuralNetwork: NeuralNetworkModel
+    Training : TrainingModel
+
+"""
+Note: Validation errors look like
+
+NeuralNetwork.Training.Optimizer.learning_rate
+  Field required [type=missing, input_value={'learn_rate': 0.001, 'batch_size': 128}, input_type=dict]
+
+which is saying that it expected to find "learning_rate",
+but saw instead, "{'learn_rate': 0.001, 'batch_size': 128}"
+"""
+
+def main(argv):
+    assert len(argv) == 2, f"{argv[0]} <config.json>"
+    with open(argv[1], encoding="utf-8") as f:
+        cfg = Config.model_validate_json( f.read() )
+    print(cfg)
+
+if __name__ == "__main__":
+    import sys
+    main(sys.argv)

--- a/utils/example.json
+++ b/utils/example.json
@@ -1,0 +1,9 @@
+{ "NeuralNetwork": {
+	"Training": {
+	  "Optimizer": {
+		"learning_rate": 0.001,
+		"batch_size": 128
+	  }
+    }
+  }
+}

--- a/utils/import_csv.py
+++ b/utils/import_csv.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+
+""" Import a CSV file into ADIOS2 format
+    so that it can be read by HydraGNN
+    as an AdiosDataset.
+"""
+import os, json
+import pickle, csv
+from pathlib import Path
+import random
+
+import logging
+import sys
+import argparse
+import time
+
+import mpi4py
+mpi4py.rc.thread_level = "serialized"
+mpi4py.rc.threads = False
+from mpi4py import MPI
+
+from tqdm import tqdm
+import pandas as pd
+import yaml
+
+import hydragnn
+from hydragnn.utils.pickledataset import SimplePickleWriter #, SimplePickleDataset
+from hydragnn.utils.smiles_utils import (
+    get_node_attribute_name,
+    generate_graphdata_from_smilestr,
+)
+from hydragnn.preprocess.utils import gather_deg
+from hydragnn.utils import nsplit
+
+import numpy as np
+
+try:
+    from hydragnn.utils.adiosdataset import AdiosWriter, AdiosDataset
+except ImportError:
+    pass
+
+import torch_geometric.data
+import torch
+
+node_types = {"C": 0, "F": 1, "H": 2, "N": 3, "O": 4, "S": 5, "Hg": 6, "Cl": 7}
+
+info = logging.info
+
+def random_splits(N, x, y):
+    """ Shuffle and sample the data indices.
+
+        Args:
+        
+          N: number of data elements
+          x: training fraction
+          y: validation fraction
+
+        Notes:
+          0 <= x <= 1.0
+          0 <= y <= 1.0
+          0 <= (1-x-y) <= 1.0 is the testing fraction
+          so x+y <= 1.0
+    """
+    assert 0.0 <= x <= 1.0
+    assert 0.0 <= y <= 1.0-x
+    a = list(range(N))
+    a = random.sample(a, N)
+    return np.split( a, [int(x * N), int((x+y) * N)] )
+
+def load_columns(datafile, descr):
+    print(descr)
+    smiles_all = []
+    values_all = []
+    with open(datafile, "r") as file:
+        csvreader = csv.reader(file)
+        print(next(csvreader))
+        for row in csvreader:
+            smiles_all.append(row[0])
+            values_all.append([int(row[-1])])
+
+    N = len(smiles_all)
+    assert len(values_all) == N
+    print("Total:", N)
+
+    idxs = random_splits(N, 0.8, 0.1)
+    assert len(idxs) == 3
+    smiles = [ [smiles_all[i] for i in ix] for ix in idxs ]
+    values = [ torch.tensor([values_all[i] for i in ix]) for ix in idxs ]
+    return smiles, values
+
+def main():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument(
+        "--input",
+        help="input CSV/PQ file",
+        required=True,
+    )
+    parser.add_argument(
+        "--descr",
+        help="yaml description",
+        required=True,
+    )
+    parser.add_argument(
+        "--output",
+        help="output directory",
+        required=True,
+    )
+    args = parser.parse_args()
+    if args.output.endswith(".pkl"):
+        out_format = "pickle"
+    elif args.output.endswith(".bp"):
+        out_format = "adios"
+    else:
+        raise "Invalid output format. --output must end with .pkl (pickle) or .bp (adios) suffix."
+    basedir = args.output
+    # create output path and ensure it doesn't yet exist
+    Path(basedir).mkdir(parents=True)
+
+    comm = MPI.COMM_WORLD
+    rank = comm.Get_rank()
+    comm_size = comm.Get_size()
+
+    ## Set up logging
+    logging.basicConfig(
+        level=logging.INFO,
+        format=f"%(levelname)s (rank {rank}): %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    descr = yaml.safe_load(args.descr)
+    smiles_sets, values_sets = load_columns(args.input, descr)
+    info(
+        "trainset,valset,testset size: %d %d %d",
+        *map(len, smiles_sets)
+    )
+
+    verbosity = 2
+
+    setnames = ["trainset", "valset", "testset"]
+    dataset = dict((k,[]) for k in setnames)
+    for name, smileset, valueset in zip(setnames, smiles_sets, values_sets):
+        rx = list(nsplit(range(len(smileset)), comm_size))[rank]
+        info("subset range (%s): %d %d %d", name, len(smileset), rx.start, rx.stop)
+        ## local portion
+        _smileset = smileset[rx.start : rx.stop]
+        _valueset = valueset[rx.start : rx.stop]
+
+        for smilestr, ytarget in tqdm(
+            zip(_smileset, _valueset),
+            disable=rank != 0,
+            desc="Featurizing",
+            total=len(_smileset)
+        ):
+            try:
+                data = generate_graphdata_from_smilestr(
+                    smilestr, ytarget, node_types
+                )
+
+                assert isinstance(data, torch_geometric.data.Data)
+                dataset[name].append(data)
+            except Exception as e:
+                print(
+                    f"Exception in call to generate_graphdata_from_smilestr."
+                    f" {e} for {smilestr}. Ignoring molecule and proceeding .."
+                )
+
+    # pre-compute PNA degrees
+    pna_deg = gather_deg(dataset["trainset"])
+    # this is stored with the trainset in pickle format
+    # and as a global in adios format
+    #config["pna_deg"] = pna_deg
+
+    if output_format == 'pickle':
+        for name, data in dataset.items():
+            attrs = dict()
+            if name == "trainset":
+                attrs["pna_deg"] = pna_deg
+            SimplePickleWriter(
+                data,
+                basedir,
+                name,
+                use_subdir=True,
+                attrs=attrs,
+            )
+    elif output_format == 'adios':
+        adwriter = AdiosWriter(basedir, comm)
+        for name, data in dataset.items():
+            adwriter.add(name, data)
+        adwriter.add_global("pna_deg", pna_deg)
+        adwriter.save()
+    else:
+        raise "Invalid output format. Must be one of pickle/adios"
+
+if __name__ == "__main__":
+    main()

--- a/utils/import_csv.py
+++ b/utils/import_csv.py
@@ -68,15 +68,10 @@ def random_splits(N, x, y):
     return np.split( a, [int(x * N), int((x+y) * N)] )
 
 def load_columns(datafile, descr):
-    print(descr)
-    smiles_all = []
-    values_all = []
-    with open(datafile, "r") as file:
-        csvreader = csv.reader(file)
-        print(next(csvreader))
-        for row in csvreader:
-            smiles_all.append(row[0])
-            values_all.append([int(row[-1])])
+    df = pd.read_csv(datafile)
+    smiles_all = df[ descr["smiles"] ].to_list()
+    names = [ val["name"] for val in descr["graph_tasks"] ]
+    values_all = df[ names ].values #.tolist()
 
     N = len(smiles_all)
     assert len(values_all) == N
@@ -110,9 +105,9 @@ def main():
     )
     args = parser.parse_args()
     if args.output.endswith(".pkl"):
-        out_format = "pickle"
+        output_format = "pickle"
     elif args.output.endswith(".bp"):
-        out_format = "adios"
+        output_format = "adios"
     else:
         raise "Invalid output format. --output must end with .pkl (pickle) or .bp (adios) suffix."
     basedir = args.output
@@ -130,7 +125,8 @@ def main():
         datefmt="%H:%M:%S",
     )
 
-    descr = yaml.safe_load(args.descr)
+    with open(args.descr, "r", encoding="utf-8") as f:
+        descr = yaml.safe_load(f)
     smiles_sets, values_sets = load_columns(args.input, descr)
     info(
         "trainset,valset,testset size: %d %d %d",

--- a/utils/import_csv.py
+++ b/utils/import_csv.py
@@ -199,7 +199,7 @@ def main():
         ## local portion
         _smileset = smileset[rx.start : rx.stop]
         _valueset = valueset[rx.start : rx.stop]
-
+        missed_count = 0
         for smilestr, ytarget in tqdm(
             zip(_smileset, _valueset),
             disable=rank != 0,
@@ -208,7 +208,7 @@ def main():
         ):
             try:
                 data = generate_graphdata_from_smilestr(
-                    smilestr, ytarget
+                    smilestr, ytarget, get_positions=True
                 )
                 # TODO: ensure data.pos is populated (e.g. call rdkit)
                 # TODO: should we energy minimize these coordinates
@@ -220,7 +220,8 @@ def main():
                     f"Exception in call to generate_graphdata_from_smilestr."
                     f" {e} for {smilestr}. Ignoring molecule and proceeding .."
                 )
-
+                missed_count += 1
+    print(f'missed {missed_count} molecules')
     # pre-compute PNA degrees
     pna_deg = gather_deg(dataset["trainset"])
     # this is stored with the trainset in pickle format
@@ -231,7 +232,6 @@ def main():
     node_names = [x.replace("atomicnumber", "atomic_number") for x in node_names]
     edge_names, edge_dims = get_edge_attribute_name()
     task_dims = [1]*len(task_names)
-
     attrs = {
         "x_name": node_names,
         "x_name/feature_count": np.array(node_dims),

--- a/utils/models.py
+++ b/utils/models.py
@@ -1,0 +1,51 @@
+from enum import Enum
+from typing import Annotated, List, Optional
+import re
+import json
+
+import yaml
+from pydantic import BaseModel, AfterValidator
+
+def valid_split(s):
+    if s.startswith("train"): return True
+    if s.startswith("val"): return True
+    if s.startswith("test"): return True
+    if s.startswith("excl"): return True
+    return False
+SplitValue = Annotated[str, AfterValidator(valid_split)]
+
+cat_re = re.compile(r"categorical\([1-9][0-9]*\)")
+def valid_task_type(s):
+    if s.startswith("num"): return True
+    if s == "binary": return True
+    if cat_re.fullmatch(s): return True
+    return False
+TypeValue = Annotated[str, AfterValidator(valid_task_type)]
+
+class Task(BaseModel):
+    name: str
+    type: TypeValue
+    description: str = ""
+
+class DataDescriptor(BaseModel, extra="ignore"): # or "allow" to keep extra
+    name:    str
+    smiles:  str
+    source:  str
+    split:   Optional[str] = None
+    authors: str = ""
+    ref:     str = ""
+    graph_tasks: List[Task] = []
+    edge_tasks:  List[Task] = []
+    node_tasks:  List[Task] = []
+
+def main(argv):
+    assert len(argv) == 2, f"Usage: {argv[0]} <descr.yaml>"
+    with open(argv[1], "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    descr = DataDescriptor.model_validate(data)
+    #print(descr.model_dump_json(indent=2, exclude_defaults=True))
+    print( f"{descr.name}: {len(descr.graph_tasks)} tasks." )
+
+if __name__=="__main__":
+    import sys
+    main(sys.argv)

--- a/utils/models.py
+++ b/utils/models.py
@@ -16,25 +16,26 @@ SplitValue = Annotated[str, AfterValidator(valid_split)]
 
 cat_re = re.compile(r"categorical\([1-9][0-9]*\)")
 def valid_task_type(s):
-    if s.startswith("num"): return True
-    if s == "binary": return True
-    if cat_re.fullmatch(s): return True
-    return False
+    if s.startswith("num"): return s
+    if s == "binary": return s
+    if cat_re.fullmatch(s): return s
+    return None
+# TODO: fix this validator to check all types match a pattern
 TypeValue = Annotated[str, AfterValidator(valid_task_type)]
 
 class Task(BaseModel):
-    name: str
-    type: TypeValue
+    name: str           # column name for task
+    type: TypeValue     # type of task
     description: str = ""
 
 class DataDescriptor(BaseModel, extra="ignore"): # or "allow" to keep extra
     name:    str
     smiles:  str
     source:  str
-    split:   Optional[str] = None
-    authors: str = ""
+    split:   Optional[str] = None # column name for split
+    authors: str = ""             # list of authors
     ref:     str = ""
-    graph_tasks: List[Task] = []
+    graph_tasks: List[Task] = []  # list of prediction tasks for a graph
     edge_tasks:  List[Task] = []
     node_tasks:  List[Task] = []
 

--- a/utils/notes.md
+++ b/utils/notes.md
@@ -1,0 +1,10 @@
+
+The "Training" block was moved out of "NeuralNetwork"
+and to the top-level of "Config" 
+
+Moved batch\_size into "Optimizer": 
+
+    ["Training"]["Optimizer"]["batch_size"]
+
+
+

--- a/utils/test.yaml
+++ b/utils/test.yaml
@@ -1,0 +1,23 @@
+name: ""
+authors: ""
+source: http://na
+ref: ""
+
+split:  null # no test/train split column present
+smiles: smiles
+graph_tasks:
+  - name: FDA_APPROVED
+    type: binary
+    description: ""
+  - name: CT_TOX
+    type: binary
+    description: ""
+  - name: Score
+    type: numeric
+    description: ""
+  - name: XYZ
+    type: categorical
+    description: ""
+  - name: ABC
+    type: categorical
+    description: ""

--- a/utils/train.py
+++ b/utils/train.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+
+""" Run HydraGNN's main train/test/validate
+    loop on the given dataset / model combination.
+"""
+import os, json
+import pickle, csv
+
+import logging
+import sys
+from tqdm import tqdm
+
+import mpi4py
+mpi4py.rc.thread_level = "serialized"
+mpi4py.rc.threads = False
+from mpi4py import MPI
+
+from itertools import chain
+import argparse
+import time
+
+import hydragnn
+from hydragnn.utils.print_utils import print_distributed, iterate_tqdm, log
+from hydragnn.utils.time_utils import Timer
+from hydragnn.utils.distdataset import DistDataset
+from hydragnn.utils.pickledataset import SimplePickleWriter, SimplePickleDataset
+from hydragnn.utils.smiles_utils import (
+    get_node_attribute_name,
+    generate_graphdata_from_smilestr,
+)
+from hydragnn.preprocess.utils import gather_deg
+from hydragnn.utils import nsplit
+import hydragnn.utils.tracer as tr
+
+import numpy as np
+
+try:
+    from hydragnn.utils.adiosdataset import AdiosWriter, AdiosDataset
+except ImportError:
+    pass
+
+import torch_geometric.data
+import torch
+import torch.distributed as dist
+
+
+def run():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "--adios",
+        help="Adios dataset",
+        action="store_const",
+        dest="format",
+        const="adios",
+    )
+    group.add_argument(
+        "--pickle",
+        help="Pickle dataset",
+        action="store_const",
+        dest="format",
+        const="pickle",
+    )
+    group.add_argument(
+        "--csv", help="CSV dataset", action="store_const", dest="format", const="csv"
+    )
+    parser.set_defaults(format="adios")
+    """
+    group1 = parser.add_mutually_exclusive_group()
+    group1.add_argument(
+        "--shmem",
+        help="shmem dataset",
+        action="store_const",
+        dest="dataset",
+        const="shmem",
+    )
+    group1.add_argument(
+        "--ddstore",
+        help="ddstore dataset",
+        action="store_const",
+        dest="dataset",
+        const="ddstore",
+    )
+    group1.add_argument(
+        "--simple",
+        help="no special dataset",
+        action="store_const",
+        dest="dataset",
+        const="simple",
+    )
+    parser.set_defaults(dataset="simple")
+    """
+    parser.add_argument("--everyone", action="store_true", help="gptimer")
+    args = parser.parse_args()
+
+
+    tr.initialize()
+    tr.disable()
+    timer = Timer("load_data")
+    timer.start()
+
+    if args.format == "adios":
+        shmem = ddstore = False
+        if args.dataset == "shmem":
+            shmem = True
+            os.environ["HYDRAGNN_AGGR_BACKEND"] = "torch"
+            os.environ["HYDRAGNN_USE_ddstore"] = "0"
+        elif args.dataset == "ddstore":
+            ddstore = True
+            os.environ["HYDRAGNN_AGGR_BACKEND"] = "mpi"
+            os.environ["HYDRAGNN_USE_ddstore"] = "1"
+
+        opt = {"preload": False, "shmem": shmem, "ddstore": ddstore}
+        fname = os.path.join(os.path.dirname(__file__), "dataset", "clintox.bp")
+        trainset = AdiosDataset(fname, "trainset", comm, **opt)
+        valset = AdiosDataset(fname, "valset", comm)
+        testset = AdiosDataset(fname, "testset", comm)
+        comm.Barrier()
+    elif args.format == "pickle":
+        basedir = os.path.join(os.path.dirname(__file__), "dataset", "pickle")
+        trainset = SimplePickleDataset(basedir, "trainset")
+        valset = SimplePickleDataset(basedir, "valset")
+        testset = SimplePickleDataset(basedir, "testset")
+        pna_deg = trainset.pna_deg
+        if args.dataset == "ddstore":
+            opt = {"ddstore_width": args.ddstore_width}
+            trainset = DistDataset(trainset, "trainset", comm, **opt)
+            valset = DistDataset(valset, "valset", comm, **opt)
+            testset = DistDataset(testset, "testset", comm, **opt)
+            trainset.pna_deg = pna_deg
+    else:
+        raise NotImplementedError("No supported format: %s" % (args.format))
+
+    info(
+        "trainset,valset,testset size: %d %d %d"
+        % (len(trainset), len(valset), len(testset))
+    )
+
+    if args.dataset == "ddstore":
+        os.environ["HYDRAGNN_AGGR_BACKEND"] = "mpi"
+        os.environ["HYDRAGNN_USE_ddstore"] = "1"
+
+    (
+        train_loader,
+        val_loader,
+        test_loader,
+    ) = hydragnn.preprocess.create_dataloaders(
+        trainset, valset, testset, config["NeuralNetwork"]["Training"]["batch_size"]
+    )
+    comm.Barrier()
+
+    config = hydragnn.utils.update_config(config, train_loader, val_loader, test_loader)
+    comm.Barrier()
+
+    hydragnn.utils.save_config(config, log_name)
+    comm.Barrier()
+
+    timer.stop()
+
+    model = hydragnn.models.create_model_config(
+        config=config["NeuralNetwork"],
+        verbosity=verbosity,
+    )
+    model = hydragnn.utils.get_distributed_model(model, verbosity)
+
+    learning_rate = config["NeuralNetwork"]["Training"]["Optimizer"]["learning_rate"]
+    optimizer = torch.optim.AdamW(model.parameters(), lr=learning_rate)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, mode="min", factor=0.5, patience=5, min_lr=0.00001
+    )
+
+    hydragnn.utils.load_existing_model_config(
+        model, config["NeuralNetwork"]["Training"], optimizer=optimizer
+    )
+
+    ##################################################################################################################
+
+    hydragnn.train.train_validate_test(
+        model,
+        optimizer,
+        train_loader,
+        val_loader,
+        test_loader,
+        writer,
+        scheduler,
+        config["NeuralNetwork"],
+        log_name,
+        verbosity,
+        create_plots=False,
+    )
+
+    hydragnn.utils.save_model(model, optimizer, log_name)
+    hydragnn.utils.print_timers(verbosity)
+
+    if args.mae:
+        import matplotlib.pyplot as plt
+
+        ##################################################################################################################
+        fig, axs = plt.subplots(1, 3, figsize=(18, 6))
+        for isub, (loader, setname) in enumerate(
+            zip([train_loader, val_loader, test_loader], ["train", "val", "test"])
+        ):
+            error, rmse_task, true_values, predicted_values = hydragnn.train.test(
+                loader, model, verbosity
+            )
+            ihead = 0
+            head_true = np.asarray(true_values[ihead].cpu()).squeeze()
+            head_pred = np.asarray(predicted_values[ihead].cpu()).squeeze()
+            ifeat = var_config["output_index"][ihead]
+            outtype = var_config["type"][ihead]
+            varname = graph_feature_names[ifeat]
+
+            ax = axs[isub]
+            error_mae = np.mean(np.abs(head_pred - head_true))
+            error_rmse = np.sqrt(np.mean(np.abs(head_pred - head_true) ** 2))
+            print(varname, ": ev, mae=", error_mae, ", rmse= ", error_rmse)
+
+            ax.scatter(
+                head_true,
+                head_pred,
+                s=7,
+                linewidth=0.5,
+                edgecolor="b",
+                facecolor="none",
+            )
+            minv = np.minimum(np.amin(head_pred), np.amin(head_true))
+            maxv = np.maximum(np.amax(head_pred), np.amax(head_true))
+            ax.plot([minv, maxv], [minv, maxv], "r--")
+            ax.set_title(setname + "; " + varname + " (eV)", fontsize=16)
+            ax.text(
+                minv + 0.1 * (maxv - minv),
+                maxv - 0.1 * (maxv - minv),
+                "MAE: {:.2f}".format(error_mae),
+            )
+        if rank == 0:
+            fig.savefig(os.path.join("logs", log_name, varname + "_all.png"))
+        plt.close()
+
+    if tr.has("GPTLTracer"):
+        import gptl4py as gp
+
+        eligible = rank if args.everyone else 0
+        if rank == eligible:
+            gp.pr_file(os.path.join("logs", log_name, "gp_timing.p%d" % rank))
+        gp.pr_summary_file(os.path.join("logs", log_name, "gp_timing.summary"))
+        gp.finalize()

--- a/utils/yaml_to_config.py
+++ b/utils/yaml_to_config.py
@@ -3,12 +3,11 @@
 import json
 import yaml
 
-from hydragnn.utils.smiles_utils import (
-    get_node_attribute_name,
-)
-
-node_types = {"C": 0, "F": 1, "H": 2, "N": 3, "O": 4, "S": 5, "Hg": 6, "Cl": 7}
-
+# TODO: create a pydantic.BaseModel to validate the config object
+# TODO: add a version number to the config (and/or redo all configs...)
+#
+# TODO: refactor edge_features, task_weights, and Variables_of_interest
+# TODO: change "output_heads" to be a list.
 config = {
   "Verbosity": {
     "level": 2
@@ -114,10 +113,6 @@ def main(argv):
 
     var_config = config["NeuralNetwork"]["Variables_of_interest"]
 
-    (
-        var_config["input_node_feature_names"],
-        var_config["input_node_feature_dims"],
-    ) = get_node_attribute_name(node_types)
     var_config["node_feature_dims"] = var_config["input_node_feature_dims"]
     ninp = len(var_config["node_feature_dims"])
     var_config["input_node_features"] = list(range(ninp))

--- a/utils/yaml_to_config.py
+++ b/utils/yaml_to_config.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+
+import json
+import yaml
+
+config = {
+  "Verbosity": {
+    "level": 2
+  },
+  "NeuralNetwork": {
+    "Architecture": {
+      "edge_features": ["aromatic", "single", "double", "triple"],
+      "model_type": "PNA",
+      "max_neighbours": 20,
+      "hidden_dim": 200,
+      "num_conv_layers": 4,
+      "output_heads": {
+        "graph": {
+          "num_sharedlayers": 1,
+          "dim_sharedlayers": 200,
+          "num_headlayers": 2,
+          "dim_headlayers": [
+            200,
+            200
+          ]
+        }
+      },
+      "task_weights": [
+        1
+      ]
+    },
+    "Variables_of_interest": {
+      "input_node_feature_names": ["Z", "x"],
+      "input_node_feature_dims": [1, 3],
+      "input_node_features": [0, 1],
+      "denormalize_output": False
+    },
+    "Training": {
+      "num_epoch": 10,
+      "batch_size": 128,
+      "continue": 0,
+      "startfrom": "existing_model",
+      "Optimizer": {
+        "learning_rate": 0.001
+      }
+    }
+  }
+}
+
+def main(argv):
+    assert len(argv) == 3, f"Usage: {argv[0]} <in.yaml> <out.json>"
+    inp = argv[1]
+    out = argv[2]
+
+    graph_feature_names = ["CT_TOX"]
+    graph_feature_dim = [1]
+
+    with open(inp, "r", encoding="utf-8") as f:
+        descr = yaml.safe_load(f)
+
+    var_config = config["NeuralNetwork"]["Variables_of_interest"]
+    var_config["output_index"] = [ 0 ]
+    var_config["type"] = [ "graph" ]
+    var_config["output_names"] = [
+        graph_feature_names[item]
+        for ihead, item in enumerate(var_config["output_index"])
+    ]
+    var_config["graph_feature_names"] = graph_feature_names
+    var_config["graph_feature_dims"] = graph_feature_dim
+
+    with open(out, "w", encoding="utf-8") as f:
+        f.write(json.dumps(config, indent=2))
+
+if __name__=="__main__":
+    import sys
+    main(sys.argv)


### PR DESCRIPTION
This pull request adds position data to the molecular dataset stored in ADIOS format. The new implementation includes:

	•	Position data integration: Position (x, y, z) coordinates for each atom in the molecular dataset are now included.
	•	Backward compatibility: Ensured that datasets without position data can still be read without errors.

I checked that the positions were added to the ADIOS files with `bpls -a data.bp`: 
```
 int64_t  testset/ndata                        attr
  float    testset/pos                          {7198, 3}
  int64_t  testset/pos/variable_count           {146}
  int64_t  testset/pos/variable_dim             attr
  int64_t  testset/pos/variable_offset          {146}
  float    testset/x                            {7198, 6}
  int64_t  testset/x/variable_count             {146}
  int64_t  testset/x/variable_dim               attr
  int64_t  testset/x/variable_offset            {146}
  double   testset/y                            {292}
```


