### PR TITLE
Reformatting MACE

### DIFF
--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -20,6 +20,7 @@ from hydragnn.utils.model import activation_function_selection, loss_function_se
 import sys
 from hydragnn.utils.distributed import get_device
 from hydragnn.utils.print.print_utils import print_master
+from hydragnn.utils.model.operations import get_edge_vectors_and_lengths
 
 import inspect
 
@@ -136,6 +137,10 @@ class Base(Module):
             self.feature_layers.append(BatchNorm(self.hidden_dim))
 
     def _embedding(self, data):
+        if not hasattr(data, "edge_shifts"):
+            data.edge_shifts = torch.zeros(
+                (data.edge_index.size(1), 3), device=data.edge_index.device
+            )
         conv_args = {"edge_index": data.edge_index.to(torch.long)}
         if self.use_edge_attr:
             assert (

--- a/hydragnn/models/MACEStack.py
+++ b/hydragnn/models/MACEStack.py
@@ -322,7 +322,7 @@ class MACEStack(Base):
         prod = EquivariantProductBasisBlock(
             node_feats_irreps=interaction_irreps,
             target_irreps=hidden_irreps,
-            correlation=self.correlation[0],
+            correlation=self.correlation[0],  # Currently uniform across all layers
             num_elements=self.num_elements,
             use_sc=use_sc,
         )

--- a/hydragnn/models/MACEStack.py
+++ b/hydragnn/models/MACEStack.py
@@ -402,8 +402,12 @@ class MACEStack(Base):
         # initialize the spherical harmonics, since the initial spherical harmonic projection
         # uses the nodal position vector  x/||x|| as the input to the spherical harmonics.
         # If we didn't center at 0, these models wouldn't even be invariant to translation.
-        mean_pos = scatter(data.pos, data.batch, dim=0, reduce="mean")
-        data.pos = data.pos - mean_pos[data.batch]
+        if data.batch is None:
+            mean_pos = data.pos.mean(dim=0, keepdim=True)
+            data.pos = data.pos - mean_pos
+        else:
+            mean_pos = scatter(data.pos, data.batch, dim=0, reduce="mean")
+            data.pos = data.pos - mean_pos[data.batch]
 
         # Get edge vectors and distances
         edge_vec, edge_dist = get_edge_vectors_and_lengths(

--- a/hydragnn/models/MACEStack.py
+++ b/hydragnn/models/MACEStack.py
@@ -57,6 +57,7 @@ from e3nn.util.jit import compile_mode
 # HydraGNN
 from .Base import Base
 from hydragnn.utils.model.operations import get_edge_vectors_and_lengths
+from hydragnn.utils.model.irreps_tools import create_irreps_string
 from hydragnn.utils.model.mace_utils.modules.blocks import (
     CombineBlock,
     SplitBlock,
@@ -449,14 +450,6 @@ class MACEStack(Base):
 
     def __str__(self):
         return "MACEStack"
-
-
-def create_irreps_string(
-    n: int, ell: int
-):  # Custom function to create irreps easily for MACE
-    # By choice and somewhat regular convention, the default parity is for all even ell values and odd for all odd ell values
-    irreps = [f"{n}x{ell}{'e' if ell % 2 == 0 else 'o'}" for ell in range(ell + 1)]
-    return " + ".join(irreps)
 
 
 def process_node_attributes(node_attributes, num_elements):

--- a/hydragnn/utils/model/irreps_tools.py
+++ b/hydragnn/utils/model/irreps_tools.py
@@ -100,3 +100,10 @@ def extract_invariant(x: torch.Tensor, num_layers: int, num_features: int, l_max
         )
     out.append(x[:, -num_features:])
     return torch.cat(out, dim=-1)
+
+
+# Added by HydraGNN group:
+def create_irreps_string(n: int, ell: int):  # Custom function to create irreps easily
+    # By choice and somewhat regular convention, the default parity is for all even ell values and odd for all odd ell values
+    irreps = [f"{n}x{ell}{'e' if ell % 2 == 0 else 'o'}" for ell in range(ell + 1)]
+    return " + ".join(irreps)

--- a/hydragnn/utils/model/mace_utils/modules/blocks.py
+++ b/hydragnn/utils/model/mace_utils/modules/blocks.py
@@ -25,6 +25,7 @@ from hydragnn.utils.model.mace_utils.tools.compile import simplify_if_compile
 from hydragnn.utils.model.irreps_tools import (
     reshape_irreps,
     tp_out_irreps_with_instructions,
+    create_irreps_string,
 )
 
 from .radial import (


### PR DESCRIPTION
Reworking of MACE for cleanliness, robustness to hyperparameter configurations, and numerical stability in decoders.

Main Changes:

(1) Many changes to cleanliness and comments, moving some blocks to the utils.
(2) Handle configurations with only one convolutional layer where both first_layer and last_layer are true
(3) Do not append multiple layers in the decoder block when doing a purely linear decoding. This is because multiple linear layers stacked on top of each other without activations can be cause more erratic training / numerical instability.