### PR TITLE
Enable bf16 support in PyTorch/PyG and DeepSpeed

### DIFF
--- a/hydragnn/run_prediction.py
+++ b/hydragnn/run_prediction.py
@@ -27,7 +27,7 @@ from hydragnn.postprocess.postprocess import output_denormalize
 deepspeed_available = True
 try:
     import deepspeed
-except ImportError:
+except:
     deepspeed_available = False
 
 

--- a/hydragnn/run_training.py
+++ b/hydragnn/run_training.py
@@ -41,7 +41,7 @@ from hydragnn.train.train_validate_test import train_validate_test
 deepspeed_available = True
 try:
     import deepspeed
-except ImportError:
+except:
     deepspeed_available = False
 
 

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -27,7 +27,7 @@ import os
 
 from torch.profiler import record_function
 
-from hydragnn.utils.distributed import get_comm_size_and_rank
+from hydragnn.utils.distributed import get_comm_size_and_rank, print_peak_memory
 import torch.distributed as dist
 import pickle
 
@@ -576,10 +576,6 @@ def train(
                 tr.stop("backward_sync")
         tr.stop("backward", **syncopt)
         tr.start("opt_step", **syncopt)
-        print_distributed(
-            verbosity,
-            f"Memory used {torch.cuda.max_memory_allocated()/1e9} GB, before opt",
-        )
         # print_peak_memory(verbosity, "Max memory allocated before optimizer step")
         if use_deepspeed:
             model.step()
@@ -589,10 +585,6 @@ def train(
                 scaler.update()
             else:
                 opt.step()
-        print_distributed(
-            verbosity,
-            f"Memory used {torch.cuda.max_memory_allocated()/1e9} GB, after opt",
-        )
         # print_peak_memory(verbosity, "Max memory allocated after optimizer step")
         tr.stop("opt_step", **syncopt)
         profiler.step()

--- a/hydragnn/utils/distributed/__init__.py
+++ b/hydragnn/utils/distributed/__init__.py
@@ -4,6 +4,7 @@ from .distributed import (
     get_device,
     get_device_name,
     get_device_from_name,
+    get_local_rank,
     is_model_distributed,
     get_distributed_model,
     distributed_model_wrapper,

--- a/hydragnn/utils/distributed/distributed.py
+++ b/hydragnn/utils/distributed/distributed.py
@@ -456,7 +456,8 @@ def print_peak_memory(verbosity_level, prefix):
         device = get_device()
         print_distributed(
             verbosity_level,
-            f"{prefix}: {torch.cuda.max_memory_allocated(device) // 1e6}MB ",
+            f"{prefix}: {torch.cuda.max_memory_allocated(device)/1e9} GB",
+            f"{torch.cuda.max_memory_cached()/1e9} GB",
         )
 
 

--- a/hydragnn/utils/optimizer/optimizer.py
+++ b/hydragnn/utils/optimizer/optimizer.py
@@ -5,7 +5,7 @@ from torch.distributed.optim import ZeroRedundancyOptimizer
 deepspeed_available = True
 try:
     import deepspeed
-except ImportError:
+except:
     deepspeed_available = False
 
 


### PR DESCRIPTION
This update adds support for bf16 in PyTorch/PyG with DeepSpeed integration. 

Main updates:
* Incorporated Pei’s initial bf16 implementation.
* Enabled bf16 support in DeepSpeed.
* Updated `distributed_model_wrapper` to toggle bf16 mode with or without DeepSpeed.
* Main example to demonstrate those changes is `examples/multidataset_deepspeed/train.py`