### PR TITLE
Adding tensorboard writer close

### DIFF
--- a/examples/LennardJones/LennardJones.py
+++ b/examples/LennardJones/LennardJones.py
@@ -323,6 +323,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/alexandria/train.py
+++ b/examples/alexandria/train.py
@@ -706,6 +706,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/ani1_x/train.py
+++ b/examples/ani1_x/train.py
@@ -535,6 +535,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/csce/train_gap.py
+++ b/examples/csce/train_gap.py
@@ -437,6 +437,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.time_utils.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if args.mae:
         import matplotlib.pyplot as plt

--- a/examples/dftb_uv_spectrum/train_discrete_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_discrete_uv_spectrum.py
@@ -363,6 +363,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.save_model(model, optimizer, log_name)
     hydragnn.utils.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if args.mae:
         import matplotlib.pyplot as plt

--- a/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
@@ -361,6 +361,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.save_model(model, optimizer, log_name)
     hydragnn.utils.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if args.mae:
         import matplotlib.pyplot as plt

--- a/examples/eam/eam.py
+++ b/examples/eam/eam.py
@@ -219,5 +219,7 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.time_utils.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     sys.exit(0)

--- a/examples/ising_model/train_ising.py
+++ b/examples/ising_model/train_ising.py
@@ -428,6 +428,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/lsms/lsms.py
+++ b/examples/lsms/lsms.py
@@ -227,5 +227,7 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     sys.exit(0)

--- a/examples/md17/md17.py
+++ b/examples/md17/md17.py
@@ -133,6 +133,8 @@ def main(mpnn_type=None, global_attn_engine=None, global_attn_type=None):
         log_name,
         verbosity,
     )
+    if writer is not None:
+        writer.close()
 
 
 if __name__ == "__main__":

--- a/examples/mptrj/train.py
+++ b/examples/mptrj/train.py
@@ -558,6 +558,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/multibranch/train.py
+++ b/examples/multibranch/train.py
@@ -515,6 +515,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/multibranch_hpo/train.py
+++ b/examples/multibranch_hpo/train.py
@@ -611,6 +611,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/multidataset/train.py
+++ b/examples/multidataset/train.py
@@ -395,6 +395,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/multidataset_deepspeed/train.py
+++ b/examples/multidataset_deepspeed/train.py
@@ -475,6 +475,8 @@ if __name__ == "__main__":
     )  # optimizer is managed by deepspeed model
 
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/multidataset_hpo/gfm.py
+++ b/examples/multidataset_hpo/gfm.py
@@ -413,6 +413,8 @@ def main():
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/ogb/train_gap.py
+++ b/examples/ogb/train_gap.py
@@ -530,6 +530,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if args.mae:
         ##################################################################################################################

--- a/examples/open_catalyst_2020/train.py
+++ b/examples/open_catalyst_2020/train.py
@@ -464,6 +464,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/open_catalyst_2022/train.py
+++ b/examples/open_catalyst_2022/train.py
@@ -619,6 +619,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/open_materials_2024/train.py
+++ b/examples/open_materials_2024/train.py
@@ -356,6 +356,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/open_molecules_2025/train.py
+++ b/examples/open_molecules_2025/train.py
@@ -377,6 +377,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/qm7x/train.py
+++ b/examples/qm7x/train.py
@@ -605,6 +605,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/qm9/qm9.py
+++ b/examples/qm9/qm9.py
@@ -141,6 +141,8 @@ def main(mpnn_type=None, global_attn_engine=None, global_attn_type=None):
     )
 
     tr.save(log_name)
+    if writer is not None:
+        writer.close()
 
 
 if __name__ == "__main__":

--- a/examples/qm9_hpo/qm9.py
+++ b/examples/qm9_hpo/qm9.py
@@ -133,6 +133,9 @@ def main(mpnn_type=None, global_attn_engine=None, global_attn_type=None):
         verbosity,
     )
 
+    if writer is not None:
+        writer.close()
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(

--- a/examples/qm9_hpo/qm9_deephyper.py
+++ b/examples/qm9_hpo/qm9_deephyper.py
@@ -169,6 +169,8 @@ def run(trial):
 
     hydragnn.utils.model.model.save_model(model, optimizer, trial_log_name)
     hydragnn.utils.print.print_distributed(verbosity)
+    if writer is not None:
+        writer.close()
 
     # Return the metric to minimize (e.g., validation loss)
     validation_loss, tasks_loss = hydragnn.train.validate(

--- a/examples/qm9_hpo/qm9_optuna.py
+++ b/examples/qm9_hpo/qm9_optuna.py
@@ -116,6 +116,8 @@ def objective(trial):
 
     hydragnn.utils.save_model(model, optimizer, log_name)
     hydragnn.utils.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     """
     if tr.has("GPTLTracer"):

--- a/examples/transition1x/train.py
+++ b/examples/transition1x/train.py
@@ -570,6 +570,8 @@ if __name__ == "__main__":
 
     hydragnn.utils.model.save_model(model, optimizer, log_name)
     hydragnn.utils.profiling_and_tracing.print_timers(verbosity)
+    if writer is not None:
+        writer.close()
 
     if tr.has("GPTLTracer"):
         import gptl4py as gp

--- a/examples/zinc/zinc.py
+++ b/examples/zinc/zinc.py
@@ -109,3 +109,6 @@ hydragnn.train.train_validate_test(
     log_name,
     verbosity,
 )
+
+if writer is not None:
+    writer.close()

--- a/hydragnn/run_training.py
+++ b/hydragnn/run_training.py
@@ -180,3 +180,6 @@ def _(config: dict, use_deepspeed=False):
     save_model(model, optimizer, log_name, use_deepspeed=use_deepspeed)
 
     print_timers(config["Verbosity"]["level"])
+
+    if writer is not None:
+        writer.close()

--- a/tests/test_datasetclass_inheritance.py
+++ b/tests/test_datasetclass_inheritance.py
@@ -200,6 +200,9 @@ def unittest_train_model_dataset_class_inheritance(
         create_plots=True,
     )
 
+    if writer is not None:
+        writer.close()
+
 
 # Test vector output
 ## FIXME: this is temporarily disabled to avoid multiple instantiations of DDP


### PR DESCRIPTION
This PR adds a quick fix to ensure that the TensorBoard writer is properly closed in all examples.

We opened the writer using:
```
writer = hydragnn.utils.get_summary_writer(log_name)
```
but many examples did not explicitly close it. This sometimes resulted in TensorBoard logs not being written out cleanly.

To address this, I added the following snippet at the end of all examples
```
    if writer is not None:
        writer.close()
```
This will the logs are flushed and closed properly.