### PR TITLE
Align examples pbc

### DIFF
--- a/examples/LennardJones/LJ.json
+++ b/examples/LennardJones/LJ.json
@@ -21,7 +21,7 @@
       "periodic_boundary_conditions": true,
       "global_attn_engine": "",
       "global_attn_type": "",
-      "mpnn_type": "EGNN",
+      "mpnn_type": "DimeNet",
       "radius": 5.0,
       "max_neighbours": 5,
       "int_emb_size": 32,
@@ -61,7 +61,7 @@
       "output_names": ["graph_energy"]
     },
     "Training": {
-      "num_epoch": 15,
+      "num_epoch": 25,
       "batch_size": 64,
       "perc_train": 0.7,
       "patience": 20,

--- a/examples/LennardJones/LJ_data.py
+++ b/examples/LennardJones/LJ_data.py
@@ -53,6 +53,7 @@ primitive_bravais_lattice_constant_z = 3.8
 
 def create_dataset(path, config):
     radius_cutoff = config["NeuralNetwork"]["Architecture"]["radius"]
+    max_num_neighbors = config["NeuralNetwork"]["Architecture"]["max_neighbours"]
     number_configurations = (
         config["Dataset"]["number_configurations"]
         if "number_configurations" in config["Dataset"]
@@ -75,6 +76,7 @@ def create_dataset(path, config):
         atom_types,
         atomic_structure_handler=atomic_structure_handler,
         radius_cutoff=radius_cutoff,
+        max_num_neighbors=max_num_neighbors,
         relative_maximum_atomic_displacement=1e-1,
         number_configurations=number_configurations,
     )

--- a/examples/LennardJones/LJ_data.py
+++ b/examples/LennardJones/LJ_data.py
@@ -167,7 +167,7 @@ class LJDataset(AbstractBaseDataset):
         forces_pre_scaled = forces * forces_pre_scaling_factor
 
         data = Data(
-            supercell_size=torch_supercell.to(torch.float32),
+            cell=torch_supercell.to(torch.float32),
             num_nodes=num_nodes,
             grad_energy_post_scaling_factor=grad_energy_post_scaling_factor,
             forces_pre_scaling_factor=torch.tensor(forces_pre_scaling_factor).to(
@@ -345,7 +345,7 @@ def create_configuration(
     supercell_size_x = primitive_bravais_lattice_constant_x * uc_x
     supercell_size_y = primitive_bravais_lattice_constant_y * uc_y
     supercell_size_z = primitive_bravais_lattice_constant_z * uc_z
-    data.supercell_size = torch.diag(
+    data.cell = torch.diag(
         torch.tensor([supercell_size_x, supercell_size_y, supercell_size_z])
     )
     data.pbc = [True, True, True]
@@ -375,7 +375,7 @@ def create_configuration(
     filetxt = total_energy_str + "\n" + energy_per_atom_str
 
     for index in range(0, 3):
-        numpy_row = data.supercell_size[index, :].detach().numpy()
+        numpy_row = data.cell[index, :].detach().numpy()
         numpy_string_row = numpy.array2string(numpy_row, precision=64, separator="\t")
         filetxt += "\n" + numpy_string_row.lstrip("[").rstrip("]")
 
@@ -426,23 +426,23 @@ class AtomicStructureHandler:
                     ## in the code. Because of this, we can simply adjust the neighbor position coordinate-wise to be closer than
                     ## as done in the following lines of code. The logic goes that if the distance vector[index] is larger than half the supercell size,
                     ## then there is a closer distance at +- supercell_size[index], and we adjust to that for each coordinate
-                    if abs(distance_vector[0]) > data.supercell_size[0, 0] / 2:
+                    if abs(distance_vector[0]) > data.cell[0, 0] / 2:
                         if distance_vector[0] > 0:
-                            neighbor_pos[0] -= data.supercell_size[0, 0]
+                            neighbor_pos[0] -= data.cell[0, 0]
                         else:
-                            neighbor_pos[0] += data.supercell_size[0, 0]
+                            neighbor_pos[0] += data.cell[0, 0]
 
-                    if abs(distance_vector[1]) > data.supercell_size[1, 1] / 2:
+                    if abs(distance_vector[1]) > data.cell[1, 1] / 2:
                         if distance_vector[1] > 0:
-                            neighbor_pos[1] -= data.supercell_size[1, 1]
+                            neighbor_pos[1] -= data.cell[1, 1]
                         else:
-                            neighbor_pos[1] += data.supercell_size[1, 1]
+                            neighbor_pos[1] += data.cell[1, 1]
 
-                    if abs(distance_vector[2]) > data.supercell_size[2, 2] / 2:
+                    if abs(distance_vector[2]) > data.cell[2, 2] / 2:
                         if distance_vector[2] > 0:
-                            neighbor_pos[2] -= data.supercell_size[2, 2]
+                            neighbor_pos[2] -= data.cell[2, 2]
                         else:
-                            neighbor_pos[2] += data.supercell_size[2, 2]
+                            neighbor_pos[2] += data.cell[2, 2]
 
                 # The distance vecor may need to be updated after applying PBCs
                 distance_vector = data.pos[node_id, :] - neighbor_pos

--- a/examples/LennardJones/LJ_inference_plots.py
+++ b/examples/LennardJones/LJ_inference_plots.py
@@ -132,10 +132,10 @@ if __name__ == "__main__":
     input_filename = os.path.join(dirpwd, args.inputfile)
     with open(input_filename, "r") as f:
         config = json.load(f)
-    hydragnn.utils.setup_log(get_log_name_config(config))
+    hydragnn.utils.print.setup_log(get_log_name_config(config))
     ##################################################################################################################
     # Always initialize for multi-rank training.
-    comm_size, rank = hydragnn.utils.setup_ddp()
+    comm_size, rank = hydragnn.utils.distributed.setup_ddp()
     ##################################################################################################################
     comm = MPI.COMM_WORLD
 

--- a/examples/LennardJones/LJ_inference_plots.py
+++ b/examples/LennardJones/LJ_inference_plots.py
@@ -102,25 +102,6 @@ def getcolordensity(xdata, ydata):
     return hist2d_norm
 
 
-from sklearn.metrics import r2_score
-
-
-def get_r2(energy_true_list, energy_pred_list, forces_true_list, forces_pred_list):
-    # Convert inputs to numpy arrays
-    energy_true_list = np.array(energy_true_list)
-    energy_pred_list = np.array(energy_pred_list)
-    forces_true_list = np.array(forces_true_list)
-    forces_pred_list = np.array(forces_pred_list)
-
-    # Compute R^2 for energy
-    energy_r2 = r2_score(energy_true_list, energy_pred_list)
-
-    # Compute R^2 for forces (flatten both arrays for 1D comparison)
-    forces_r2 = r2_score(forces_true_list.flatten(), forces_pred_list.flatten())
-
-    return energy_r2, forces_r2
-
-
 if __name__ == "__main__":
 
     modelname = "LJ"
@@ -202,7 +183,7 @@ if __name__ == "__main__":
     variable_index = 0
     # for output_name, output_type, output_dim in zip(config["NeuralNetwork"]["Variables_of_interest"]["output_names"], config["NeuralNetwork"]["Variables_of_interest"]["type"], config["NeuralNetwork"]["Variables_of_interest"]["output_dim"]):
 
-    # test_MAE = 0.0
+    test_MAE = 0.0
 
     num_samples = len(testset)
     energy_true_list = []
@@ -216,7 +197,7 @@ if __name__ == "__main__":
             0
         ]  # Note that this is sensitive to energy and forces prediction being single-task (current requirement)
         energy_pred = torch.sum(node_energy_pred, dim=0).float()
-        # test_MAE += torch.norm(energy_pred - data.energy, p=1).item() / len(testset)
+        test_MAE += torch.norm(energy_pred - data.energy, p=1).item() / len(testset)
         # predicted.backward(retain_graph=True)
         # gradients = data.pos.grad
         grads_energy = torch.autograd.grad(
@@ -231,12 +212,6 @@ if __name__ == "__main__":
         forces_pred_list.extend((-grads_energy).flatten().tolist())
         forces_true_list.extend(data.forces.flatten().tolist())
 
-    test_energy_r2, test_force_r2 = get_r2(
-        energy_true_list, energy_pred_list, forces_true_list, forces_pred_list
-    )
-    print(f"Test R2 energy: ", test_energy_r2)
-    print(f"Test R2 forces: ", test_force_r2)
-
     hist2d_norm = getcolordensity(energy_true_list, energy_pred_list)
 
     fig, ax = plt.subplots()
@@ -246,12 +221,12 @@ if __name__ == "__main__":
     plt.colorbar()
     plt.xlabel("True values")
     plt.ylabel("Predicted values")
-    plt.title(f"Energy")
+    plt.title(f"energy")
     plt.draw()
     plt.tight_layout()
     plt.savefig(f"./energy_Scatterplot" + ".png", dpi=400)
 
-    # print(f"Test MAE energy: ", test_MAE)
+    print(f"Test MAE energy: ", test_MAE)
 
     hist2d_norm = getcolordensity(forces_pred_list, forces_true_list)
     fig, ax = plt.subplots()

--- a/examples/mptrj/train.py
+++ b/examples/mptrj/train.py
@@ -26,7 +26,10 @@ from hydragnn.utils.datasets.pickledataset import (
     SimplePickleDataset,
 )
 from hydragnn.preprocess.graph_samples_checks_and_updates import gather_deg
-from hydragnn.preprocess.graph_samples_checks_and_updates import RadiusGraphPBC
+from hydragnn.preprocess.graph_samples_checks_and_updates import (
+    RadiusGraph,
+    RadiusGraphPBC,
+)
 from hydragnn.preprocess.load_data import split_dataset
 
 import hydragnn.utils.profiling_and_tracing.tracer as tr
@@ -66,7 +69,8 @@ class MPTrjDataset(AbstractBaseDataset):
         self.var_config = var_config
         self.energy_per_atom = energy_per_atom
 
-        self.radius_graph = RadiusGraphPBC(5.0, loop=False, max_num_neighbors=50)
+        self.radius_graph = RadiusGraph(5.0, loop=False, max_num_neighbors=50)
+        self.radius_graph_pbc = RadiusGraphPBC(5.0, loop=False, max_num_neighbors=50)
 
         self.dist = dist
         if self.dist:
@@ -118,10 +122,20 @@ class MPTrjDataset(AbstractBaseDataset):
                 info["magmom"] = k["magmom"]
 
                 # Convert lists to PyTorch tensors
-                lattice_mat = torch.tensor(
-                    info["atoms"]["lattice_mat"], dtype=torch.float32
-                )
-                pbc = info["atoms"]["pbc"]
+                lattice_mat = None
+                try:
+                    lattice_mat = torch.tensor(
+                        info["atoms"]["lattice_mat"], dtype=torch.float32
+                    )
+                except:
+                    print(f"Structure does not have lattice_mat", flush=True)
+
+                pbc = None
+                try:
+                    pbc = info["atoms"]["pbc"]
+                except:
+                    print(f"Structure does not have pbc", flush=True)
+
                 coords = torch.tensor(info["atoms"]["coords"], dtype=torch.float32)
 
                 # Multiply 'lattice_mat' by the transpose of 'coords'
@@ -160,7 +174,18 @@ class MPTrjDataset(AbstractBaseDataset):
                     y=energy,
                 )
 
-                data = self.radius_graph(data)
+                if data.pbc is not None and data.cell is not None:
+                    try:
+                        data = self.radius_graph_pbc(data)
+                    except:
+                        print(
+                            f"Structure could not successfully apply pbc radius graph",
+                            flush=True,
+                        )
+                        data = self.radius_graph(data)
+                else:
+                    data = self.radius_graph(data)
+
                 data = transform_coordinates(data)
                 if self.check_forces_values(data.force):
                     self.dataset.append(data)

--- a/examples/mptrj/train.py
+++ b/examples/mptrj/train.py
@@ -150,7 +150,7 @@ class MPTrjDataset(AbstractBaseDataset):
 
                 # Creating the Data object
                 data = Data(
-                    supercell_size=lattice_mat,
+                    cell=lattice_mat,
                     energy=energy,
                     force=forces,
                     # stress=torch.tensor(stresses, dtype=torch.float32),

--- a/examples/mptrj/train.py
+++ b/examples/mptrj/train.py
@@ -26,10 +26,7 @@ from hydragnn.utils.datasets.pickledataset import (
     SimplePickleDataset,
 )
 from hydragnn.preprocess.graph_samples_checks_and_updates import gather_deg
-from hydragnn.preprocess.graph_samples_checks_and_updates import (
-    RadiusGraph,
-    RadiusGraphPBC,
-)
+from hydragnn.preprocess.graph_samples_checks_and_updates import RadiusGraphPBC
 from hydragnn.preprocess.load_data import split_dataset
 
 import hydragnn.utils.profiling_and_tracing.tracer as tr
@@ -69,7 +66,7 @@ class MPTrjDataset(AbstractBaseDataset):
         self.var_config = var_config
         self.energy_per_atom = energy_per_atom
 
-        self.radius_graph = RadiusGraph(5.0, loop=False, max_num_neighbors=50)
+        self.radius_graph = RadiusGraphPBC(5.0, loop=False, max_num_neighbors=50)
 
         self.dist = dist
         if self.dist:
@@ -124,6 +121,7 @@ class MPTrjDataset(AbstractBaseDataset):
                 lattice_mat = torch.tensor(
                     info["atoms"]["lattice_mat"], dtype=torch.float32
                 )
+                pbc = info["atoms"]["pbc"]
                 coords = torch.tensor(info["atoms"]["coords"], dtype=torch.float32)
 
                 # Multiply 'lattice_mat' by the transpose of 'coords'
@@ -151,6 +149,7 @@ class MPTrjDataset(AbstractBaseDataset):
                 # Creating the Data object
                 data = Data(
                     cell=lattice_mat,
+                    pbc=pbc,
                     energy=energy,
                     force=forces,
                     # stress=torch.tensor(stresses, dtype=torch.float32),

--- a/examples/open_catalyst_2020/train.py
+++ b/examples/open_catalyst_2020/train.py
@@ -89,7 +89,7 @@ class OpenCatalystDataset(AbstractBaseDataset):
             print(self.rank, "WARN: No files to process. Continue ...")
 
         # Initialize feature extractor.
-        a2g = AtomsToGraphs(max_neigh=50, radius=3.0)
+        a2g = AtomsToGraphs(max_neigh=5, radius=6.0)
 
         list_atomistic_structures = write_images_to_adios(
             a2g,
@@ -110,7 +110,6 @@ class OpenCatalystDataset(AbstractBaseDataset):
         random.shuffle(self.dataset)
 
     def check_forces_values(self, forces):
-
         # Calculate the L2 norm for each row
         norms = torch.norm(forces, p=2, dim=1)
         # Check if all norms are less than the threshold
@@ -179,7 +178,7 @@ if __name__ == "__main__":
         dest="format",
         const="pickle",
     )
-    parser.set_defaults(format="adios")
+    parser.set_defaults(format="pickle")
     args = parser.parse_args()
 
     graph_feature_names = ["energy"]
@@ -359,7 +358,11 @@ if __name__ == "__main__":
         os.environ["HYDRAGNN_AGGR_BACKEND"] = "mpi"
         os.environ["HYDRAGNN_USE_ddstore"] = "1"
 
-    (train_loader, val_loader, test_loader,) = hydragnn.preprocess.create_dataloaders(
+    (
+        train_loader,
+        val_loader,
+        test_loader,
+    ) = hydragnn.preprocess.create_dataloaders(
         trainset, valset, testset, config["NeuralNetwork"]["Training"]["batch_size"]
     )
 

--- a/examples/open_catalyst_2020/train.py
+++ b/examples/open_catalyst_2020/train.py
@@ -89,7 +89,7 @@ class OpenCatalystDataset(AbstractBaseDataset):
             print(self.rank, "WARN: No files to process. Continue ...")
 
         # Initialize feature extractor.
-        a2g = AtomsToGraphs(max_neigh=50, radius=6, r_pbc=False)
+        a2g = AtomsToGraphs(max_neigh=50, radius=3, r_pbc=True)
 
         list_atomistic_structures = write_images_to_adios(
             a2g,
@@ -187,7 +187,7 @@ if __name__ == "__main__":
     node_feature_names = ["atomic_number", "cartesian_coordinates", "forces"]
     node_feature_dims = [1, 3, 3]
     dirpwd = os.path.dirname(os.path.abspath(__file__))
-    datadir = os.path.join(dirpwd, "dataset")
+    datadir = os.path.join(dirpwd, "datasets")
     ##################################################################################################################
     input_filename = os.path.join(dirpwd, args.inputfile)
     ##################################################################################################################

--- a/examples/open_catalyst_2020/train.py
+++ b/examples/open_catalyst_2020/train.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
     node_feature_names = ["atomic_number", "cartesian_coordinates", "forces"]
     node_feature_dims = [1, 3, 3]
     dirpwd = os.path.dirname(os.path.abspath(__file__))
-    datadir = os.path.join(dirpwd, "datasets")
+    datadir = os.path.join(dirpwd, "dataset")
     ##################################################################################################################
     input_filename = os.path.join(dirpwd, args.inputfile)
     ##################################################################################################################

--- a/examples/open_catalyst_2020/train.py
+++ b/examples/open_catalyst_2020/train.py
@@ -89,7 +89,7 @@ class OpenCatalystDataset(AbstractBaseDataset):
             print(self.rank, "WARN: No files to process. Continue ...")
 
         # Initialize feature extractor.
-        a2g = AtomsToGraphs(max_neigh=5, radius=6.0)
+        a2g = AtomsToGraphs(max_neigh=50, radius=6.0)
 
         list_atomistic_structures = write_images_to_adios(
             a2g,
@@ -178,7 +178,7 @@ if __name__ == "__main__":
         dest="format",
         const="pickle",
     )
-    parser.set_defaults(format="pickle")
+    parser.set_defaults(format="adios")
     args = parser.parse_args()
 
     graph_feature_names = ["energy"]

--- a/examples/open_catalyst_2020/train.py
+++ b/examples/open_catalyst_2020/train.py
@@ -89,7 +89,7 @@ class OpenCatalystDataset(AbstractBaseDataset):
             print(self.rank, "WARN: No files to process. Continue ...")
 
         # Initialize feature extractor.
-        a2g = AtomsToGraphs(max_neigh=50, radius=3)
+        a2g = AtomsToGraphs(max_neigh=50, radius=3.0)
 
         list_atomistic_structures = write_images_to_adios(
             a2g,

--- a/examples/open_catalyst_2020/train.py
+++ b/examples/open_catalyst_2020/train.py
@@ -89,7 +89,7 @@ class OpenCatalystDataset(AbstractBaseDataset):
             print(self.rank, "WARN: No files to process. Continue ...")
 
         # Initialize feature extractor.
-        a2g = AtomsToGraphs(max_neigh=50, radius=3, r_pbc=True)
+        a2g = AtomsToGraphs(max_neigh=50, radius=3)
 
         list_atomistic_structures = write_images_to_adios(
             a2g,

--- a/examples/open_catalyst_2020/train.py
+++ b/examples/open_catalyst_2020/train.py
@@ -358,11 +358,7 @@ if __name__ == "__main__":
         os.environ["HYDRAGNN_AGGR_BACKEND"] = "mpi"
         os.environ["HYDRAGNN_USE_ddstore"] = "1"
 
-    (
-        train_loader,
-        val_loader,
-        test_loader,
-    ) = hydragnn.preprocess.create_dataloaders(
+    (train_loader, val_loader, test_loader,) = hydragnn.preprocess.create_dataloaders(
         trainset, valset, testset, config["NeuralNetwork"]["Training"]["batch_size"]
     )
 

--- a/examples/open_catalyst_2020/utils/atoms_to_graphs.py
+++ b/examples/open_catalyst_2020/utils/atoms_to_graphs.py
@@ -93,12 +93,6 @@ class AtomsToGraphs:
         # https://wiki.fysik.dtu.dk/ase/_modules/ase/atoms.html#Atoms.get_tags
         tags = torch.Tensor(atoms.get_tags())
 
-        # Check if data has data.pbc and throw error if not
-        if not hasattr(atoms, "pbc"):
-            raise ValueError(
-                "The atoms object does not have the periodic boundary conditions."
-            )
-
         # put the minimum data in torch geometric data object
         data = Data(
             cell=cell,

--- a/examples/open_catalyst_2020/utils/atoms_to_graphs.py
+++ b/examples/open_catalyst_2020/utils/atoms_to_graphs.py
@@ -51,7 +51,7 @@ class AtomsToGraphs:
     def __init__(
         self,
         max_neigh=200,
-        radius=3.0,
+        radius=6.0,
     ):
         self.max_neigh = max_neigh
         self.radius = radius

--- a/examples/open_catalyst_2020/utils/atoms_to_graphs.py
+++ b/examples/open_catalyst_2020/utils/atoms_to_graphs.py
@@ -52,7 +52,7 @@ class AtomsToGraphs:
         self,
         max_neigh=200,
         radius=6,
-        r_pbc=False,
+        r_pbc=True,
     ):
         self.max_neigh = max_neigh
         self.radius = radius
@@ -86,15 +86,23 @@ class AtomsToGraphs:
         # set the atomic numbers, positions, and cell
         atomic_numbers = torch.Tensor(atoms.get_atomic_numbers()).unsqueeze(1)
         positions = torch.Tensor(atoms.get_positions())
-        cell = torch.Tensor(np.array(atoms.get_cell())).view(1, 3, 3)
+        cell = torch.Tensor(np.array(atoms.get_cell())).view(3, 3)
+        pbc = atoms.get_pbc()
         natoms = torch.IntTensor([positions.shape[0]])
         # initialized to torch.zeros(natoms) if tags missing.
         # https://wiki.fysik.dtu.dk/ase/_modules/ase/atoms.html#Atoms.get_tags
         tags = torch.Tensor(atoms.get_tags())
 
+        # Check if data has data.pbc and throw error if not
+        if not hasattr(atoms, "pbc"):
+            raise ValueError(
+                "The atoms object does not have the periodic boundary conditions."
+            )
+
         # put the minimum data in torch geometric data object
         data = Data(
             cell=cell,
+            pbc=pbc,
             pos=positions,
             atomic_numbers=atomic_numbers,
             natoms=natoms,

--- a/examples/open_catalyst_2020/utils/atoms_to_graphs.py
+++ b/examples/open_catalyst_2020/utils/atoms_to_graphs.py
@@ -48,12 +48,12 @@ class AtomsToGraphs:
     def __init__(
         self,
         max_neigh=200,
-        radius=6,
+        radius=3.0,
     ):
         self.max_neigh = max_neigh
         self.radius = radius
-        
-        # NOTE Open Catalyst 2020 dataset has PBC: 
+
+        # NOTE Open Catalyst 2020 dataset has PBC:
         #      https://pubs.acs.org/doi/10.1021/acscatal.0c04525#_i3 (Section 2: Tasks, paragraph 2)
         self.radius_graph = RadiusGraphPBC(
             self.radius, loop=False, max_num_neighbors=self.max_neigh

--- a/examples/open_catalyst_2020/utils/atoms_to_graphs.py
+++ b/examples/open_catalyst_2020/utils/atoms_to_graphs.py
@@ -15,10 +15,7 @@ import torch
 from torch_geometric.data import Data
 from torch_geometric.transforms import Distance, Spherical, LocalCartesian
 
-from hydragnn.preprocess.graph_samples_checks_and_updates import (
-    RadiusGraph,
-    RadiusGraphPBC,
-)
+from hydragnn.preprocess.graph_samples_checks_and_updates import RadiusGraphPBC
 
 # transform_coordinates = Spherical(norm=False, cat=False)
 # transform_coordinates = LocalCartesian(norm=False, cat=False)
@@ -52,20 +49,15 @@ class AtomsToGraphs:
         self,
         max_neigh=200,
         radius=6,
-        r_pbc=True,
     ):
         self.max_neigh = max_neigh
         self.radius = radius
-        self.r_pbc = r_pbc
-
-        if self.r_pbc:
-            self.radius_graph = RadiusGraphPBC(
-                self.radius, loop=False, max_num_neighbors=self.max_neigh
-            )
-        else:
-            self.radius_graph = RadiusGraph(
-                self.radius, loop=False, max_num_neighbors=self.max_neigh
-            )
+        
+        # NOTE Open Catalyst 2020 dataset has PBC: 
+        #      https://pubs.acs.org/doi/10.1021/acscatal.0c04525#_i3 (Section 2: Tasks, paragraph 2)
+        self.radius_graph = RadiusGraphPBC(
+            self.radius, loop=False, max_num_neighbors=self.max_neigh
+        )
 
     def convert(
         self,

--- a/examples/open_catalyst_2022/train.py
+++ b/examples/open_catalyst_2022/train.py
@@ -440,11 +440,7 @@ if __name__ == "__main__":
         os.environ["HYDRAGNN_AGGR_BACKEND"] = "mpi"
         os.environ["HYDRAGNN_USE_ddstore"] = "1"
 
-    (
-        train_loader,
-        val_loader,
-        test_loader,
-    ) = hydragnn.preprocess.create_dataloaders(
+    (train_loader, val_loader, test_loader,) = hydragnn.preprocess.create_dataloaders(
         trainset, valset, testset, config["NeuralNetwork"]["Training"]["batch_size"]
     )
 

--- a/examples/open_catalyst_2022/train.py
+++ b/examples/open_catalyst_2022/train.py
@@ -70,8 +70,8 @@ class OpenCatalystDataset(AbstractBaseDataset):
         self.data_path = dirpath
         self.energy_per_atom = energy_per_atom
 
-        # NOTE Open Catalyst 2020 dataset has PBC:
-        #      https://pubs.acs.org/doi/10.1021/acscatal.0c04525#_i3 (Section 2: Tasks, paragraph 2)
+        # NOTE Open Catalyst 2022 dataset has PBC:
+        #      https://pubs.acs.org/doi/10.1021/acscatal.2c05426 (Section: Tasks, paragraph 3)
         self.radius_graph = RadiusGraphPBC(3.0, loop=False, max_num_neighbors=50)
 
         # Threshold for atomic forces in eV/angstrom

--- a/examples/open_catalyst_2022/train.py
+++ b/examples/open_catalyst_2022/train.py
@@ -70,9 +70,9 @@ class OpenCatalystDataset(AbstractBaseDataset):
         self.data_path = dirpath
         self.energy_per_atom = energy_per_atom
 
-        # NOTE Open Catalyst 2020 dataset has PBC: 
+        # NOTE Open Catalyst 2020 dataset has PBC:
         #      https://pubs.acs.org/doi/10.1021/acscatal.0c04525#_i3 (Section 2: Tasks, paragraph 2)
-        self.radius_graph = RadiusGraphPBC(6.0, loop=False, max_num_neighbors=50)
+        self.radius_graph = RadiusGraphPBC(3.0, loop=False, max_num_neighbors=50)
 
         # Threshold for atomic forces in eV/angstrom
         self.forces_norm_threshold = 100.0

--- a/examples/open_catalyst_2022/train.py
+++ b/examples/open_catalyst_2022/train.py
@@ -34,10 +34,7 @@ import hydragnn.utils.profiling_and_tracing.tracer as tr
 
 from hydragnn.utils.print.print_utils import iterate_tqdm, log
 
-from hydragnn.preprocess.graph_samples_checks_and_updates import (
-    RadiusGraph,
-    RadiusGraphPBC,
-)
+from hydragnn.preprocess.graph_samples_checks_and_updates import RadiusGraphPBC
 
 from ase.io import read
 
@@ -66,7 +63,6 @@ class OpenCatalystDataset(AbstractBaseDataset):
         data_type,
         energy_per_atom=True,
         dist=False,
-        r_pbc=True,
     ):
         super().__init__()
 
@@ -74,11 +70,9 @@ class OpenCatalystDataset(AbstractBaseDataset):
         self.data_path = dirpath
         self.energy_per_atom = energy_per_atom
 
-        self.r_pbc = r_pbc
-        if self.r_pbc:
-            self.radius_graph = RadiusGraphPBC(6.0, loop=False, max_num_neighbors=50)
-        else:
-            self.radius_graph = RadiusGraph(6.0, loop=False, max_num_neighbors=50)
+        # NOTE Open Catalyst 2020 dataset has PBC: 
+        #      https://pubs.acs.org/doi/10.1021/acscatal.0c04525#_i3 (Section 2: Tasks, paragraph 2)
+        self.radius_graph = RadiusGraphPBC(6.0, loop=False, max_num_neighbors=50)
 
         # Threshold for atomic forces in eV/angstrom
         self.forces_norm_threshold = 100.0

--- a/examples/open_catalyst_2022/train.py
+++ b/examples/open_catalyst_2022/train.py
@@ -66,7 +66,7 @@ class OpenCatalystDataset(AbstractBaseDataset):
         data_type,
         energy_per_atom=True,
         dist=False,
-        r_pbc=False,
+        r_pbc=True,
     ):
         super().__init__()
 
@@ -126,7 +126,8 @@ class OpenCatalystDataset(AbstractBaseDataset):
         # set the atomic numbers, positions, and cell
         atomic_numbers = torch.Tensor(atoms.get_atomic_numbers()).unsqueeze(1)
         positions = torch.Tensor(atoms.get_positions())
-        cell = torch.Tensor(np.array(atoms.get_cell())).view(1, 3, 3)
+        cell = torch.Tensor(np.array(atoms.get_cell())).view(3, 3)
+        pbc = atoms.get_pbc()
         natoms = torch.IntTensor([positions.shape[0]])
         # initialized to torch.zeros(natoms) if tags missing.
         # https://wiki.fysik.dtu.dk/ase/_modules/ase/atoms.html#Atoms.get_tags
@@ -135,6 +136,7 @@ class OpenCatalystDataset(AbstractBaseDataset):
         # put the minimum data in torch geometric data object
         data = Data(
             cell=cell,
+            pbc=pbc,
             pos=positions,
             atomic_numbers=atomic_numbers,
             natoms=natoms,

--- a/examples/open_catalyst_2022/train.py
+++ b/examples/open_catalyst_2022/train.py
@@ -74,8 +74,8 @@ class OpenCatalystDataset(AbstractBaseDataset):
 
         # NOTE Open Catalyst 2022 dataset has PBC:
         #      https://pubs.acs.org/doi/10.1021/acscatal.2c05426 (Section: Tasks, paragraph 3)
-        self.radius_graph = RadiusGraph(3.0, loop=False, max_num_neighbors=50)
-        self.radius_graph_pbc = RadiusGraphPBC(3.0, loop=False, max_num_neighbors=50)
+        self.radius_graph = RadiusGraph(6.0, loop=False, max_num_neighbors=50)
+        self.radius_graph_pbc = RadiusGraphPBC(6.0, loop=False, max_num_neighbors=50)
 
         # Threshold for atomic forces in eV/angstrom
         self.forces_norm_threshold = 100.0
@@ -189,7 +189,6 @@ class OpenCatalystDataset(AbstractBaseDataset):
         return data_list
 
     def check_forces_values(self, forces):
-
         # Calculate the L2 norm for each row
         norms = torch.norm(forces, p=2, dim=1)
         # Check if all norms are less than the threshold
@@ -441,7 +440,11 @@ if __name__ == "__main__":
         os.environ["HYDRAGNN_AGGR_BACKEND"] = "mpi"
         os.environ["HYDRAGNN_USE_ddstore"] = "1"
 
-    (train_loader, val_loader, test_loader,) = hydragnn.preprocess.create_dataloaders(
+    (
+        train_loader,
+        val_loader,
+        test_loader,
+    ) = hydragnn.preprocess.create_dataloaders(
         trainset, valset, testset, config["NeuralNetwork"]["Training"]["batch_size"]
     )
 

--- a/hydragnn/preprocess/cfg_raw_dataset_loader.py
+++ b/hydragnn/preprocess/cfg_raw_dataset_loader.py
@@ -75,7 +75,7 @@ class CFG_RawDataLoader(AbstractRawDataLoader):
 
         data_object = Data()
 
-        data_object.supercell_size = tensor(ase_object.cell.array).float()
+        data_object.cell = tensor(ase_object.cell.array).float()
         data_object.pos = tensor(ase_object.arrays["positions"]).float()
         proton_numbers = np.expand_dims(ase_object.arrays["numbers"], axis=1)
         masses = np.expand_dims(ase_object.arrays["masses"], axis=1)

--- a/hydragnn/preprocess/graph_samples_checks_and_updates.py
+++ b/hydragnn/preprocess/graph_samples_checks_and_updates.py
@@ -266,14 +266,18 @@ class RadiusGraphPBC(RadiusGraph):
             data.pos = data.pos.to(torch.get_default_dtype())
         # Canonicalize based off data.pos, similar to PyG's default behavior
         device, dtype = data.pos.device, data.pos.dtype
-        if not isinstance(data.cell, torch.Tensor):
+        if not (
+            isinstance(data.cell, torch.Tensor)
+            and data.cell.dtype == dtype
+            and data.cell.device == device
+        ):
             data.cell = torch.tensor(data.cell, dtype=dtype, device=device)
-        if not isinstance(data.pbc, torch.Tensor):
+        if not (
+            isinstance(data.pbc, torch.Tensor)
+            and data.pbc.dtype == torch.bool
+            and data.pbc.device == device
+        ):
             data.pbc = torch.tensor(data.pbc, dtype=torch.bool, device=device)
-        if data.cell.device != device:
-            data.cell = data.cell.to(device)
-        if data.pbc.device != device:
-            data.pbc = data.pbc.to(device)
 
         return data, device, dtype
 

--- a/hydragnn/preprocess/graph_samples_checks_and_updates.py
+++ b/hydragnn/preprocess/graph_samples_checks_and_updates.py
@@ -133,7 +133,7 @@ def get_radius_graph_pbc_config(config, loop=False):
 
 
 class RadiusGraphPBC(RadiusGraph):
-    r"""Creates edges based on node positions `pos` to all points within a
+    r"""Creates edges based on node positions :obj:`pos` to all points within a
     given distance, including periodic images, and limits the number of neighbors per node.
     """
 

--- a/hydragnn/preprocess/graph_samples_checks_and_updates.py
+++ b/hydragnn/preprocess/graph_samples_checks_and_updates.py
@@ -23,7 +23,6 @@ from .dataset_descriptors import AtomFeatures
 from hydragnn.utils.distributed import get_device
 
 
-
 ## This function can be slow if datasets is too large. Use with caution.
 ## Recommend to use check_if_graph_size_variable_dist
 def check_if_graph_size_variable(train_loader, val_loader, test_loader):

--- a/hydragnn/preprocess/graph_samples_checks_and_updates.py
+++ b/hydragnn/preprocess/graph_samples_checks_and_updates.py
@@ -11,8 +11,8 @@
 
 import torch
 from torch_geometric.transforms import RadiusGraph
-from torch_geometric.utils import remove_self_loops, degree, lexsort
 from torch_geometric.data import Data
+from torch_geometric.utils import remove_self_loops, degree
 
 import ase
 import ase.neighborlist
@@ -215,7 +215,7 @@ class RadiusGraphPBC(RadiusGraph):
     def _remove_true_self_loops(
         self, edge_src, edge_dst, edge_length, edge_cell_shifts
     ):
-        # Create mask to remove true self loops (i.e. the same source and destination node, with no shifts across periodic boundaries)
+        # Create a mask to remove true self loops (i.e. the same source and destination node, with no shifts across periodic boundaries)
         true_self_edges = edge_src == edge_dst
         true_self_edges &= np.all(edge_cell_shifts == 0, axis=1)
         mask = ~true_self_edges
@@ -233,17 +233,10 @@ class RadiusGraphPBC(RadiusGraph):
     ):
         # Lexsort primarily by src node, and then by edge_dist
         sorted_indices = np.lexsort((edge_length, edge_src))
-        (
-            edge_src_sorted,
-            edge_dst_sorted,
-            edge_length_sorted,
-            edge_cell_shifts_sorted,
-        ) = (
-            edge_src[sorted_indices],
-            edge_dst[sorted_indices],
-            edge_length[sorted_indices],
-            edge_cell_shifts[sorted_indices],
-        )
+        edge_src, edge_dst, edge_length, edge_cell_shifts = [
+            edge_arg[sorted_indices]
+            for edge_arg in [edge_src, edge_dst, edge_length, edge_cell_shifts]
+        ]
 
         # Create a mask to keep only `max_num_neighbors` per node
         unique_src, counts = np.unique(edge_src, return_counts=True)
@@ -257,10 +250,10 @@ class RadiusGraphPBC(RadiusGraph):
 
         # Apply the mask and return
         return (
-            edge_src_sorted[mask],
-            edge_dst_sorted[mask],
-            edge_length_sorted[mask],
-            edge_cell_shifts_sorted[mask],
+            edge_src[mask],
+            edge_dst[mask],
+            edge_length[mask],
+            edge_cell_shifts[mask],
         )
 
     def __repr__(self) -> str:

--- a/tests/test_periodic_boundary_conditions.py
+++ b/tests/test_periodic_boundary_conditions.py
@@ -81,9 +81,7 @@ def pytest_periodic_h2():
 
     # Create # Hydrogen molecule (H2) with arbitrary node features
     data = Data()
-    data.supercell_size = torch.tensor(
-        [[3.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 3.0]]
-    )
+    data.cell = torch.tensor([[3.0, 0.0, 0.0], [0.0, 3.0, 0.0], [0.0, 0.0, 3.0]])
     data.pbc = [True, True, True]
     data.atom_types = [1, 1]
     data.pos = torch.tensor([[1.0, 1.0, 1.0], [1.43, 1.43, 1.43]])
@@ -108,7 +106,7 @@ def pytest_periodic_bcc_large():
 
     # Convert to PyG
     data2 = Data()
-    data2.supercell_size = torch.tensor(supercell.cell[:])
+    data2.cell = torch.tensor(supercell.cell[:])
     data2.pbc = [True, True, True]
     data2.atom_types = np.ones(len(supercell)) * 27
     data2.pos = torch.tensor(supercell.positions)


### PR DESCRIPTION
This PR aims to accomplish four main things:

(1) Align the OC examples with their datasets in the literature, which always have PBC
(2) Unify the naming of `cell` in the examples and all other parts of HydraGNN. Including `cell` is required by PBC
(3) Improved simplicity of the LJ example
  -  Using tools for `edge_vec` and `forces`, rather than manual
(4) Improved robustness of applying pbc
  - Checking for dupe edges instead of a check on radius, since the radius check can falter for non-cubic PBC
  - Adjusting the radius in OC examples so as to not create dupe edges