### PR TITLE
Fix pbc conv args (secondary method to compare) (draft)

### DIFF
--- a/hydragnn/models/PNAPlusStack.py
+++ b/hydragnn/models/PNAPlusStack.py
@@ -101,9 +101,7 @@ class PNAPlusStack(Base):
             data.pos is not None
         ), "PNA+ requires node positions (data.pos) to be set."
 
-        j, i = data.edge_index  # j->i
-        dist = (data.pos[i] - data.pos[j]).pow(2).sum(dim=-1).sqrt()
-        rbf = self.rbf(dist)
+        rbf = self.rbf(data.edge_dist)
         # rbf = dist.unsqueeze(-1)
         conv_args = {"edge_index": data.edge_index.to(torch.long), "rbf": rbf}
 

--- a/hydragnn/preprocess/serialized_dataset_loader.py
+++ b/hydragnn/preprocess/serialized_dataset_loader.py
@@ -124,12 +124,13 @@ class SerializedDataLoader:
         if self.rotational_invariance:
             dataset[:] = [rotational_invariance(data) for data in dataset]
 
-        if self.periodic_boundary_conditions:
+        if self.periodic_boundary_conditions or any(self.periodic_boundary_conditions):
             # edge lengths already added manually if using PBC, so no need to call Distance.
             compute_edges = get_radius_graph_pbc(
                 radius=self.radius,
                 loop=False,
                 max_neighbours=self.max_neighbours,
+                pbc=self.periodic_boundary_conditions,
             )
         else:
             compute_edges = get_radius_graph(

--- a/hydragnn/utils/datasets/abstractrawdataset.py
+++ b/hydragnn/utils/datasets/abstractrawdataset.py
@@ -338,12 +338,13 @@ class AbstractRawDataset(AbstractBaseDataset, ABC):
         if self.rotational_invariance:
             self.dataset[:] = [rotational_invariance(data) for data in self.dataset]
 
-        if self.periodic_boundary_conditions:
+        if self.periodic_boundary_conditions or any(self.periodic_boundary_conditions):
             # edge lengths already added manually if using PBC, so no need to call Distance.
             compute_edges = get_radius_graph_pbc(
                 radius=self.radius,
                 loop=False,
                 max_neighbours=self.max_neighbours,
+                pbc=self.periodic_boundary_conditions,
             )
         else:
             compute_edges = get_radius_graph(


### PR DESCRIPTION
Draft for a different method to properly get vectors and differences with pbc conditions.

Main Takeaways:
(1) There is a way to pass the different dimensions for pbc as a list, such as `[True, False, True]`
(2) ASE is able to pass pbc-consistent edge vectors easily, without us having to worry about the details.

Questions/Problems:
(1) Is it a requirement of HYDRA that we pass the data through the radius_graph? If not, this would be a problem, because the `edge_vec` will not be created and will be missing when called by a model stack.