### PR TITLE
FNET cov80: missingness-aware T-GCN forecaster

### DIFF
--- a/examples/fnet_temporal_anomaly_detection/README.md
+++ b/examples/fnet_temporal_anomaly_detection/README.md
@@ -1,0 +1,73 @@
+# FNET temporal anomaly detection (cov80 T-GCN forecaster)
+
+Multi-feature spatiotemporal forecasting on FNET PMU data, built on HydraGNN's
+`TemporalGCN`. This is the HydraGNN port of the standalone T-GCN "cov80"
+forecaster: it tolerates missing PMU samples by **keeping and masking** gaps
+(rather than dropping them), trains with a **masked loss** so imputed targets do
+not contribute, and reports **masked metrics**.
+
+## Pipeline
+
+1. Load one day of FNET parquet (`[FDRID]-[device]-[date].parquet`) + `FDRLocation.xlsx`.
+2. Per-device dynamic features: `freq_dev, rocof, angle_delta, volt_dev`.
+3. **Keep-and-mask alignment** onto a uniform `dt` grid: gaps are kept as NaN and
+   recorded in `observed_mask`; devices below `--min_device_coverage` and timesteps
+   below `--min_step_coverage` are dropped.
+4. **Impute** the remaining gaps (interpolate → ffill/bfill → train-only median).
+5. **Train-only feature scaling** over observed values (`--scaling`).
+6. Geographic k-NN graph (`exp(-d/σ)` haversine) with edge weights.
+7. Sliding-window `Data` objects:
+   - `x_seq = [N, Tin, F_dyn + 1 (observed-mask) + F_static]`
+   - `y     = [N, H * len(out_features)]`
+   - `observed_mask = [N, H * len(out_features)]` (forecast-window loss mask)
+8. **Slice-then-window 4-way split** (train/val/test/pred) — each segment is
+   windowed independently so no window straddles a boundary (no leakage).
+9. Train `TemporalGCN`; score val/test/pred with masked MSE/MAE/RMSE/R²/MAPE.
+
+## Usage
+
+```bash
+# Pre-process + cache only
+python fnet_temporal_anomaly_detection.py --preonly \
+    --data_root <grid-data> --date <date>
+
+# Train from an existing cache
+python fnet_temporal_anomaly_detection.py --date <date>
+
+# End to end (preprocess -> cache -> train)
+python fnet_temporal_anomaly_detection.py --do_all \
+    --data_root <grid-data> --date <date> --num_epoch 30
+```
+
+> **Regenerate the cache after any preprocessing change.** The cache stores the
+> windowed `Data` objects (mask channel, loss mask, 4-way split, scaling). An old
+> cache will silently train on stale tensors — delete
+> `dataset/fnet_<date>.pickle/` + `dataset/fnet_<date>_meta.pkl` and re-run
+> `--preonly`/`--do_all`.
+
+## cov80 flags
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `--min_device_coverage` | 0.5 | Drop a device covering less than this fraction of the grid |
+| `--min_step_coverage` | 0.8 | Keep a timestep only if ≥ this fraction of nodes are observed |
+| `--short_gap_steps` | 10 | Max gap (steps) filled by linear interpolation |
+| `--medium_gap_steps` | 300 | Max gap (steps) filled by ffill/bfill |
+| `--scaling` | `global` | `none` / `per_node` / `global` / `robust` (train-only, observed-only) |
+| `--scaled_clip_value` | 10.0 | For `--scaling robust`: clip to ± this (≤0 disables) |
+| `--out_features` | `0 2 3` | Output channels into `[0=freq_dev,1=rocof,2=angle_delta,3=volt_dev]`; use `0 3` for the 2-output parity set |
+| `--train_frac/--val_frac/--test_frac/--pred_frac` | 0.8/0.05/0.05/0.1 | 4-way time split |
+
+Model knobs are in `fnet_temporal_anomaly_detection.json`; `loss_function_type`
+must be `mse` (the masked-loss path is MSE-specific).
+
+## Outputs (`--out_dir`, default `outputs_fnet_temporal/`)
+
+- `metrics.json` — masked MSE/MAE/RMSE/R²/MAPE per split, in scaled + original units
+- `preds_{val,test,pred}.npy`, `ys_*.npy`, `masks_*.npy` — `[W, N, H, F_out]`
+- `feat_mean/feat_std/out_idx.npy`, `X.npy`, `tvec.npy`, `A_hat.npy`, `sites.csv`
+
+## Notes
+
+- The masked loss requires the `mask=` support in `Base.loss`;
+  without it the run still trains, just unmasked.

--- a/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.json
+++ b/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.json
@@ -22,7 +22,7 @@
             "task_weights": [1.0]
         },
         "Variables_of_interest": {
-            "input_node_features": [0, 1, 2, 3, 4, 5, 6, 7],
+            "input_node_features": [0, 1, 2, 3, 4, 5, 6, 7, 8],
             "output_names": ["multi_forecast"],
             "output_index": [0],
             "output_dim": [30],

--- a/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.json
+++ b/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.json
@@ -37,7 +37,7 @@
             "min_delta": 1e-3,
             "Checkpoint": true,
             "checkpoint_warmup": 5,
-            "loss_function_type": "smooth_l1",
+            "loss_function_type": "mse",
             "batch_size": 32,
             "continue": 0,
             "startfrom": "existing_model",

--- a/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
+++ b/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
@@ -400,6 +400,64 @@ def robust_impute_feature_matrix(
     return out
 
 
+def scale_features(X, observed_mask, train_end, method, clip_value=10.0):
+    """Train-only feature scaling computed over OBSERVED values only (imputed
+    cells are excluded from the statistics). Returns (X_scaled, center, scale),
+    with center/scale shaped (N, F) so they broadcast against X [T, N, F] and
+    round-trip through the existing per-node denormalization in the diagnostics.
+
+    method:
+      none      - identity (no scaling)
+      per_node  - per-(node, channel) mean/std (transductive; each PMU whitened)
+      global    - global per-channel mean/std (one center/scale per feature)
+      robust    - global per-channel median/IQR + clip to +/- clip_value
+
+    The observed-mask input channel is added later (during windowing), so it is
+    never seen here and stays unscaled.
+    """
+    _, N, F = X.shape
+    center = np.zeros((N, F), dtype=np.float32)
+    scale = np.ones((N, F), dtype=np.float32)
+    if method == "none":
+        return X.astype(np.float32), center, scale
+
+    obs = observed_mask[:train_end] > 0.5  # [train_end, N]
+    Xtr = X[:train_end]  # [train_end, N, F]
+
+    if method == "per_node":
+        for j in range(N):
+            m = obs[:, j]
+            if not m.any():
+                continue
+            vals = Xtr[m, j, :]  # [n_obs, F]
+            center[j] = vals.mean(axis=0)
+            s = vals.std(axis=0)
+            scale[j] = np.where(s < 1e-8, np.float32(1.0), s)
+    elif method in ("global", "robust"):
+        for f in range(F):
+            vals = Xtr[:, :, f][obs]  # 1-D observed values for channel f
+            if vals.size == 0:
+                continue
+            if method == "robust":
+                c = float(np.median(vals))
+                q25, q75 = np.percentile(vals, [25, 75])
+                s = float(q75 - q25)
+            else:  # global mean/std
+                c = float(vals.mean())
+                s = float(vals.std())
+            if not (np.isfinite(s) and s >= 1e-8):
+                s = 1.0
+            center[:, f] = c  # same per-channel value tiled across nodes
+            scale[:, f] = s
+    else:
+        raise ValueError(f"Unknown --scaling method: {method}")
+
+    Xs = (X - center[None, :, :]) / scale[None, :, :]
+    if method == "robust" and clip_value and clip_value > 0:
+        Xs = np.clip(Xs, -clip_value, clip_value)
+    return Xs.astype(np.float32), center, scale
+
+
 # ─────────────────────────────────────────────────────────────────────────────
 # 3.  Geographic k-NN graph + static node embeddings
 # ─────────────────────────────────────────────────────────────────────────────
@@ -790,25 +848,17 @@ def preprocess_stage(args, cache_dir: Path):
         f"unique grids = {len(grid_name_to_idx)}"
     )
 
-    # Per-(node, channel) standardization computed only on the train time
-    # slice. This acts as a frozen per-node bias + scale: each PMU gets its
-    # own zero-point and variance for each of the 4 dynamic features, so the
-    # model only has to predict residuals around the node's own baseline.
-    # Shapes: feat_mean / feat_std are (N, F_dyn); broadcast over time.
-    train_end_t = max(int(T * args.train_frac), 2)
-    feat_mean = X[:train_end_t].mean(axis=0).astype(np.float32)  # (N, F_dyn)
-    feat_std = X[:train_end_t].std(axis=0).astype(np.float32)  # (N, F_dyn)
-    feat_std = np.where(feat_std < 1e-8, np.float32(1.0), feat_std)
-    X = ((X - feat_mean[None, :, :]) / feat_std[None, :, :]).astype(np.float32)
-    print(
-        f"[scale] per-node mean shape={feat_mean.shape}  "
-        f"channel-avg={np.array2string(feat_mean.mean(axis=0), precision=4)}  "
-        f"channel-spread(std-of-means)={np.array2string(feat_mean.std(axis=0), precision=4)}"
+    # Train-only feature scaling over OBSERVED values (imputed cells excluded
+    # from the statistics). Method via --scaling; the observed-mask channel is
+    # added later (in windowing), so it is never scaled. train_end_t is the same
+    # train slice used for the imputation fallback above.
+    X, feat_mean, feat_std = scale_features(
+        X, observed_mask, train_end_t, args.scaling, clip_value=args.scaled_clip_value
     )
     print(
-        f"[scale] per-node std  shape={feat_std.shape}   "
-        f"channel-avg={np.array2string(feat_std.mean(axis=0), precision=4)}  "
-        f"channel-spread(std-of-stds)={np.array2string(feat_std.std(axis=0), precision=4)}"
+        f"[scale] method={args.scaling}  center/scale shape={feat_mean.shape}  "
+        f"channel-avg-center={np.array2string(feat_mean.mean(axis=0), precision=4)}  "
+        f"channel-avg-scale={np.array2string(feat_std.mean(axis=0), precision=4)}"
     )
 
     # Slice the timeline into 4 contiguous segments, THEN window each segment
@@ -880,6 +930,7 @@ def preprocess_stage(args, cache_dir: Path):
         "F_static": int(grid_embed.shape[1]),
         "feat_mean": feat_mean,
         "feat_std": feat_std,
+        "scaling": args.scaling,
         "out_idx": np.array([0, 2, 3], dtype=np.int64),
         "predict_delta": bool(args.predict_delta),
     }
@@ -1158,6 +1209,21 @@ def build_argparser() -> argparse.ArgumentParser:
         type=int,
         default=300,
         help="Max gap length (steps) filled by ffill/bfill during impute",
+    )
+    p.add_argument(
+        "--scaling",
+        type=str,
+        default="global",
+        choices=["none", "per_node", "global", "robust"],
+        help="Train-only feature scaling over observed values. Default 'global' "
+        "(per-channel mean/std). per_node is transductive; robust = median/IQR + clip",
+    )
+    p.add_argument(
+        "--scaled_clip_value",
+        type=float,
+        default=10.0,
+        help="For --scaling robust: clip standardized features to +/- this value "
+        "(<= 0 disables clipping)",
     )
     # Cache
     p.add_argument(

--- a/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
+++ b/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
@@ -599,6 +599,23 @@ def make_window_dataset(
             # so PyG's DataLoader concatenates it edge-aligned with edge_index
             # across a batch. Consumed by GCNConv via TemporalGCN's conv string.
             data.edge_weight = edge_weight.clone()
+        if observed_mask is not None:
+            # Forecast-window LOSS mask, aligned element-for-element with y (same
+            # permute/reshape). The per-(t, node) observed flag is broadcast over
+            # the F_OUT output channels. Consumed by Base.loss(mask=...) so imputed
+            # targets are excluded from the objective. NOTE: distinct from the
+            # input-window mask channel baked into x_seq above (different window).
+            m_block = np.repeat(
+                observed_mask[s + 1 : s + 1 + H][:, :, None], F_OUT, axis=2
+            )  # [H, N, F_OUT]
+            y_mask = (
+                torch.from_numpy(m_block)
+                .permute(1, 0, 2)
+                .reshape(N, H * F_OUT)
+                .contiguous()
+            )
+            assert y_mask.shape == y.shape
+            data.observed_mask = y_mask
         dataset.append(data)
     return dataset
 

--- a/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
+++ b/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
@@ -93,6 +93,7 @@ except ImportError:
 EARTH_RADIUS_KM = 6371.0
 F_DYN = 4  # freq_dev, rocof, angle_delta, volt_dev
 F_OUT = 3  # freq_dev, angle_delta, volt_dev (RoCoF is input-only)
+F_MASK = 1  # observed-mask input channel (1 = observed, 0 = imputed/missing)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -501,6 +502,7 @@ def make_window_dataset(
     edge_index,
     Tin: int,
     H: int,
+    observed_mask=None,
     edge_weight=None,
     predict_delta: bool = False,
     max_windows: int | None = None,
@@ -508,9 +510,13 @@ def make_window_dataset(
     """Build sliding-window torch_geometric Data objects.
 
     Per window:
-      data.x_seq : [N, Tin, F_dyn + F_static]   (static features tiled across time)
+      data.x_seq : [N, Tin, F_dyn (+1 mask) + F_static]   (mask + static tiled in time)
       data.y     : [N, H * F_out]               (multi-step target per node, flat)
       data.y_loc : [[0, N]]                     single output head spans all N nodes
+
+    If ``observed_mask`` ([T, N], 1=observed / 0=imputed) is given, it is tiled as
+    an extra input channel between the dynamic and static features so the model
+    can condition on which inputs are real.
 
     If ``predict_delta`` is True, the target is the per-step increment
     ``X[s+1+h] - X[s]`` (in the standardized feature space) rather than the
@@ -548,9 +554,21 @@ def make_window_dataset(
     for s in start_indices:
         # Dynamic input: shape [Tin, N, F_dyn] -> [N, Tin, F_dyn]
         x_dyn = torch.from_numpy(X[s - Tin + 1 : s + 1]).permute(1, 0, 2).contiguous()
+        channels = [x_dyn]
+        if observed_mask is not None:
+            # Observed-mask channel (1=observed, 0=imputed/missing), placed between
+            # the dynamic and static features. [Tin, N] -> [N, Tin, 1].
+            mask_win = (
+                torch.from_numpy(observed_mask[s - Tin + 1 : s + 1])
+                .permute(1, 0)
+                .unsqueeze(-1)
+                .contiguous()
+            )
+            channels.append(mask_win)
+        channels.append(static_t)
         x_seq = torch.cat(
-            [x_dyn, static_t], dim=-1
-        ).contiguous()  # [N, Tin, F_dyn+F_static]
+            channels, dim=-1
+        ).contiguous()  # [N, Tin, F_dyn(+1)+F_static]
 
         # Multi-step target: shape [H, N, F_out] -> [N, H*F_out]
         y_block = X[s + 1 : s + 1 + H][:, :, out_idx]  # [H, N, F_out]
@@ -798,6 +816,7 @@ def preprocess_stage(args, cache_dir: Path):
             edge_index,
             Tin=args.Tin,
             H=args.horizon,
+            observed_mask=observed_mask[lo:hi],
             edge_weight=edge_weight,
             predict_delta=bool(args.predict_delta),
             max_windows=args.max_windows,
@@ -839,6 +858,7 @@ def preprocess_stage(args, cache_dir: Path):
         "Tin": int(args.Tin),
         "horizon": int(args.horizon),
         "F_dyn": F_DYN,
+        "F_mask": F_MASK,
         "F_out": F_OUT,
         "F_static": int(grid_embed.shape[1]),
         "feat_mean": feat_mean,
@@ -905,11 +925,12 @@ def train_stage(args, cache_dir: Path):
         f"[cache] train/val/test/pred = "
         f"{len(trainset)}/{len(valset)}/{len(testset)}/{len(predset)}  "
         f"| sites={len(meta['sites'])}, Tin={meta['Tin']}, H={meta['horizon']}, "
-        f"F_dyn={meta['F_dyn']}, F_static={meta['F_static']}, F_out={meta['F_out']}"
+        f"F_dyn={meta['F_dyn']}, F_mask={meta.get('F_mask', 0)}, "
+        f"F_static={meta['F_static']}, F_out={meta['F_out']}"
     )
 
     # Patch JSON config to match cached tensor shapes.
-    F_total = meta["F_dyn"] + meta["F_static"]
+    F_total = meta["F_dyn"] + meta.get("F_mask", 0) + meta["F_static"]
     target_dim = meta["horizon"] * meta["F_out"]
     config["NeuralNetwork"]["Variables_of_interest"]["input_node_features"] = list(
         range(F_total)

--- a/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
+++ b/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
@@ -249,24 +249,36 @@ def load_day_folder(date_dir: Path, limit: int = None, min_samples: int = 1000):
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-def stack_node_features(fdr_ids, data, dt: float):
-    """Resample every device onto a common uniform time grid.
+def stack_node_features(
+    fdr_ids,
+    data,
+    dt: float,
+    min_device_coverage: float = 0.5,
+    min_step_coverage: float = 0.8,
+):
+    """Resample every device onto a common uniform time grid, KEEPING gaps.
 
-    PMU streams are not phase-locked across sensors and individual streams
-    have small gaps. Doing a strict timestamp inner-join would either return
-    nothing (sub-sample skew) or shrink to tens of rows (many small gaps).
+    PMU streams are not phase-locked across sensors and individual streams have
+    small gaps. We build a single regular grid at step ``dt`` over the common
+    window and reindex each device onto it with nearest-neighbor matching within
+    tolerance ``dt / 2``.
 
-    Instead we build a single regular grid at step ``dt`` covering the
-    intersection ``[max(start_i), min(end_i)]`` and reindex each device
-    onto it with nearest-neighbor matching within tolerance ``dt / 2``.
-    Devices that produce all-NaN after reindex are dropped. Any time slot
-    where any kept device is missing is dropped at the end.
+    cov80 "keep-and-mask": rather than dropping every slot where a device is
+    missing (which discards exactly the disturbance-adjacent data the downstream
+    detector needs), missing cells are KEPT as NaN and recorded in
+    ``observed_mask``. Devices covering less than ``min_device_coverage`` of the
+    grid are still dropped (a near-dead sensor would be almost entirely imputed
+    and would pollute its graph neighbors). Timesteps where fewer than
+    ``min_step_coverage`` of the retained nodes are present are dropped. The
+    remaining NaNs are imputed downstream; ``observed_mask`` lets the loss ignore
+    the imputed targets.
 
     Returns
     -------
-    tvec     : np.ndarray  (T,)        seconds since first slot
-    X        : np.ndarray  (T, N, 4)   dynamic features per node per slot
-    keep_ids : list[int]               FDR ids that survived alignment
+    tvec          : np.ndarray  (T,)       seconds since first kept slot
+    X             : np.ndarray  (T, N, 4)  dynamic features; NaN at gaps (pre-impute)
+    observed_mask : np.ndarray  (T, N)     1.0 where the node was actually observed
+    keep_ids      : list[int]              FDR ids that survived alignment
     """
     feats = ("freq_dev", "rocof", "angle_delta", "volt_dev")
     starts = pd.Series([data[fid]["timestamp"].iloc[0] for fid in fdr_ids])
@@ -306,7 +318,7 @@ def stack_node_features(fdr_ids, data, dt: float):
         )
         re = sub.reindex(grid, method="nearest", tolerance=tol)
         coverage = re[list(feats)].notna().all(axis=1).mean()
-        if coverage < 0.95:
+        if coverage < min_device_coverage:
             dropped.append((fid, float(coverage)))
             continue
         re.columns = [f"{fid}:{c}" for c in feats]
@@ -314,32 +326,77 @@ def stack_node_features(fdr_ids, data, dt: float):
         keep_ids.append(fid)
     if not keep_ids:
         raise RuntimeError(
-            "No device covered at least 95% of the common grid; "
-            "consider widening the percentile window or using a different day."
+            f"No device covered at least {min_device_coverage:.0%} of the common "
+            f"grid; lower --min_device_coverage or use a different day."
         )
     if dropped:
         print(
-            f"[align] WARNING: {len(dropped)} device(s) dropped for low coverage "
-            f"(< 95%). First: {[d[0] for d in dropped[:5]]}"
+            f"[align] WARNING: {len(dropped)} device(s) dropped for coverage "
+            f"< {min_device_coverage:.0%}. First: {[d[0] for d in dropped[:5]]}"
         )
 
     M = pd.concat(columns, axis=1)
-    # Keep only slots where every retained device is present.
-    valid_mask = M.notna().all(axis=1)
-    M = M.loc[valid_mask]
-    if len(M) == 0:
-        raise RuntimeError("After alignment, no time slot has all devices present.")
 
-    tvec = (
-        (M.index - M.index[0]).total_seconds().to_numpy(dtype=np.float32)
+    # Per-(timestep, node) observed mask: a node is "observed" at t when all of
+    # its features are present after the nearest-reindex (a gap leaves all NaN).
+    present = np.stack(
+        [
+            M[[f"{fid}:{c}" for c in feats]].notna().all(axis=1).to_numpy()
+            for fid in keep_ids
+        ],
+        axis=1,
+    )  # [n_slots, N] bool
+
+    # Keep timesteps with enough node coverage (vs. requiring ALL nodes present).
+    keep_steps = present.mean(axis=1) >= min_step_coverage
+    if not keep_steps.any():
+        raise RuntimeError(
+            f"No timestep reached {min_step_coverage:.0%} node coverage; "
+            f"lower --min_step_coverage or use a different day."
+        )
+    M = M[keep_steps]
+    observed_mask = present[keep_steps].astype(np.float32)  # [T, N]
+    print(
+        f"[align] kept {int(keep_steps.sum())}/{int(keep_steps.size)} timesteps "
+        f"(>= {min_step_coverage:.0%} node coverage); "
+        f"observed fraction = {float(observed_mask.mean()):.3f}"
     )
+
+    tvec = (M.index - M.index[0]).total_seconds().to_numpy(dtype=np.float32)
     ordered = [f"{fid}:{c}" for fid in keep_ids for c in feats]
     X = (
         M[ordered]
         .to_numpy(dtype=np.float32)
         .reshape(len(tvec), len(keep_ids), len(feats))
-    )
-    return tvec, X, keep_ids
+    )  # contains NaN at gaps (imputed downstream)
+    return tvec, X, observed_mask, keep_ids
+
+
+def robust_impute_feature_matrix(
+    feature_matrix, observed_mask, train_end, short_gap_steps, medium_gap_steps
+):
+    """Per-sensor gap imputation: linear interpolate (short gaps) -> ffill/bfill
+    (medium gaps) -> train-only median fallback.
+
+    The fallback median is computed from observed *training* values only, so
+    imputation never leaks future/val/test information into the train segment.
+    Ported from the standalone T-GCN (train.py). Operates on one feature channel
+    at a time: ``feature_matrix`` and ``observed_mask`` are both [T, N].
+    """
+    out = feature_matrix.copy()
+    _, N = out.shape
+    for j in range(N):
+        col = pd.Series(out[:, j], dtype=float)
+        train_obs = observed_mask[:train_end, j] > 0.5
+        train_vals = out[:train_end, j][train_obs]
+        fallback = float(np.nanmedian(train_vals)) if train_vals.size > 0 else 0.0
+        col = col.interpolate(
+            method="linear", limit=short_gap_steps, limit_direction="both"
+        )
+        col = col.ffill(limit=medium_gap_steps).bfill(limit=medium_gap_steps)
+        col = col.fillna(fallback)
+        out[:, j] = col.to_numpy(dtype=np.float32)
+    return out
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -640,7 +697,13 @@ def preprocess_stage(args, cache_dir: Path):
         )
     print(f"[meta]  {len(fdr_ids)} devices retained after metadata filtering")
 
-    tvec, X, kept_after_align = stack_node_features(fdr_ids, data, dt)
+    tvec, X, observed_mask, kept_after_align = stack_node_features(
+        fdr_ids,
+        data,
+        dt,
+        min_device_coverage=args.min_device_coverage,
+        min_step_coverage=args.min_step_coverage,
+    )
     if len(kept_after_align) != len(fdr_ids):
         keep_set = set(kept_after_align)
         sites = [
@@ -657,10 +720,24 @@ def preprocess_stage(args, cache_dir: Path):
     if args.stride > 1:
         tvec = tvec[:: args.stride]
         X = X[:: args.stride]
+        observed_mask = observed_mask[:: args.stride]
         dt = dt * args.stride
         print(f"[align] applied stride={args.stride}: dt -> {dt:.4f} s")
     T, N, F = X.shape
-    print(f"[align] X shape = {(T, N, F)} (after timestamp inner-join)")
+    print(f"[align] X shape = {(T, N, F)} (gaps kept; observed_mask attached)")
+
+    # Impute the gaps (NaN) left by keep-and-mask alignment so the model sees a
+    # dense input. Train-only median fallback avoids leakage; observed_mask still
+    # marks these cells so the masked loss can ignore the imputed *targets*.
+    train_end_t = max(int(T * args.train_frac), 2)
+    for f in range(F):
+        X[:, :, f] = robust_impute_feature_matrix(
+            X[:, :, f],
+            observed_mask,
+            train_end_t,
+            args.short_gap_steps,
+            args.medium_gap_steps,
+        )
 
     edge_index, edge_weight, A_hat = build_geo_knn_graph(
         meta_active, k=args.k, sigma_km=args.sigma_km
@@ -751,6 +828,7 @@ def preprocess_stage(args, cache_dir: Path):
         "sites": sites,
         "tvec": tvec,
         "X": X,
+        "observed_mask": observed_mask,
         "dt": float(dt),
         "edge_index": edge_index,
         "edge_weight": edge_weight,
@@ -1016,6 +1094,32 @@ def build_argparser() -> argparse.ArgumentParser:
         type=int,
         default=1,
         help="Temporal subsampling stride applied after alignment",
+    )
+    # Coverage / imputation (cov80 keep-and-mask)
+    p.add_argument(
+        "--min_device_coverage",
+        type=float,
+        default=0.5,
+        help="Drop a device covering less than this fraction of the time grid "
+        "(retained devices' gaps are imputed + masked)",
+    )
+    p.add_argument(
+        "--min_step_coverage",
+        type=float,
+        default=0.8,
+        help="Keep a timestep only if at least this fraction of nodes are observed",
+    )
+    p.add_argument(
+        "--short_gap_steps",
+        type=int,
+        default=10,
+        help="Max gap length (steps) filled by linear interpolation during impute",
+    )
+    p.add_argument(
+        "--medium_gap_steps",
+        type=int,
+        default=300,
+        help="Max gap length (steps) filled by ffill/bfill during impute",
     )
     # Cache
     p.add_argument(

--- a/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
+++ b/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
@@ -92,7 +92,7 @@ except ImportError:
 
 EARTH_RADIUS_KM = 6371.0
 F_DYN = 4  # freq_dev, rocof, angle_delta, volt_dev
-F_OUT = 3  # freq_dev, angle_delta, volt_dev (RoCoF is input-only)
+OUT_FEATURES_DEFAULT = [0, 2, 3]  # default outputs: freq_dev, angle_delta, volt_dev
 F_MASK = 1  # observed-mask input channel (1 = observed, 0 = imputed/missing)
 
 
@@ -561,6 +561,7 @@ def make_window_dataset(
     Tin: int,
     H: int,
     observed_mask=None,
+    out_idx=None,
     edge_weight=None,
     predict_delta: bool = False,
     max_windows: int | None = None,
@@ -593,13 +594,15 @@ def make_window_dataset(
     )
     pos = torch.zeros(N, 3)
     batch = torch.zeros(N, dtype=torch.long)
-    target_dim = H * F_OUT
+    out_idx = np.asarray(
+        OUT_FEATURES_DEFAULT if out_idx is None else out_idx, dtype=np.int64
+    )
+    F_out = len(out_idx)
+    target_dim = H * F_out
     # HydraGNN uses y_loc to slice y per output head; for a node-level head with
     # `output_dim` channels per node, dim_item = (y_loc[0,1] - y_loc[0,0]) / N,
     # so y_loc must span N * output_dim entries.
     y_loc = torch.tensor([[0, N * target_dim]], dtype=torch.int64)
-    # Output indices: freq_dev (0), angle_delta (2), volt_dev (3)
-    out_idx = np.array([0, 2, 3], dtype=np.int64)
 
     dataset = []
     start_indices = range(Tin - 1, T - H)
@@ -637,7 +640,7 @@ def make_window_dataset(
         y = (
             torch.from_numpy(y_block)
             .permute(1, 0, 2)  # [N, H, F_out]
-            .reshape(N, H * F_OUT)
+            .reshape(N, H * F_out)
             .contiguous()
         )
 
@@ -660,16 +663,16 @@ def make_window_dataset(
         if observed_mask is not None:
             # Forecast-window LOSS mask, aligned element-for-element with y (same
             # permute/reshape). The per-(t, node) observed flag is broadcast over
-            # the F_OUT output channels. Consumed by Base.loss(mask=...) so imputed
+            # the F_out output channels. Consumed by Base.loss(mask=...) so imputed
             # targets are excluded from the objective. NOTE: distinct from the
             # input-window mask channel baked into x_seq above (different window).
             m_block = np.repeat(
-                observed_mask[s + 1 : s + 1 + H][:, :, None], F_OUT, axis=2
-            )  # [H, N, F_OUT]
+                observed_mask[s + 1 : s + 1 + H][:, :, None], F_out, axis=2
+            )  # [H, N, F_out]
             y_mask = (
                 torch.from_numpy(m_block)
                 .permute(1, 0, 2)
-                .reshape(N, H * F_OUT)
+                .reshape(N, H * F_out)
                 .contiguous()
             )
             assert y_mask.shape == y.shape
@@ -876,6 +879,7 @@ def preprocess_stage(args, cache_dir: Path):
         ("test", n_train + n_val, n_train + n_val + n_test),
         ("pred", n_train + n_val + n_test, T),
     ]
+    out_idx = np.array(args.out_features, dtype=np.int64)
     seg_data = {
         name: make_window_dataset(
             X[lo:hi],
@@ -884,6 +888,7 @@ def preprocess_stage(args, cache_dir: Path):
             Tin=args.Tin,
             H=args.horizon,
             observed_mask=observed_mask[lo:hi],
+            out_idx=out_idx,
             edge_weight=edge_weight,
             predict_delta=bool(args.predict_delta),
             max_windows=args.max_windows,
@@ -926,12 +931,12 @@ def preprocess_stage(args, cache_dir: Path):
         "horizon": int(args.horizon),
         "F_dyn": F_DYN,
         "F_mask": F_MASK,
-        "F_out": F_OUT,
+        "F_out": int(len(out_idx)),
         "F_static": int(grid_embed.shape[1]),
         "feat_mean": feat_mean,
         "feat_std": feat_std,
         "scaling": args.scaling,
-        "out_idx": np.array([0, 2, 3], dtype=np.int64),
+        "out_idx": out_idx,
         "predict_delta": bool(args.predict_delta),
     }
     write_cache(
@@ -1054,15 +1059,28 @@ def train_stage(args, cache_dir: Path):
 
     raw_model = (model.module if hasattr(model, "module") else model).to(device)
     print("\n[score] Scoring val + test + pred windows ...")
-    preds_val, ys_val = _score_split(raw_model, val_loader, meta, device)
-    preds_test, ys_test = _score_split(raw_model, test_loader, meta, device)
-    preds_pred, ys_pred = _score_split(raw_model, pred_loader, meta, device)
-    val_mse = float(np.mean((preds_val - ys_val) ** 2))
-    test_mse = float(np.mean((preds_test - ys_test) ** 2))
-    pred_mse = float(np.mean((preds_pred - ys_pred) ** 2)) if preds_pred.size else float("nan")
-    print(f"[score] val MSE  = {val_mse:.6e}")
-    print(f"[score] test MSE = {test_mse:.6e}")
-    print(f"[score] pred MSE = {pred_mse:.6e}")
+    preds_val, ys_val, masks_val = _score_split(raw_model, val_loader, meta, device)
+    preds_test, ys_test, masks_test = _score_split(raw_model, test_loader, meta, device)
+    preds_pred, ys_pred, masks_pred = _score_split(raw_model, pred_loader, meta, device)
+
+    # Masked metrics (observed targets only) in standardized + original units.
+    fm, fs, oidx = meta["feat_mean"], meta["feat_std"], meta["out_idx"]
+    metrics = {}
+    for name, p, y, m in (
+        ("val", preds_val, ys_val, masks_val),
+        ("test", preds_test, ys_test, masks_test),
+        ("pred", preds_pred, ys_pred, masks_pred),
+    ):
+        scaled = compute_metrics(p, y, m)
+        original = compute_metrics(
+            denormalize(p, fm, fs, oidx), denormalize(y, fm, fs, oidx), m
+        )
+        metrics[name] = {"scaled": scaled, "original": original}
+        print(
+            f"[score] {name:>4}: MSE={scaled['mse']:.4e} MAE={scaled['mae']:.4e} "
+            f"RMSE={scaled['rmse']:.4e} R2={scaled['r2']:.4f} "
+            f"MAPE={scaled['mape']:.2f}%  (scaled, masked)"
+        )
 
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -1076,6 +1094,11 @@ def train_stage(args, cache_dir: Path):
     np.save(out_dir / "ys_test.npy", ys_test)
     np.save(out_dir / "preds_pred.npy", preds_pred)
     np.save(out_dir / "ys_pred.npy", ys_pred)
+    np.save(out_dir / "masks_val.npy", masks_val)
+    np.save(out_dir / "masks_test.npy", masks_test)
+    np.save(out_dir / "masks_pred.npy", masks_pred)
+    with open(out_dir / "metrics.json", "w") as f:
+        json.dump(metrics, f, indent=2)
     if "feat_mean" in meta and "feat_std" in meta:
         np.save(out_dir / "feat_mean.npy", meta["feat_mean"])
         np.save(out_dir / "feat_std.npy", meta["feat_std"])
@@ -1096,10 +1119,48 @@ def train_stage(args, cache_dir: Path):
         dist.destroy_process_group()
 
 
-def _score_split(model, loader, meta, device):
-    """Run model over a dataloader and return stacked (preds, ys).
+def compute_metrics(preds, ys, masks):
+    """MSE / MAE / RMSE / R2 / MAPE over OBSERVED elements only (mask > 0.5).
 
-    Each window's per-node output is reshaped back to [N, H, F_out].
+    preds / ys / masks are [W, N, H, F_out]. Returns all-NaN if no observed
+    elements. Ported from the standalone T-GCN (train.py compute_metrics).
+    """
+    valid = masks.reshape(-1) > 0.5
+    p = preds.reshape(-1)[valid]
+    y = ys.reshape(-1)[valid]
+    if p.size == 0:
+        return {k: float("nan") for k in ("mse", "mae", "rmse", "r2", "mape")}
+    err = p - y
+    mse = float(np.mean(err**2))
+    ss_res = float(np.sum(err**2))
+    ss_tot = float(np.sum((y - y.mean()) ** 2))
+    r2 = float(1.0 - ss_res / ss_tot) if ss_tot > 0 else 0.0
+    nz = np.abs(y) > 1e-8
+    mape = float(np.mean(np.abs(err[nz] / y[nz])) * 100.0) if nz.any() else 0.0
+    return {
+        "mse": mse,
+        "mae": float(np.mean(np.abs(err))),
+        "rmse": float(np.sqrt(mse)),
+        "r2": r2,
+        "mape": mape,
+    }
+
+
+def denormalize(arr, feat_mean, feat_std, out_idx):
+    """Map standardized [W, N, H, F_out] back to physical units using the
+    per-node (N, F_dyn) train scaler restricted to the output channels."""
+    if arr.size == 0:
+        return arr
+    center = feat_mean[:, out_idx]  # [N, F_out]
+    scale = feat_std[:, out_idx]  # [N, F_out]
+    return arr * scale[None, :, None, :] + center[None, :, None, :]
+
+
+def _score_split(model, loader, meta, device):
+    """Run model over a dataloader and return stacked (preds, ys, masks).
+
+    Each window's per-node output is reshaped to [N, H, F_out]; masks are the
+    forecast-window observed masks (1 = observed) used for masked metrics.
     Returns arrays of shape [num_windows, N, H, F_out].
     """
     N = len(meta["fdr_ids"])
@@ -1107,7 +1168,7 @@ def _score_split(model, loader, meta, device):
     Fo = meta["F_out"]
     out_idx = meta["out_idx"]
     predict_delta = bool(meta.get("predict_delta", False))
-    preds, ys = [], []
+    preds, ys, masks = [], [], []
     model.eval()
     with torch.no_grad():
         for data in loader:
@@ -1120,6 +1181,10 @@ def _score_split(model, loader, meta, device):
             B = y_pred.shape[0] // N
             y_pred = y_pred.reshape(B, N, H, Fo)
             y_true = y_true.reshape(B, N, H, Fo)
+            if hasattr(data, "observed_mask") and data.observed_mask is not None:
+                m = data.observed_mask.cpu().numpy().reshape(B, N, H, Fo)
+            else:
+                m = np.ones((B, N, H, Fo), dtype=np.float32)
             if predict_delta:
                 # Re-add last observed level so saved arrays are in absolute
                 # (standardized) space, matching the no-delta convention.
@@ -1129,11 +1194,15 @@ def _score_split(model, loader, meta, device):
                 y_true = y_true + x_last
             preds.append(y_pred)
             ys.append(y_true)
+            masks.append(m)
     if not preds:
-        return np.zeros((0, N, H, Fo), dtype=np.float32), np.zeros(
-            (0, N, H, Fo), dtype=np.float32
-        )
-    return np.concatenate(preds, axis=0), np.concatenate(ys, axis=0)
+        empty = np.zeros((0, N, H, Fo), dtype=np.float32)
+        return empty, empty.copy(), empty.copy()
+    return (
+        np.concatenate(preds, axis=0),
+        np.concatenate(ys, axis=0),
+        np.concatenate(masks, axis=0),
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1268,6 +1337,15 @@ def build_argparser() -> argparse.ArgumentParser:
     )
     p.add_argument(
         "--horizon", type=int, default=10, help="Forecast horizon length (steps)"
+    )
+    p.add_argument(
+        "--out_features",
+        type=int,
+        nargs="+",
+        default=[0, 2, 3],
+        help="Output feature indices into the 4 dynamic channels "
+        "[0=freq_dev, 1=rocof, 2=angle_delta, 3=volt_dev]. Default '0 2 3' (drop "
+        "RoCoF); use '0 3' for the 2-output (freq_dev, volt_dev) parity set",
     )
     p.add_argument(
         "--predict_delta",

--- a/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
+++ b/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
@@ -528,16 +528,6 @@ def make_window_dataset(
     return dataset
 
 
-def time_ordered_split(dataset, train_frac: float, val_frac: float):
-    n = len(dataset)
-    n_train = int(n * train_frac)
-    n_val = int(n * val_frac)
-    train = dataset[:n_train]
-    val = dataset[n_train : n_train + n_val]
-    test = dataset[n_train + n_val :]
-    return train, val, test
-
-
 # ─────────────────────────────────────────────────────────────────────────────
 # 5.  Cache I/O (pickle / ADIOS)
 # ─────────────────────────────────────────────────────────────────────────────
@@ -553,7 +543,7 @@ def _meta_path(cache_dir: Path, date: str) -> Path:
 
 
 def write_cache(
-    cache_dir: Path, date: str, fmt: str, trainset, valset, testset, meta: dict
+    cache_dir: Path, date: str, fmt: str, trainset, valset, testset, predset, meta: dict
 ):
     cache_dir.mkdir(parents=True, exist_ok=True)
     if fmt == "pickle":
@@ -561,6 +551,7 @@ def write_cache(
         SimplePickleWriter(trainset, basedir, "trainset", use_subdir=True)
         SimplePickleWriter(valset, basedir, "valset", use_subdir=True)
         SimplePickleWriter(testset, basedir, "testset", use_subdir=True)
+        SimplePickleWriter(predset, basedir, "predset", use_subdir=True)
         print(f"[cache] pickle splits saved under {basedir}/")
     elif fmt == "adios":
         if not ADIOS_AVAILABLE:
@@ -573,6 +564,7 @@ def write_cache(
         adwriter.add("trainset", trainset)
         adwriter.add("valset", valset)
         adwriter.add("testset", testset)
+        adwriter.add("predset", predset)
         adwriter.save()
         print(f"[cache] adios splits saved to {fname}")
     else:
@@ -595,6 +587,7 @@ def read_cache(cache_dir: Path, date: str, fmt: str):
         trainset = SimplePickleDataset(basedir=basedir, label="trainset")
         valset = SimplePickleDataset(basedir=basedir, label="valset")
         testset = SimplePickleDataset(basedir=basedir, label="testset")
+        predset = SimplePickleDataset(basedir=basedir, label="predset")
     elif fmt == "adios":
         if not ADIOS_AVAILABLE:
             raise RuntimeError(
@@ -606,9 +599,10 @@ def read_cache(cache_dir: Path, date: str, fmt: str):
         trainset = AdiosDataset(fname, "trainset", comm, **opt)
         valset = AdiosDataset(fname, "valset", comm, **opt)
         testset = AdiosDataset(fname, "testset", comm, **opt)
+        predset = AdiosDataset(fname, "predset", comm, **opt)
     else:
         raise ValueError(f"Unknown --format: {fmt}")
-    return trainset, valset, testset, meta
+    return trainset, valset, testset, predset, meta
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -705,33 +699,52 @@ def preprocess_stage(args, cache_dir: Path):
         f"channel-spread(std-of-stds)={np.array2string(feat_std.std(axis=0), precision=4)}"
     )
 
-    full_dataset = make_window_dataset(
-        X,
-        grid_embed,
-        edge_index,
-        Tin=args.Tin,
-        H=args.horizon,
-        edge_weight=edge_weight,
-        predict_delta=bool(args.predict_delta),
-        max_windows=args.max_windows,
+    # Slice the timeline into 4 contiguous segments, THEN window each segment
+    # independently. The previous order (window the whole series, then split the
+    # window list by index) let overlapping sliding windows straddle the
+    # train/val/test boundaries, leaking recent history across splits. Windowing
+    # per-segment guarantees no window crosses a boundary.
+    T = X.shape[0]
+    n_train = int(T * args.train_frac)
+    n_val = int(T * args.val_frac)
+    n_test = int(T * args.test_frac)
+    seg_bounds = [
+        ("train", 0, n_train),
+        ("val", n_train, n_train + n_val),
+        ("test", n_train + n_val, n_train + n_val + n_test),
+        ("pred", n_train + n_val + n_test, T),
+    ]
+    seg_data = {
+        name: make_window_dataset(
+            X[lo:hi],
+            grid_embed,
+            edge_index,
+            Tin=args.Tin,
+            H=args.horizon,
+            edge_weight=edge_weight,
+            predict_delta=bool(args.predict_delta),
+            max_windows=args.max_windows,
+        )
+        for name, lo, hi in seg_bounds
+    }
+    train_data, val_data, test_data, pred_data = (
+        seg_data["train"],
+        seg_data["val"],
+        seg_data["test"],
+        seg_data["pred"],
     )
     if args.predict_delta:
         print("[ds]    target = delta from x_last (predict_delta=True)")
     print(
-        f"[ds]    {len(full_dataset)} windows  " f"(Tin={args.Tin}, H={args.horizon})"
+        f"[split] slice-then-window train/val/test/pred = "
+        f"{len(train_data)}/{len(val_data)}/{len(test_data)}/{len(pred_data)}  "
+        f"(Tin={args.Tin}, H={args.horizon}; no window crosses a boundary)"
     )
-    if len(full_dataset) < 8:
+    if min(len(train_data), len(val_data), len(test_data)) < 1:
         raise RuntimeError(
-            "Too few windows; reduce --Tin/--horizon or use a longer day."
+            "A split produced 0 windows; each segment length must exceed Tin + H. "
+            "Reduce --Tin/--horizon, change split fractions, or use a longer day."
         )
-
-    train_data, val_data, test_data = time_ordered_split(
-        full_dataset, train_frac=args.train_frac, val_frac=args.val_frac
-    )
-    print(
-        f"[split] train/val/test = {len(train_data)}/{len(val_data)}/{len(test_data)}  "
-        f"(time-ordered)"
-    )
 
     meta = {
         "fdr_ids": fdr_ids,
@@ -756,7 +769,14 @@ def preprocess_stage(args, cache_dir: Path):
         "predict_delta": bool(args.predict_delta),
     }
     write_cache(
-        cache_dir, args.date, args.format, train_data, val_data, test_data, meta
+        cache_dir,
+        args.date,
+        args.format,
+        train_data,
+        val_data,
+        test_data,
+        pred_data,
+        meta,
     )
 
 
@@ -800,9 +820,12 @@ def train_stage(args, cache_dir: Path):
     hydragnn.utils.print.print_utils.setup_log(log_name)
 
     print(f"[cache] reading splits ({args.format}) from {cache_dir}")
-    trainset, valset, testset, meta = read_cache(cache_dir, args.date, args.format)
+    trainset, valset, testset, predset, meta = read_cache(
+        cache_dir, args.date, args.format
+    )
     print(
-        f"[cache] train/val/test = {len(trainset)}/{len(valset)}/{len(testset)}  "
+        f"[cache] train/val/test/pred = "
+        f"{len(trainset)}/{len(valset)}/{len(testset)}/{len(predset)}  "
         f"| sites={len(meta['sites'])}, Tin={meta['Tin']}, H={meta['horizon']}, "
         f"F_dyn={meta['F_dyn']}, F_static={meta['F_static']}, F_out={meta['F_out']}"
     )
@@ -815,11 +838,13 @@ def train_stage(args, cache_dir: Path):
     )
     config["NeuralNetwork"]["Variables_of_interest"]["output_dim"] = [target_dim]
 
+    bs = config["NeuralNetwork"]["Training"]["batch_size"]
     train_loader, val_loader, test_loader = hydragnn.preprocess.create_dataloaders(
-        trainset,
-        valset,
-        testset,
-        config["NeuralNetwork"]["Training"]["batch_size"],
+        trainset, valset, testset, bs
+    )
+    # Separate loader for the final held-out 'pred' split (scored after training).
+    pred_loader, _, _ = hydragnn.preprocess.create_dataloaders(
+        predset, predset, predset, bs
     )
     config = hydragnn.utils.input_config_parsing.update_config(
         config, train_loader, val_loader, test_loader
@@ -861,13 +886,16 @@ def train_stage(args, cache_dir: Path):
     )
 
     raw_model = (model.module if hasattr(model, "module") else model).to(device)
-    print("\n[score] Scoring val + test windows ...")
+    print("\n[score] Scoring val + test + pred windows ...")
     preds_val, ys_val = _score_split(raw_model, val_loader, meta, device)
     preds_test, ys_test = _score_split(raw_model, test_loader, meta, device)
+    preds_pred, ys_pred = _score_split(raw_model, pred_loader, meta, device)
     val_mse = float(np.mean((preds_val - ys_val) ** 2))
     test_mse = float(np.mean((preds_test - ys_test) ** 2))
-    print(f"[score] val MSE = {val_mse:.6e}")
+    pred_mse = float(np.mean((preds_pred - ys_pred) ** 2)) if preds_pred.size else float("nan")
+    print(f"[score] val MSE  = {val_mse:.6e}")
     print(f"[score] test MSE = {test_mse:.6e}")
+    print(f"[score] pred MSE = {pred_mse:.6e}")
 
     out_dir = Path(args.out_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -879,6 +907,8 @@ def train_stage(args, cache_dir: Path):
     np.save(out_dir / "ys_val.npy", ys_val)
     np.save(out_dir / "preds_test.npy", preds_test)
     np.save(out_dir / "ys_test.npy", ys_test)
+    np.save(out_dir / "preds_pred.npy", preds_pred)
+    np.save(out_dir / "ys_pred.npy", ys_pred)
     if "feat_mean" in meta and "feat_std" in meta:
         np.save(out_dir / "feat_mean.npy", meta["feat_mean"])
         np.save(out_dir / "feat_std.npy", meta["feat_std"])
@@ -1044,9 +1074,16 @@ def build_argparser() -> argparse.ArgumentParser:
         default=None,
         help="Cap total windows (evenly spaced subset). Useful for fast iteration.",
     )
-    # Split
+    # Split (4-way, time-ordered; each segment is windowed independently)
     p.add_argument("--train_frac", type=float, default=0.8)
-    p.add_argument("--val_frac", type=float, default=0.1)
+    p.add_argument("--val_frac", type=float, default=0.05)
+    p.add_argument("--test_frac", type=float, default=0.05)
+    p.add_argument(
+        "--pred_frac",
+        type=float,
+        default=0.10,
+        help="Final held-out segment, scored once after training",
+    )
     # Model overrides (also used as HPO knobs)
     p.add_argument(
         "--mpnn_type", type=str, default=None, help="Override mpnn_type from JSON"

--- a/examples/fnet_temporal_anomaly_detection/score_train_split.py
+++ b/examples/fnet_temporal_anomaly_detection/score_train_split.py
@@ -113,7 +113,9 @@ def main():
     hydragnn.utils.distributed.setup_ddp()
 
     print(f"[cache] reading splits ({args.format}) from {cache_dir}")
-    trainset, valset, testset, meta = read_cache(cache_dir, args.date, args.format)
+    trainset, valset, testset, predset, meta = read_cache(
+        cache_dir, args.date, args.format
+    )
     print(
         f"[cache] train/val/test = {len(trainset)}/{len(valset)}/{len(testset)}  "
         f"| sites={len(meta['sites'])}, Tin={meta['Tin']}, H={meta['horizon']}, "

--- a/tests/test_fnet_cov80.py
+++ b/tests/test_fnet_cov80.py
@@ -1,0 +1,154 @@
+"""
+Parquet-free unit tests for the FNET cov80 forecaster transforms.
+
+Exercises the data-side cov80 logic on tiny in-memory arrays (no parquet, no
+DDP, no real PMU files) so it runs in well under a second:
+
+  * keep-and-mask alignment     (stack_node_features)
+  * gap imputation              (robust_impute_feature_matrix)
+  * train-only observed scaling (scale_features)
+  * windowing                   (make_window_dataset): the observed-mask input
+    channel, the forecast-window loss mask aligned with y, and configurable
+    out_idx.
+
+The example module imports hydragnn at top level, so it is loaded via importlib
+(the examples directory is not a package).
+"""
+
+import importlib.util
+import os
+
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+_EXAMPLE = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "examples",
+    "fnet_temporal_anomaly_detection",
+    "fnet_temporal_anomaly_detection.py",
+)
+
+
+def _load_example():
+    spec = importlib.util.spec_from_file_location("fnet_cov80_example", _EXAMPLE)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+fnet = _load_example()
+
+
+# --------------------------------------------------------------------------- #
+# Imputation
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.mpi_skip()
+def pytest_cov80_impute_fills_gaps():
+    """robust_impute interpolates internal gaps and leaves no NaN."""
+    X = np.array([[1.0], [np.nan], [3.0], [np.nan], [np.nan]], dtype=np.float32)
+    mask = np.array([[1.0], [0.0], [1.0], [0.0], [0.0]], dtype=np.float32)
+    out = fnet.robust_impute_feature_matrix(
+        X.copy(), mask, train_end=5, short_gap_steps=10, medium_gap_steps=10
+    )
+    assert not np.isnan(out).any()
+    assert out[1, 0] == pytest.approx(2.0, abs=1e-5)  # linear interp 1 -> 3
+
+
+# --------------------------------------------------------------------------- #
+# Scaling
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.mpi_skip()
+def pytest_cov80_scale_features_observed_only_and_methods():
+    """Scaling uses observed values only; method shapes/behaviors are correct."""
+    T, N, F = 10, 2, 1
+    X = np.ones((T, N, F), dtype=np.float32)
+    X[:, 0, 0] = np.arange(T)  # node 0 varies 0..9
+    obsm = np.ones((T, N), dtype=np.float32)
+    obsm[0, 0] = 0.0  # node 0's value 0 at t=0 is "imputed" -> excluded from stats
+
+    # none = identity
+    Xs, c, s = fnet.scale_features(X.copy(), obsm, train_end=T, method="none")
+    assert np.allclose(Xs, X) and np.allclose(c, 0.0) and np.allclose(s, 1.0)
+
+    # global = one center/scale per channel, tiled across nodes, observed-only
+    _, cg, sg = fnet.scale_features(X.copy(), obsm, train_end=T, method="global")
+    assert cg.shape == (N, F)
+    assert np.allclose(cg[:, 0], cg[0, 0])  # same value across nodes
+    expected = X[:, :, 0][obsm > 0.5].mean()
+    assert cg[0, 0] == pytest.approx(float(expected), abs=1e-4)
+
+    # per_node = different center per node
+    _, cp, sp = fnet.scale_features(X.copy(), obsm, train_end=T, method="per_node")
+    assert cp.shape == (N, F)
+    assert cp[0, 0] != cp[1, 0]
+
+
+# --------------------------------------------------------------------------- #
+# Windowing: mask input channel + forecast-window loss mask + out_idx
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.mpi_skip()
+def pytest_cov80_window_mask_channel_and_loss_mask():
+    N, T, Fstat, Tin, H = 4, 12, 4, 3, 2
+    Fdyn = fnet.F_DYN
+    rng = np.random.default_rng(0)
+    X = rng.standard_normal((T, N, Fdyn)).astype(np.float32)
+    obsm = (rng.random((T, N)) > 0.1).astype(np.float32)
+    grid = rng.standard_normal((N, Fstat)).astype(np.float32)
+    edge_index = torch.tensor([[0, 1, 2, 3], [1, 2, 3, 0]], dtype=torch.long)
+    out_idx = np.array([0, 3], dtype=np.int64)  # 2 outputs
+
+    ds = fnet.make_window_dataset(
+        X, grid, edge_index, Tin=Tin, H=H, observed_mask=obsm, out_idx=out_idx
+    )
+    assert len(ds) == (T - H) - (Tin - 1)
+    d = ds[0]
+    # x_seq = dynamic + 1 mask + static channels
+    assert tuple(d.x_seq.shape) == (N, Tin, Fdyn + fnet.F_MASK + Fstat)
+    # y and the loss mask are H * len(out_idx) wide and identically shaped
+    assert tuple(d.y.shape) == (N, H * len(out_idx))
+    assert tuple(d.observed_mask.shape) == tuple(d.y.shape)
+    # loss mask is 0/1
+    uniq = set(np.unique(d.observed_mask.numpy()).tolist())
+    assert uniq.issubset({0.0, 1.0})
+
+
+# --------------------------------------------------------------------------- #
+# Keep-and-mask alignment
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.mpi_skip()
+def pytest_cov80_stack_keep_and_mask():
+    feats = ["freq_dev", "rocof", "angle_delta", "volt_dev"]
+    base = pd.Timestamp("2024-01-01")
+    grid = pd.date_range(base, periods=10, freq="1s")
+
+    def dev(times):
+        df = pd.DataFrame({"timestamp": times})
+        for c in feats:
+            df[c] = np.arange(len(times), dtype=float)
+        return df
+
+    data = {
+        1: dev(grid),               # full coverage
+        2: dev(grid.delete(5)),     # one internal gap (missing t=5)
+        3: dev(grid[[0, 4, 9]]),    # spans full range but only 30% covered
+    }
+    tvec, X, obsm, keep = fnet.stack_node_features(
+        [1, 2, 3], data, dt=1.0, min_device_coverage=0.5, min_step_coverage=0.5
+    )
+
+    assert set(keep) == {1, 2}          # device 3 dropped (< 50% coverage)
+    assert X.shape[1] == 2               # N = 2 kept nodes
+    assert obsm.shape == (X.shape[0], 2)
+    assert obsm.min() == 0.0             # device 2's gap is recorded as unobserved
+    assert obsm.max() == 1.0


### PR DESCRIPTION
## Summary

Brings HydraGNN's FNET TemporalGCN example up to T-GCN cov80 forecaster: instead of dropping incomplete PMU time slots, it **keeps and masks** them, **imputes** the gaps, trains with a **masked loss** so imputed targets don't contribute, and reports **masked metrics**. Also fixes a train/val/test data leak in the windowing.

**Example-only** — all changes are under `examples/fnet_temporal_anomaly_detection/` plus a test in `tests/`. 

## What changed (commit by commit)

- **slice-then-window + 4-way split (leakage fix).** Previously the whole series was windowed and the *window list* was split by index, so overlapping windows straddled the train/val/test boundary and leaked recent history. Now the timeline is sliced into 4 contiguous segments (train/val/test/**pred** = 0.8/0.05/0.05/0.1) and each is windowed independently. (Removed `time_ordered_split`; cache + `train_stage` carry the 4th `pred` holdout.)
- **keep-and-mask alignment + impute.** `stack_node_features` keeps gaps (NaN) and emits `observed_mask [T,N]`; drops devices `< --min_device_coverage` (0.5) and timesteps `< --min_step_coverage` (0.8). New `robust_impute_feature_matrix` (interpolate → ffill/bfill → train-only median) fills gaps.
- **observed-mask input channel.** Tiled into `x_seq` → `[N, Tin, 4 dyn + 1 mask + 4 static = 9]` so the model can condition on which inputs are real.
- **masked loss wiring.** Attaches `data.observed_mask [N, H·F_out]` (the forecast-window mask, aligned element-for-element with `y`); sets `loss_function_type: mse`; imputed targets are excluded from the objective.
- **scaling flag.** `--scaling none|per_node|global|robust` (train-only, computed over observed values only). **Default is `global`** (per-channel mean/std).
- **configurable outputs.** `--out_features` (default `0 2 3`); `0 3` reproduces T-GCN's 2-output (Δf, ΔV) set.
- **masked multi-metrics.** MSE/MAE/RMSE/R²/MAPE over observed elements, in scaled + original units, written to `metrics.json`.
- **tests + README + config tidy.** `tests/test_fnet_cov80.py`; example `README.md`.

## Two masks (kept distinct)

- **Input-window mask** — the 5th channel of `x_seq` (window `s−Tin+1…s`).
- **Forecast-window loss mask** — `data.observed_mask`, shape `== data.y` (window `s+1…s+H`), consumed by `Base.loss(mask=…)`.

Same source array, different window and shape.

## Behavior changes worth noting (intended)

- **Leakage fix** changes current val/test numbers — they were optimistic due to cross-split window overlap.
- **Scaling default** flips per-node → `global` (per-node is transductive); use `--scaling per_node` for the old behavior.
- **Alignment** keeps more sensors/timesteps (mask+impute) instead of dropping them.
- **Loss** is `mse` (the masked path is MSE-specific).

## New flags

`--min_device_coverage` · `--min_step_coverage` · `--short_gap_steps` · `--medium_gap_steps` · `--scaling` · `--scaled_clip_value` · `--out_features` · `--test_frac` · `--pred_frac`

## Testing

- `pytest tests/test_fnet_cov80.py` — 4 passing (parquet-free): impute fills gaps, observed-only scaling, 9-channel `x_seq` + loss-mask shape + `out_idx`, keep-and-mask alignment.
- End-to-end on full data: trains, and the masked training loss agrees with the masked reported scores; `metrics.json` written.

## Notes

- **Regenerate the cache** after pulling — the cached tensors changed (mask channel, loss mask, 4-way split, scaling). Delete `dataset/fnet_<date>.pickle/` + `_meta.pkl`  and re-run `--preonly`/`--do_all`.
- Files: `examples/fnet_temporal_anomaly_detection/{*.py,*.json,README.md}`, `tests/test_fnet_cov80.py`. No framework changes.
- The per-device coverage floor (`--min_device_coverage 0.5`) is a pragmatic relaxation of the old hardcoded 0.95 — set `0.0` to keep every metadata sensor (strict cov80).
