### PR TITLE
Light refactor to improve development

### DIFF
--- a/hydragnn/models/GINStack.py
+++ b/hydragnn/models/GINStack.py
@@ -33,14 +33,14 @@ class GINStack(Base):
             train_eps=True,
         )
 
-        input_args = "x, pos, edge_index"
-        conv_args = "x, edge_index"
-
         return Sequential(
-            input_args,
+            self.input_args,
             [
-                (gin, conv_args + " -> x"),
-                (lambda x, pos: [x, pos], "x, pos -> x, pos"),
+                (gin, self.conv_args + " -> inv_node_feat"),
+                (
+                    lambda x, equiv_node_feat: [x, equiv_node_feat],
+                    "inv_node_feat, equiv_node_feat -> inv_node_feat, equiv_node_feat",
+                ),
             ],
         )
 

--- a/hydragnn/models/MACEStack.py
+++ b/hydragnn/models/MACEStack.py
@@ -403,7 +403,9 @@ class MACEStack(Base):
                     equiv_node_feat=equiv_node_feat,
                     **conv_args,
                 )
-                output = readout(data, inv_node_feat)  # [index][n_output, size_output]
+                output = readout(
+                    data, torch.cat([inv_node_feat, equiv_node_feat], dim=1)
+                )  # [index][n_output, size_output]
             else:
                 inv_node_feat, equiv_node_feat = checkpoint(
                     conv,
@@ -413,7 +415,7 @@ class MACEStack(Base):
                     **conv_args,
                 )
                 output = readout(
-                    data, inv_node_feat
+                    data, torch.cat([inv_node_feat, equiv_node_feat], dim=1)
                 )  # output is a list of tensors with [index][n_output, size_output]
             # Sum predictions for each index, taking care of size differences
             for idx, prediction in enumerate(output):

--- a/hydragnn/models/MFCStack.py
+++ b/hydragnn/models/MFCStack.py
@@ -21,13 +21,15 @@ from .Base import Base
 class MFCStack(Base):
     def __init__(
         self,
+        input_args,
+        conv_args,
         max_degree: int,
         *args,
         **kwargs,
     ):
         self.max_degree = max_degree
 
-        super().__init__(*args, **kwargs)
+        super().__init__(input_args, conv_args, *args, **kwargs)
 
     def get_conv(self, input_dim, output_dim):
         mfc = MFConv(
@@ -36,14 +38,14 @@ class MFCStack(Base):
             max_degree=self.max_degree,
         )
 
-        input_args = "x, pos, edge_index"
-        conv_args = "x, edge_index"
-
         return Sequential(
-            input_args,
+            self.input_args,
             [
-                (mfc, conv_args + " -> x"),
-                (lambda x, pos: [x, pos], "x, pos -> x, pos"),
+                (mfc, self.conv_args + " -> inv_node_feat"),
+                (
+                    lambda x, pos: [x, pos],
+                    "inv_node_feat, equiv_node_feat -> inv_node_feat, equiv_node_feat",
+                ),
             ],
         )
 

--- a/hydragnn/models/PAINNStack.py
+++ b/hydragnn/models/PAINNStack.py
@@ -31,6 +31,8 @@ class PAINNStack(Base):
     def __init__(
         self,
         # edge_dim: int,   # To-Do: Add edge_features
+        input_args,
+        conv_args,
         num_radial: int,
         radius: float,
         *args,
@@ -40,13 +42,11 @@ class PAINNStack(Base):
         self.num_radial = num_radial
         self.radius = radius
 
-        super().__init__(*args, **kwargs)
+        super().__init__(input_args, conv_args, *args, **kwargs)
 
     def _init_conv(self):
         last_layer = 1 == self.num_conv_layers
-        self.graph_convs.append(
-            self.get_conv(self.input_dim, self.hidden_dim, last_layer)
-        )
+        self.graph_convs.append(self.get_conv(self.input_dim, self.hidden_dim))
         self.feature_layers.append(nn.Identity())
         for i in range(self.num_conv_layers - 1):
             last_layer = i == self.num_conv_layers - 2
@@ -59,13 +59,14 @@ class PAINNStack(Base):
         assert (
             hidden_dim > 1
         ), "PainnNet requires more than one hidden dimension between input_dim and output_dim."
+        print("hidden_dim", input_dim)
         self_inter = PainnMessage(
             node_size=input_dim, edge_size=self.num_radial, cutoff=self.radius
         )
         cross_inter = PainnUpdate(node_size=input_dim, last_layer=last_layer)
         """
-        The following linear layers are to get the correct sizing of embeddings. This is 
-        necessary to use the hidden_dim, output_dim of HYDRAGNN's stacked conv layers correctly 
+        The following linear layers are to get the correct sizing of embeddings. This is
+        necessary to use the hidden_dim, output_dim of HYDRAGNN's stacked conv layers correctly
         because node_scalar and node-vector are updated through a sum.
         """
         node_embed_out = nn.Sequential(
@@ -77,82 +78,54 @@ class PAINNStack(Base):
 
         if not last_layer:
             return geom_nn.Sequential(
-                "x, v, pos, edge_index, diff, dist",
+                self.input_args,
                 [
-                    (self_inter, "x, v, edge_index, diff, dist -> x, v"),
-                    (cross_inter, "x, v -> x, v"),
-                    (node_embed_out, "x -> x"),
-                    (vec_embed_out, "v -> v"),
-                    (lambda x, v, pos: [x, v, pos], "x, v, pos -> x, v, pos"),
+                    (
+                        self_inter,
+                        "inv_node_feat, equiv_node_feat, edge_index, diff, dist -> inv_node_feat, equiv_node_feat",
+                    ),
+                    (
+                        cross_inter,
+                        "inv_node_feat, equiv_node_feat -> inv_node_feat, equiv_node_feat",
+                    ),
+                    (node_embed_out, "inv_node_feat -> inv_node_feat"),
+                    (vec_embed_out, "equiv_node_feat -> equiv_node_feat"),
+                    (
+                        lambda inv_node_feat, equiv_node_feat: [
+                            inv_node_feat,
+                            equiv_node_feat,
+                        ],
+                        "inv_node_feat, equiv_node_feat -> inv_node_feat, equiv_node_feat",
+                    ),
                 ],
             )
         else:
             return geom_nn.Sequential(
-                "x, v, pos, edge_index, diff, dist",
+                self.input_args,
                 [
-                    (self_inter, "x, v, edge_index, diff, dist -> x, v"),
+                    (
+                        self_inter,
+                        "inv_node_feat, equiv_node_feat, edge_index, diff, dist -> inv_node_feat, equiv_node_feat",
+                    ),
                     (
                         cross_inter,
-                        "x, v -> x",
+                        "inv_node_feat, equiv_node_feat -> inv_node_feat",
                     ),  # v is not updated in the last layer to avoid hanging gradients
                     (
                         node_embed_out,
-                        "x -> x",
+                        "inv_node_feat -> inv_node_feat",
                     ),  # No need to embed down v because it's not used anymore
-                    (lambda x, v, pos: [x, v, pos], "x, v, pos -> x, v, pos"),
+                    (
+                        lambda inv_node_feat, equiv_node_feat: [
+                            inv_node_feat,
+                            equiv_node_feat,
+                        ],
+                        "inv_node_feat, equiv_node_feat -> inv_node_feat, equiv_node_feat",
+                    ),
                 ],
             )
 
-    def forward(self, data):
-        data, conv_args = self._conv_args(
-            data
-        )  # Added v to data here (necessary for PAINN Stack)
-        x = data.x
-        v = data.v
-        pos = data.pos
-
-        ### encoder part ####
-        for conv, feat_layer in zip(self.graph_convs, self.feature_layers):
-            if not self.conv_checkpointing:
-                c, v, pos = conv(x=x, v=v, pos=pos, **conv_args)  # Added v here
-            else:
-                c, v, pos = checkpoint(  # Added v here
-                    conv, use_reentrant=False, x=x, v=v, pos=pos, **conv_args
-                )
-            x = self.activation_function(feat_layer(c))
-
-        #### multi-head decoder part####
-        # shared dense layers for graph level output
-        if data.batch is None:
-            x_graph = x.mean(dim=0, keepdim=True)
-        else:
-            x_graph = geom_nn.global_mean_pool(x, data.batch.to(x.device))
-        outputs = []
-        outputs_var = []
-        for head_dim, headloc, type_head in zip(
-            self.head_dims, self.heads_NN, self.head_type
-        ):
-            if type_head == "graph":
-                x_graph_head = self.graph_shared(x_graph)
-                output_head = headloc(x_graph_head)
-                outputs.append(output_head[:, :head_dim])
-                outputs_var.append(output_head[:, head_dim:] ** 2)
-            else:
-                if self.node_NN_type == "conv":
-                    for conv, batch_norm in zip(headloc[0::2], headloc[1::2]):
-                        c, v, pos = conv(x=x, v=v, pos=pos, **conv_args)
-                        c = batch_norm(c)
-                        x = self.activation_function(c)
-                    x_node = x
-                else:
-                    x_node = headloc(x=x, batch=data.batch)
-                outputs.append(x_node[:, :head_dim])
-                outputs_var.append(x_node[:, head_dim:] ** 2)
-        if self.var_output:
-            return outputs, outputs_var
-        return outputs
-
-    def _conv_args(self, data):
+    def _embedding(self, data):
         assert (
             data.pos is not None
         ), "PAINNNet requires node positions (data.pos) to be set."
@@ -173,7 +146,7 @@ class PAINNStack(Base):
             "dist": dist,
         }
 
-        return data, conv_args
+        return data.x, data.v, conv_args
 
 
 class PainnMessage(nn.Module):
@@ -211,6 +184,8 @@ class PainnMessage(nn.Module):
             dim=1,
         )
 
+        print(node_vector[edge[:, 1]].shape)
+        print(gate_state_vector.shape)
         # num_pairs * 3 * node_size, num_pairs * node_size
         message_vector = node_vector[edge[:, 1]] * gate_state_vector.unsqueeze(1)
         edge_vector = gate_edge_vector.unsqueeze(1) * (

--- a/hydragnn/models/PAINNStack.py
+++ b/hydragnn/models/PAINNStack.py
@@ -59,7 +59,6 @@ class PAINNStack(Base):
         assert (
             hidden_dim > 1
         ), "PainnNet requires more than one hidden dimension between input_dim and output_dim."
-        print("hidden_dim", input_dim)
         self_inter = PainnMessage(
             node_size=input_dim, edge_size=self.num_radial, cutoff=self.radius
         )
@@ -184,8 +183,6 @@ class PainnMessage(nn.Module):
             dim=1,
         )
 
-        print(node_vector[edge[:, 1]].shape)
-        print(gate_state_vector.shape)
         # num_pairs * 3 * node_size, num_pairs * node_size
         message_vector = node_vector[edge[:, 1]] * gate_state_vector.unsqueeze(1)
         edge_vector = gate_edge_vector.unsqueeze(1) * (

--- a/hydragnn/models/SAGEStack.py
+++ b/hydragnn/models/SAGEStack.py
@@ -28,14 +28,17 @@ class SAGEStack(Base):
             out_channels=output_dim,
         )
 
-        input_args = "x, pos, edge_index"
-        conv_args = "x, edge_index"
-
         return Sequential(
-            input_args,
+            self.input_args,
             [
-                (sage, conv_args + " -> x"),
-                (lambda x, pos: [x, pos], "x, pos -> x, pos"),
+                (sage, self.conv_args + " -> inv_node_feat"),
+                (
+                    lambda inv_node_feat, equiv_node_feat: [
+                        inv_node_feat,
+                        equiv_node_feat,
+                    ],
+                    "inv_node_feat, equiv_node_feat -> inv_node_feat, equiv_node_feat",
+                ),
             ],
         )
 

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -127,6 +127,8 @@ def create_model(
     # Note: model-specific inputs must come first.
     if model_type == "GIN":
         model = GINStack(
+            "inv_node_feat, equiv_node_feat, edge_index",
+            "inv_node_feat, edge_index",
             input_dim,
             hidden_dim,
             output_dim,
@@ -145,6 +147,8 @@ def create_model(
     elif model_type == "PNA":
         assert pna_deg is not None, "PNA requires degree input."
         model = PNAStack(
+            "inv_node_feat, equiv_node_feat, edge_index",
+            "inv_node_feat, edge_index",
             pna_deg,
             edge_dim,
             input_dim,
@@ -170,6 +174,8 @@ def create_model(
         assert num_radial is not None, "PNAPlus requires num_radial input."
         assert radius is not None, "PNAPlus requires radius input."
         model = PNAPlusStack(
+            "inv_node_feat, equiv_node_feat, edge_index, rbf",
+            "inv_node_feat, edge_index, rbf",
             pna_deg,
             edge_dim,
             envelope_exponent,
@@ -195,6 +201,8 @@ def create_model(
         heads = 6
         negative_slope = 0.05
         model = GATStack(
+            "inv_node_feat, equiv_node_feat, edge_index",
+            "inv_node_feat, edge_index",
             heads,
             negative_slope,
             input_dim,
@@ -215,6 +223,8 @@ def create_model(
     elif model_type == "MFC":
         assert max_neighbours is not None, "MFC requires max_neighbours input."
         model = MFCStack(
+            "inv_node_feat, equiv_node_feat, edge_index",
+            "inv_node_feat, edge_index",
             max_neighbours,
             input_dim,
             hidden_dim,
@@ -233,6 +243,8 @@ def create_model(
 
     elif model_type == "CGCNN":
         model = CGCNNStack(
+            "inv_node_feat, equiv_node_feat, edge_index",  # input_args
+            "inv_node_feat, edge_index",  # conv_args
             edge_dim,
             input_dim,
             output_dim,
@@ -250,6 +262,8 @@ def create_model(
 
     elif model_type == "SAGE":
         model = SAGEStack(
+            "inv_node_feat, equiv_node_feat, edge_index",  # input_args
+            "inv_node_feat, edge_index",  # conv_args
             input_dim,
             hidden_dim,
             output_dim,
@@ -269,6 +283,8 @@ def create_model(
         assert num_filters is not None, "SchNet requires num_filters input."
         assert radius is not None, "SchNet requires radius input."
         model = SCFStack(
+            "inv_node_feat, equiv_node_feat, batch",
+            "inv_node_feat, equiv_node_feat, edge_index, edge_weight, edge_attr",
             num_gaussians,
             num_filters,
             radius,
@@ -301,6 +317,8 @@ def create_model(
         assert num_spherical is not None, "DimeNet requires num_spherical input."
         assert radius is not None, "DimeNet requires radius input."
         model = DIMEStack(
+            "inv_node_feat, equiv_node_feat, rbf, sbf, i, j, idx_kj, idx_ji",  # input_args
+            "",  # conv_args
             basis_emb_size,
             envelope_exponent,
             int_emb_size,
@@ -329,6 +347,8 @@ def create_model(
 
     elif model_type == "EGNN":
         model = EGCLStack(
+            "inv_node_feat, equiv_node_feat, edge_index, edge_attr",  # input_args
+            "",  # conv_args
             edge_dim,
             input_dim,
             hidden_dim,
@@ -349,6 +369,8 @@ def create_model(
     elif model_type == "PAINN":
         model = PAINNStack(
             # edge_dim,   # To-do add edge_features
+            "inv_node_feat, equiv_node_feat, edge_index, diff, dist",
+            "",
             num_radial,
             radius,
             input_dim,
@@ -368,6 +390,8 @@ def create_model(
     elif model_type == "PNAEq":
         assert pna_deg is not None, "PNAEq requires degree input."
         model = PNAEqStack(
+            "inv_node_feat, equiv_node_feat, edge_index, edge_rbf, edge_vec",
+            "inv_node_feat, equiv_node_feat, edge_index, edge_rbf, edge_vec",
             pna_deg,
             edge_dim,
             num_radial,
@@ -394,6 +418,8 @@ def create_model(
         assert max_ell >= 1, "MACE requires max_ell >= 1."
         assert node_max_ell >= 1, "MACE requires node_max_ell >= 1."
         model = MACEStack(
+            "node_attributes, equiv_node_feat, inv_node_feat, edge_attributes, edge_features, edge_index",
+            "node_attributes, edge_attributes, edge_features, edge_index",
             radius,
             radial_type,
             distance_transform,


### PR DESCRIPTION
PR aimed at improving signatures and variable names to enhance model development.

- Signature change: `Base.__init__(input_args, conv_args, ...)` requires arguments to be specified in the input to the base class. This enables better wrapper development by instantiating `self.input_args, self.conv_args` among all classes inheriting from `Base`. [1](https://github.com/ORNL/HydraGNN/compare/main...JustinBakerMath:HydraGNN:main?expand=1#diff-70520dd20f8abb34415c44a777926e4ab8f6239be3e6ba9ac7fa3036d2e2baf5R30-R31) 
- Note: this will automatically handle `edge_attr` adding to the arguments if `use_edge_attr` is true [2](https://github.com/ORNL/HydraGNN/compare/main...JustinBakerMath:HydraGNN:main?expand=1#diff-70520dd20f8abb34415c44a777926e4ab8f6239be3e6ba9ac7fa3036d2e2baf5R111-R114).
- Function change: `_conv_args` has been changed to `_embedding` to handle embedding of equivariant information. This is inline with the recent changes in `PAINN` and fits closely to the actual operations of this function. [3](https://github.com/ORNL/HydraGNN/compare/main...JustinBakerMath:HydraGNN:main?expand=1#diff-70520dd20f8abb34415c44a777926e4ab8f6239be3e6ba9ac7fa3036d2e2baf5R138)
- Variable change: `x, pos` to `inv_node_feat, equiv_node_feat`. The original architectures treated `x` as invariant information and `pos` as equivariant information. To improve the transparency of these variable names they have been adjusted. [4](https://github.com/ORNL/HydraGNN/compare/main...JustinBakerMath:HydraGNN:main?expand=1#diff-70520dd20f8abb34415c44a777926e4ab8f6239be3e6ba9ac7fa3036d2e2baf5R51-R52)
- Note: as a consequence, many architectures can be abstracted to `Base` e.g. `PAINN` and `PNAEq` now share the same forward call as `Base`. [5](https://github.com/ORNL/HydraGNN/compare/main...JustinBakerMath:HydraGNN:main?expand=1#diff-3431cfb9cf343c4d9db5526a35aab36edc1cabba9c63255508f15b027627f998L106-L155)