### PR TITLE
Make SchNet RadGraph divert to CPU on Hardwares that don't have PyG GPU Support

### DIFF
--- a/hydragnn/models/SCFStack.py
+++ b/hydragnn/models/SCFStack.py
@@ -20,10 +20,18 @@ from torch_geometric.nn import Sequential as PyGSeq
 from torch_geometric.nn import MessagePassing
 from torch_geometric.nn.models.schnet import (
     GaussianSmearing,
-    RadiusInteractionGraph,
     ShiftedSoftplus,
 )
 from torch_geometric.typing import OptTensor
+
+if torch.cuda.is_available():
+    from torch_geometric.nn.models.schnet import (
+        RadiusInteractionGraph as RadiusInteractionGraph,
+    )
+else:
+    from hydragnn.preprocess.graph_samples_checks_and_updates import (
+        RadiusInteractionGraphCPU as RadiusInteractionGraph,
+    )
 
 from .Base import Base
 


### PR DESCRIPTION
If `torch.cuda.is_available()`, use the radius graph as before. If not, then use a subclass of SchNet's radgraph that transfers tensors to CPU, executes the radgraph, and then puts the tensors back on the original device. 

The `torch.cuda.is_available()` check will be true for both CUDA and ROCm, so it still uses the GPU on Frontier as we'd want.