### PR TITLE
added positions for csv-to-adios pipeline

### DIFF
--- a/utils/import_csv.py
+++ b/utils/import_csv.py
@@ -199,7 +199,7 @@ def main():
         ## local portion
         _smileset = smileset[rx.start : rx.stop]
         _valueset = valueset[rx.start : rx.stop]
-
+        missed_count = 0
         for smilestr, ytarget in tqdm(
             zip(_smileset, _valueset),
             disable=rank != 0,
@@ -208,7 +208,7 @@ def main():
         ):
             try:
                 data = generate_graphdata_from_smilestr(
-                    smilestr, ytarget
+                    smilestr, ytarget, get_positions=True
                 )
                 # TODO: ensure data.pos is populated (e.g. call rdkit)
                 # TODO: should we energy minimize these coordinates
@@ -220,7 +220,8 @@ def main():
                     f"Exception in call to generate_graphdata_from_smilestr."
                     f" {e} for {smilestr}. Ignoring molecule and proceeding .."
                 )
-
+                missed_count += 1
+    print(f'missed {missed_count} molecules')
     # pre-compute PNA degrees
     pna_deg = gather_deg(dataset["trainset"])
     # this is stored with the trainset in pickle format
@@ -231,7 +232,6 @@ def main():
     node_names = [x.replace("atomicnumber", "atomic_number") for x in node_names]
     edge_names, edge_dims = get_edge_attribute_name()
     task_dims = [1]*len(task_names)
-
     attrs = {
         "x_name": node_names,
         "x_name/feature_count": np.array(node_dims),


### PR DESCRIPTION
This pr adds a couple of lines to `hydragnn/utils/smiles_utils.py` and `utils/import_csv.py` to add molecular positions to the csv file. Here is how the data look using `bpls -a data.bp`. 

```
float    testset/pos                          {6741, 3}
  int64_t  testset/pos/variable_count           {147}
  int64_t  testset/pos/variable_dim             attr
  int64_t  testset/pos/variable_offset          {147}
  float    testset/x                            {6741, 6}
  int64_t  testset/x/variable_count             {147}
  int64_t  testset/x/variable_dim               attr
  int64_t  testset/x/variable_offset            {147}
  double   testset/y                            {294}
```
