### PR TITLE
Fixing PBC conv_args (draft)

### DIFF
--- a/hydragnn/models/DIMEStack.py
+++ b/hydragnn/models/DIMEStack.py
@@ -25,6 +25,10 @@ from torch_geometric.nn.models.dimenet import (
 )
 from torch_geometric.utils import scatter
 
+from hydragnn.utils.model import (
+    get_edge_vectors_and_lengths,
+    get_pbc_edge_vectors_and_lengths,
+)
 from .Base import Base
 
 
@@ -136,18 +140,46 @@ class DIMEStack(Base):
         assert (
             data.pos is not None
         ), "DimeNet requires node positions (data.pos) to be set."
+
+        # Extract indices for triplets
         i, j, idx_i, idx_j, idx_k, idx_kj, idx_ji = triplets(
             data.edge_index, num_nodes=data.x.size(0)
         )
-        dist = (data.pos[i] - data.pos[j]).pow(2).sum(dim=-1).sqrt()
 
-        # Calculate angles.
-        pos_i = data.pos[idx_i]
-        pos_ji, pos_ki = data.pos[idx_j] - pos_i, data.pos[idx_k] - pos_i
+        # Compute vectors and lengths
+        if (
+            hasattr(data, "supercell_size") and data.supercell_size is not None
+        ):  # PBC Case
+            _, dist = get_pbc_edge_vectors_and_lengths(
+                data.pos, data.edge_index, data.supercell_size, data.batch
+            )  # Shape: (n_edges, 1)
+            pos_ji, _ = get_pbc_edge_vectors_and_lengths(
+                data.pos,
+                torch.cat([idx_i.unsqueeze(0), idx_j.unsqueeze(0)], dim=0),
+                data.supercell_size,
+                data.batch,
+            )  # i->j vector
+            pos_kj, _ = get_pbc_edge_vectors_and_lengths(
+                data.pos,
+                torch.cat([idx_j.unsqueeze(0), idx_k.unsqueeze(0)], dim=0),
+                data.supercell_size,
+                data.batch,
+            )  # j->k vector
+            pos_ki = pos_kj - pos_ji  # i->k vector (this must be done carefully in pbc)
+        else:
+            dist = torch.linalg.norm(
+                data.pos[i] - data.pos[j], dim=-1, keepdim=True
+            )  # Shape: (n_edges, 1)
+            pos_ji = data.pos[idx_j] - data.pos[idx_i]  # i->j vector
+            pos_ki = data.pos[idx_k] - data.pos[idx_i]  # i->k vector
+
+        # Compute angles using adjusted vectors
         a = (pos_ji * pos_ki).sum(dim=-1)
         b = torch.cross(pos_ji, pos_ki).norm(dim=-1)
         angle = torch.atan2(b, a)
 
+        # Compute radial and spherical basis functions
+        dist = dist.squeeze()
         rbf = self.rbf(dist)
         sbf = self.sbf(dist, angle, idx_kj)
 

--- a/hydragnn/utils/model/__init__.py
+++ b/hydragnn/utils/model/__init__.py
@@ -10,3 +10,7 @@ from .model import (
     EarlyStopping,
     print_model,
 )
+from .operations import (
+    get_edge_vectors_and_lengths,
+    get_pbc_edge_vectors_and_lengths,
+)

--- a/hydragnn/utils/model/operations.py
+++ b/hydragnn/utils/model/operations.py
@@ -8,7 +8,7 @@
 #                                                                            #
 # SPDX-License-Identifier: BSD-3-Clause                                      #
 ##############################################################################
-from typing import List, Tuple
+from typing import List, Tuple, Optional
 import numpy as np
 import torch
 
@@ -20,14 +20,102 @@ import torch
 def get_edge_vectors_and_lengths(
     positions: torch.Tensor,  # [n_nodes, 3]
     edge_index: torch.Tensor,  # [2, n_edges]
-    shifts: torch.Tensor,  # [n_edges, 3]
+    shifts: Optional[torch.Tensor] = None,  # [n_edges, 3], optional
     normalize: bool = False,
     eps: float = 1e-9,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     sender = edge_index[0]
     receiver = edge_index[1]
+
+    # If shifts is None, set it to a zero tensor of the appropriate shape
+    if shifts is None:
+        shifts = torch.zeros_like(positions[receiver] - positions[sender])
+
     vectors = positions[receiver] - positions[sender] + shifts  # [n_edges, 3]
     lengths = torch.linalg.norm(vectors, dim=-1, keepdim=True)  # [n_edges, 1]
+
+    if normalize:
+        vectors_normed = vectors / (lengths + eps)
+        return vectors_normed, lengths
+
+    return vectors, lengths
+
+
+def get_pbc_edge_vectors_and_lengths(
+    positions: torch.Tensor,  # [n_nodes, 3]
+    edge_index: torch.Tensor,  # [2, n_edges]
+    supercell_size: torch.Tensor,  # [n_graphs*3, 3], supercell matrices per graph
+    batch: torch.Tensor,  # [n_nodes], node-to-graph assignment
+    shifts: Optional[torch.Tensor] = None,  # [n_edges, 3], optional
+    normalize: bool = False,
+    eps: float = 1e-9,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """
+    Compute distance vectors between nodes, adjusting for periodic boundary conditions (PBC),
+    when each graph in a batch has its own supercell matrix.
+
+    Parameters:
+    - positions: Tensor of shape [n_nodes, 3], node positions.
+    - edge_index: Tensor of shape [2, n_edges], edge indices.
+    - supercell_size: Tensor of shape [n_graphs, 3, 3], supercell matrices per graph.
+    - batch: Tensor of shape [n_nodes], node-to-graph assignment.
+    - shifts: Optional tensor of shape [n_edges, 3], shifts to apply to the vectors.
+    - normalize: Whether to normalize the distance vectors.
+    - eps: Small value to prevent division by zero in normalization.
+
+    Returns:
+    - vectors: Tensor of shape [n_edges, 3], adjusted for PBCs.
+    - lengths: Tensor of shape [n_edges, 1], containing the lengths of the distance vectors.
+    """
+
+    # Validate and process supercell_size
+    if supercell_size is None:
+        raise ValueError("Supercell size must be provided.")
+
+    n_graphs = batch.max().item() + 1
+    expected_shape = (n_graphs * 3, 3)
+    if supercell_size.shape != expected_shape:
+        raise ValueError(
+            f"Expected supercell_size to have shape {expected_shape}, but got {supercell_size.shape}"
+        )
+
+    # Reshape supercell_size from [n_graphs*3, 3] to [n_graphs, 3, 3]
+    supercell_size = supercell_size.view(n_graphs, 3, 3)  # Shape: [n_graphs, 3, 3]
+    # Extract cell sizes along each dimension (diagonal elements)
+    supercell_size = torch.diagonal(
+        supercell_size, dim1=1, dim2=2
+    )  # Shape: [n_graphs, 3]
+
+    # Ensure tensors are on the same device
+    positions = positions.to(edge_index.device)
+    supercell_size = supercell_size.to(positions.device)
+    batch = batch.to(positions.device)
+
+    # Setup Data
+    sender = edge_index[0]  # Indices of source nodes
+    receiver = edge_index[1]  # Indices of target nodes
+    vectors = positions[receiver] - positions[sender]  # Shape: (n_edges, 3)
+    # Get the graph assignments for each edge based on sender nodes
+    edge_batch = batch[
+        sender
+    ]  # Shape: (n_edges,)   # This is very important to use the correct pbc matrix for each edge!
+    supercell_per_edge = supercell_size[edge_batch]  # Shape: (n_edges, 3, 3)
+    half_sizes = supercell_per_edge / 2  # Shape: (n_edges, 3)
+
+    # Apply PBCs
+    for dim in range(3):
+        dim_size = supercell_per_edge[:, dim]
+        over_half = vectors[:, dim] > half_sizes[:, dim]
+        under_half = vectors[:, dim] < -half_sizes[:, dim]
+        vectors[over_half, dim] -= dim_size[over_half]
+        vectors[under_half, dim] += dim_size[under_half]
+
+    # Apply shifts if provided
+    if shifts is not None:
+        vectors = vectors + shifts  # Shape: (n_edges, 3)
+
+    lengths = torch.linalg.norm(vectors, dim=-1, keepdim=True)  # Shape: (n_edges, 1)
+
     if normalize:
         vectors_normed = vectors / (lengths + eps)
         return vectors_normed, lengths


### PR DESCRIPTION
This PR aims to address the issue related to generating conv_args that are in-line with periodic boundary conditions.

The following implementation should be robust under the following assumptions, which I think should always be true:
(1) radius < min(supercell_size) / 2
(2) The edge_index has been generated correctly with periodic boundary conditions
(3) data.supercell_size exists if and only if pbc conditions are used

Currently, only two models are updated to use the new functionality. If this is a good solution, it can be easily extended to the others.