### PR TITLE
Set CUDA device before NCCL initialization for distributed GFM runs

### DIFF
--- a/examples/multidataset_hpo_sc26/gfm_mlip_all_mpnn.py
+++ b/examples/multidataset_hpo_sc26/gfm_mlip_all_mpnn.py
@@ -178,7 +178,12 @@ if __name__ == "__main__":
     parser.add_argument("--correlation", type=int, help="correlation", default=None)
     parser.add_argument("--nvme", action="store_true", help="use NVME")
     parser.add_argument("--startfrom", type=str, help="startfrom", default=None)
-    parser.add_argument("--datadir", type=str, help="path to directory containing .bp dataset files", default=None)
+    parser.add_argument(
+        "--datadir",
+        type=str,
+        help="path to directory containing .bp dataset files",
+        default=None,
+    )
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
@@ -211,7 +216,9 @@ if __name__ == "__main__":
     node_feature_names = ["atomic_number", "cartesian_coordinates", "forces"]
     node_feature_dims = [1, 3, 3]
     dirpwd = os.path.dirname(os.path.abspath(__file__))
-    datadir = args.datadir if args.datadir is not None else os.path.join(dirpwd, "dataset")
+    datadir = (
+        args.datadir if args.datadir is not None else os.path.join(dirpwd, "dataset")
+    )
     ##################################################################################################################
     input_filename = os.path.join(dirpwd, args.inputfile)
     ##################################################################################################################

--- a/examples/multidataset_hpo_sc26/gfm_mlip_all_mpnn.py
+++ b/examples/multidataset_hpo_sc26/gfm_mlip_all_mpnn.py
@@ -178,6 +178,7 @@ if __name__ == "__main__":
     parser.add_argument("--correlation", type=int, help="correlation", default=None)
     parser.add_argument("--nvme", action="store_true", help="use NVME")
     parser.add_argument("--startfrom", type=str, help="startfrom", default=None)
+    parser.add_argument("--datadir", type=str, help="path to directory containing .bp dataset files", default=None)
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument(
@@ -210,7 +211,7 @@ if __name__ == "__main__":
     node_feature_names = ["atomic_number", "cartesian_coordinates", "forces"]
     node_feature_dims = [1, 3, 3]
     dirpwd = os.path.dirname(os.path.abspath(__file__))
-    datadir = os.path.join(dirpwd, "dataset")
+    datadir = args.datadir if args.datadir is not None else os.path.join(dirpwd, "dataset")
     ##################################################################################################################
     input_filename = os.path.join(dirpwd, args.inputfile)
     ##################################################################################################################
@@ -428,9 +429,7 @@ if __name__ == "__main__":
             ndata_list = list()
             pna_deg_list = list()
             for model in modellist:
-                fname = os.path.join(
-                    os.path.dirname(__file__), "./dataset/%s-v2.bp" % model
-                )
+                fname = os.path.join(datadir, "%s-v2.bp" % model)
                 with adios2_open(fname, "r", MPI.COMM_SELF) as f:
                     f.__next__()
                     ndata = f.read_attribute("trainset/ndata").item()
@@ -598,7 +597,7 @@ if __name__ == "__main__":
         local_comm_rank = local_comm.Get_rank()
         local_comm_size = local_comm.Get_size()
 
-        fname = os.path.join(os.path.dirname(__file__), "./dataset/%s-v2.bp" % mymodel)
+        fname = os.path.join(datadir, "%s-v2.bp" % mymodel)
 
         ## FIXME: only for Frontier NVME
         bbpath = f"/mnt/bb/{os.getenv('USER')}"
@@ -826,9 +825,7 @@ if __name__ == "__main__":
         ## No DDStore. Each process opens multiple adios files.
         filename_list = list()
         for model in modellist:
-            fname = os.path.join(
-                os.path.dirname(__file__), "./dataset/%s-v2.bp" % model
-            )
+            fname = os.path.join(datadir, "%s-v2.bp" % model)
             filename_list.append(fname)
 
         kwargs = {"var_config": var_config, "keys": common_variable_names}

--- a/hydragnn/utils/distributed/distributed.py
+++ b/hydragnn/utils/distributed/distributed.py
@@ -230,6 +230,11 @@ def setup_ddp(use_deepspeed=False):
                 ## Setting LOCAL_RANK complicts with DeviceMesh when using the srun "--gpus-per-task=1" option
                 # os.environ["LOCAL_RANK"] = str(get_local_rank())
 
+            if backend == "nccl" and torch.cuda.is_available():
+                local_rank = get_local_rank()
+                if local_rank < torch.cuda.device_count():
+                    torch.cuda.set_device(local_rank)
+
             if (backend == "gloo") and ("GLOO_SOCKET_IFNAME" not in os.environ):
                 ifname = find_ifname(master_addr)
                 if ifname is not None:


### PR DESCRIPTION
## Title

Set CUDA device before NCCL initialization for distributed GFM runs

## Summary

- Add a `--datadir` option to `examples/multidataset_hpo_sc26/gfm_mlip_all_mpnn.py` so benchmark/data locations do not have to live under the example directory.
- Set the local CUDA device before initializing the NCCL process group. This ensures each rank has a deterministic current device during distributed initialization.

## Motivation

On Perlmutter, the GFM MLIP multidataset workflow can hang during FSDP v2/NCCL setup when ranks initialize distributed communication before selecting their local CUDA device. The benchmark wrapper can provide the data location, but the example script needs a `--datadir` argument to make that usable without editing source paths.

## Testing

Tested with the AmSC HydraGNN Perlmutter benchmark wrapper, using 1 GPU node, 4 ranks, Alexandria data under `/global/cfs/cdirs/amsc013/ccasert/hydragnn_data/dataset`, and a short `MAX_NUM_BATCH=1` run.

Relevant run configuration:

```bash
sbatch -A <gpu_account> \
  --export=ALL,HYDRAGNN_USE_FSDP=1,HYDRAGNN_FSDP_VERSION=2,DATA_DIR=/global/cfs/cdirs/amsc013/ccasert/hydragnn_data/dataset,MAX_NUM_BATCH=1 \
  run_perlmutter.sh
```

The benchmark wrapper sets `TRITON_CACHE_DIR=$SCRATCH/cache/triton` by default to avoid DeepSpeed/Triton cache shutdown hangs from home-directory cache locking.

Observed behavior:

- With the data-dir support but without the CUDA-device selection fix, the FSDP v2 run hangs during distributed/FSDP setup.
- With this change, the same FSDP v2 run trains for the short two-epoch smoke configuration and exits cleanly.

The Perlmutter-specific wrapper and environment details are maintained in the AmSC benchmarks repository; this PR keeps the HydraGNN changes limited to the portable example/data path and distributed initialization behavior.
