### PR TITLE
Fix Nodal Output Dim for Compute-Grad-Energy

### DIFF
--- a/examples/multibranch/train.py
+++ b/examples/multibranch/train.py
@@ -40,22 +40,6 @@ def info(*args, logtype="info", sep=" "):
     getattr(logging, logtype)(sep.join(map(str, args)))
 
 
-def check_node_feature_dim(var_config):
-    # NOTE: The following check is made to ensure compatibility with the json parsing of node features
-    # and compute_grad_energy.
-    # NOTE: In short: We need the node feature used to set up data.y to be of dimension 1, since this will dictate our
-    # nodal MLP head output dimension. Since we have node_feature_dims[0] == 1 and output_index == 0, this is already true.
-    # NOTE: In detail: When using Hydra for physics-informed force prediction for the GFM, we have the following structure:
-    # --> Load with ADIOS -->
-    # --> update_predicted_values(): defines y_loc = [0, node_feature_dims[output_index]*num_nodes] -->
-    # --> update_config_NN_outputs(): y_loc exists, so it defines output_dim = [(node_feature_dims[output_index]*num_nodes)/num_nodes]  = [node_feature_dims[output_index]] -->
-    # --> Base() ... MLPNode(): defines node MLP head with output_dim ... This must be equal to 1 as expected for nodal energy predictions
-    # NOTE Since changing json parsing functions requires base-level code changes and the imposed requirement is already being obeyed
-    # in the data setup for GFM, a quick check has been placed here instead.
-    if var_config["node_feature_dims"][var_config["output_index"][0]] != 1:
-        raise ValueError("Your node feature dim at the output index is not equal to 1.")
-
-
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
@@ -130,7 +114,6 @@ if __name__ == "__main__":
     var_config["graph_feature_dims"] = graph_feature_dims
     var_config["node_feature_names"] = node_feature_names
     var_config["node_feature_dims"] = node_feature_dims
-    check_node_feature_dim(var_config)
 
     if args.batch_size is not None:
         config["NeuralNetwork"]["Training"]["batch_size"] = args.batch_size

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -183,7 +183,10 @@ def update_config_edge_dim(config):
 def check_output_dim_consistent(data, config):
     output_type = config["NeuralNetwork"]["Variables_of_interest"]["type"]
     output_index = config["NeuralNetwork"]["Variables_of_interest"]["output_index"]
-    if hasattr(data, "y_loc"):
+    if (
+        hasattr(data, "y_loc")
+        and not config["NeuralNetwork"]["Training"]["compute_grad_energy"]
+    ):
         for ihead in range(len(output_type)):
             if output_type[ihead] == "graph":
                 assert (

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -202,7 +202,9 @@ def update_config_NN_outputs(config, data, graph_size_variable):
     """ "Extract architecture output dimensions and set node-level prediction architecture"""
 
     output_type = config["Variables_of_interest"]["type"]
-    if hasattr(data, "y_loc"):
+    if config["Training"]["compute_grad_energy"]:
+        dims_list = config["Variables_of_interest"]["output_dim"]
+    elif hasattr(data, "y_loc"):
         dims_list = []
         for ihead in range(len(output_type)):
             if output_type[ihead] == "graph":

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -183,10 +183,7 @@ def update_config_edge_dim(config):
 def check_output_dim_consistent(data, config):
     output_type = config["NeuralNetwork"]["Variables_of_interest"]["type"]
     output_index = config["NeuralNetwork"]["Variables_of_interest"]["output_index"]
-    if (
-        hasattr(data, "y_loc")
-        and not config["NeuralNetwork"]["Training"]["compute_grad_energy"]
-    ):
+    if hasattr(data, "y_loc"):
         for ihead in range(len(output_type)):
             if output_type[ihead] == "graph":
                 assert (

--- a/job-multibranch.sh
+++ b/job-multibranch.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-#SBATCH -A CPH161
+#SBATCH -A LRN070
 #SBATCH -J HydraGNN
 #SBATCH -o job-%j.out
 #SBATCH -e job-%j.out


### PR DESCRIPTION
This is a draft for how we may fix the nodal MLP's output dimension when using compute_grad_energy. This way, the output dimension is dictated by the config's instead of the node feature dim. We are still setting up dummy data.y and data.y_loc variables, but not using them, but this fix may be minimally invasive.


NOTE: In detail: When using Hydra for physics-informed force prediction for the GFM, we have the following structure:
    # --> Load with ADIOS  -->
    # --> update_predicted_values(): defines y_loc = [0, node_feature_dims[output_index]*num_nodes] -->
    # --> update_config_NN_outputs(): y_loc exists, so it defines output_dim = [(node_feature_dims[output_index]*num_nodes)/num_nodes]  = [node_feature_dims[output_index]] -->
    # --> Base() ... MLPNode(): defines node MLP head with output_dim ... This must be equal to 1 as expected for nodal energy predictions, but is actually equal to the nodal dim at variable of interest because we loaded with ADIOS.