### PR TITLE
Downstream regional anomaly detection on the cov80 forecaster

### DIFF
--- a/examples/fnet_temporal_anomaly_detection/README.md
+++ b/examples/fnet_temporal_anomaly_detection/README.md
@@ -66,6 +66,14 @@ must be `mse` (the masked-loss path is MSE-specific).
 - `metrics.json` — masked MSE/MAE/RMSE/R²/MAPE per split, in scaled + original units
 - `preds_{val,test,pred}.npy`, `ys_*.npy`, `masks_*.npy` — `[W, N, H, F_out]`
 - `feat_mean/feat_std/out_idx.npy`, `X.npy`, `tvec.npy`, `A_hat.npy`, `sites.csv`
+- `A_geo.npy` — raw `exp(-d/σ)` similarity (for downstream cluster thresholding)
+- `downstream_meta.json` — `Tin` / split fractions / stride / scaling (for downstream)
+
+## Downstream detection
+
+Post-hoc regional-anomaly detection on the saved residuals lives in
+[`downstream/`](downstream/README.md) (`regional_detector.py` → `collapse_episodes.py`).
+It reads this `--out_dir`; no retraining.
 
 ## Notes
 

--- a/examples/fnet_temporal_anomaly_detection/downstream/README.md
+++ b/examples/fnet_temporal_anomaly_detection/downstream/README.md
@@ -1,0 +1,64 @@
+# Downstream regional-anomaly detection
+
+Post-hoc disturbance detection on the cov80 forecaster's residuals. **No
+retraining** — everything here reads a forecaster `--out_dir` (produced by
+`fnet_temporal_anomaly_detection.py`) and writes CSVs under `<out_dir>/downstream/`.
+
+```
+fnet_temporal_anomaly_detection.py  --out_dir OUT
+        │  (preds/ys/masks, A_geo.npy, tvec.npy, sites.csv, downstream_meta.json)
+        ▼
+regional_detector.py  --out_dir OUT --detector map_hot   →  map_freq_hot_clusters_{all,top}.csv
+        ▼
+collapse_episodes.py  --out_dir OUT                       →  map_freq_hot_cluster_episodes_{all,selected}.csv
+```
+
+## Components
+
+| File | Role |
+|---|---|
+| `downstream_io.py` | Adapter: maps the forecaster `out_dir` artifacts into `DownstreamData` (arrays `[S,H,N,F_out]` in physical units, raw `A_geo`, per-window timestamps, mask). The single bridge; the detectors never read the model or raw parquet. |
+| `regional_detector.py` | Flags connected sensor clusters with high residual, per timestamp (`--detector strict\|map_hot`). |
+| `collapse_episodes.py` | Collapses the many per-timestamp `map_hot` clusters into distinct episodes (framework only; no plotting). |
+
+## Detectors (`--detector`)
+
+| | `map_hot` (default) | `strict` |
+|---|---|---|
+| Activation | high `freq_dev` error only | high `freq_dev` **and** RoCoF error |
+| Adjacency | raw weight `> --edge_threshold` | `>= --edge_quantile` of positive weights |
+| Guards | — | drops clusters with no true RoCoF / no cross-sensor spread |
+| Volume | many raw clusters → feed to `collapse_episodes` | ~tens of clusters, self-contained |
+| Output CSV | `map_freq_hot_clusters_*.csv` | `clusters_*.csv` |
+
+## Usage
+
+```bash
+# 1) detect (map_hot is the default; strict via --detector strict)
+python downstream/regional_detector.py --out_dir OUT --split pred --detector map_hot
+
+# 2) collapse the map_hot clusters into episodes
+python downstream/collapse_episodes.py --out_dir OUT
+```
+
+`--split` is one of `val` / `test` / `pred` (the scored splits). Key detector
+flags: `--color_max_quantile` / `--freq_quantile` / `--rocof_quantile` (activation),
+`--edge_threshold` / `--edge_quantile` (adjacency), `--min_cluster_size`. Collapse
+flags: `--episode_gap`, `--target_max_episodes`, `--peak_exclusion_window`,
+`--window_overlap_mode`. Run either script with `-h` for the full list.
+
+## What it inherits from the forecaster
+
+- **Mask-aware residuals** — imputed / missing forecast targets (`masks_*.npy` = 0)
+  are excluded from the residual, the activation quantiles, and the cluster stats.
+- **Timestamps from `tvec`** — each window's time comes from the saved `tvec.npy`
+  via the contiguous slice-then-window mapping (no parquet re-read).
+- **RoCoF channel branch** — `strict` uses a real rocof output channel if the run
+  produced one (`--out_features … 1 …`), else estimates it as the first difference
+  of `freq_dev` (identical to the forecaster's own rocof).
+
+## Scope
+
+This is the detection + episode-collapse pipeline. The failure-vs-event
+**discriminator** and the synthetic **fault-injection / scoring** harness are not
+included here.

--- a/examples/fnet_temporal_anomaly_detection/downstream/__init__.py
+++ b/examples/fnet_temporal_anomaly_detection/downstream/__init__.py
@@ -1,0 +1,10 @@
+"""Downstream — downstream regional-anomaly detection on the fnet forecaster outputs.
+
+Model-agnostic: everything here reads a forecaster ``--out_dir`` (never the model
+or the raw parquet). ``downstream_io.load_split`` is the single adapter that maps the
+saved artifacts into the arrays/graph/timestamps the detectors consume.
+"""
+
+from .downstream_io import DownstreamData, load_split
+
+__all__ = ["DownstreamData", "load_split"]

--- a/examples/fnet_temporal_anomaly_detection/downstream/collapse_episodes.py
+++ b/examples/fnet_temporal_anomaly_detection/downstream/collapse_episodes.py
@@ -1,0 +1,294 @@
+"""Collapse repeated regional clusters into episodes.
+
+The map_hot detector emits one cluster row per timestamp, so a single physical
+disturbance appears as many near-identical rows (same sensor set, adjacent
+times). This stage collapses them: group by sensor set, split each group on a
+time gap, and keep the peak frame per run -> one row per episode. A peak-window
+pass then suppresses near-duplicate episodes that share sensors.
+
+Pure pandas over the detector's ``map_freq_hot_clusters_all.csv`` — no model, no
+arrays, no plotting. Consumes/produces CSVs only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+
+# --------------------------------------------------------------------------- #
+# Collapse
+# --------------------------------------------------------------------------- #
+
+
+def parse_sensor_ids(sensor_ids_text: str) -> list[int]:
+    return [int(x) for x in str(sensor_ids_text).split(";") if str(x) != ""]
+
+
+def canonical_sensor_set(sensor_ids_text: str) -> str:
+    """Order-independent key for a cluster's sensor set."""
+    return ";".join(str(x) for x in sorted(parse_sensor_ids(sensor_ids_text)))
+
+
+def collapse_to_episodes(df: pd.DataFrame, episode_gap: int) -> pd.DataFrame:
+    """Collapse per-timestamp clusters into episodes.
+
+    Within each ``sensor_set`` group, consecutive rows whose ``time_idx`` gap is
+    <= ``episode_gap`` belong to the same episode; the episode's representative
+    frame is the one with the largest ``mean_abs_err``.
+    """
+    rows: list[dict] = []
+    episode_id = 0
+    for sensor_set, group in df.sort_values(["sensor_set", "time_idx"]).groupby(
+        "sensor_set", sort=False
+    ):
+        g = group.sort_values("time_idx").reset_index(drop=True)
+        t = g["time_idx"].to_numpy(dtype=int)
+        start = 0
+        for i in range(1, len(g) + 1):
+            boundary = i == len(g) or (t[i] - t[i - 1]) > episode_gap
+            if not boundary:
+                continue
+            seg = g.iloc[start:i]
+            peak_row = seg.loc[int(seg["mean_abs_err"].idxmax())]
+            rows.append(
+                {
+                    "episode_id": episode_id,
+                    "sensor_set": sensor_set,
+                    "cluster_size": int(peak_row["cluster_size"]),
+                    "start_time_idx": int(seg["time_idx"].min()),
+                    "end_time_idx": int(seg["time_idx"].max()),
+                    "peak_time_idx": int(peak_row["time_idx"]),
+                    "n_frames": int(len(seg)),
+                    "duration_steps": int(
+                        seg["time_idx"].max() - seg["time_idx"].min() + 1
+                    ),
+                    "peak_mean_abs_err": float(seg["mean_abs_err"].max()),
+                    "peak_max_abs_err": float(seg["max_abs_err"].max()),
+                    "sensor_ids": str(peak_row["sensor_ids"]),
+                    "sensor_names": str(peak_row.get("sensor_names", "")),
+                    "sensor_indices": str(peak_row["sensor_indices"]),
+                    "peak_timestamp": str(peak_row.get("timestamp", "")),
+                }
+            )
+            episode_id += 1
+            start = i
+    return pd.DataFrame(rows)
+
+
+def choose_episode_gap(
+    df: pd.DataFrame,
+    initial_gap: int,
+    candidate_gaps: list[int],
+    target_max_episodes: int,
+) -> tuple[int, pd.DataFrame]:
+    """Pick the smallest gap (>= initial) whose collapse yields <= target
+    episodes. Larger gaps merge more, so episode count falls as the gap grows."""
+    ordered = sorted(set([g for g in candidate_gaps if g >= initial_gap] + [initial_gap]))
+    chosen_gap, chosen_df = ordered[-1], collapse_to_episodes(df, ordered[-1])
+    for gap in ordered:
+        eps = collapse_to_episodes(df, gap)
+        chosen_gap, chosen_df = gap, eps
+        if len(eps) <= target_max_episodes:
+            break
+    return chosen_gap, chosen_df
+
+
+def select_with_peak_window(
+    episodes: pd.DataFrame, max_selected: int, window: int, overlap_mode: str
+) -> pd.DataFrame:
+    """Greedily keep top episodes, suppressing a candidate whose peak is within
+    ``window`` steps of an already-selected one (``global``: any; ``sensor_overlap``:
+    only if their sensor sets intersect). Assumes ``episodes`` is pre-ranked."""
+    if episodes.empty or max_selected <= 0:
+        return episodes.head(0).copy()
+    selected_rows: list[dict] = []
+    selected_peaks: list[int] = []
+    selected_sets: list[set] = []
+    for row in episodes.itertuples(index=False):
+        candidate_peak = int(row.peak_time_idx)
+        candidate_set = set(parse_sensor_ids(str(row.sensor_ids)))
+        blocked = False
+        for prev_peak, prev_set in zip(selected_peaks, selected_sets):
+            if abs(candidate_peak - prev_peak) > window:
+                continue
+            if overlap_mode == "global" or candidate_set.intersection(prev_set):
+                blocked = True
+                break
+        if blocked:
+            continue
+        selected_rows.append(row._asdict())
+        selected_peaks.append(candidate_peak)
+        selected_sets.append(candidate_set)
+        if len(selected_rows) >= max_selected:
+            break
+    return pd.DataFrame(selected_rows)
+
+
+def rank_episodes(episodes: pd.DataFrame) -> pd.DataFrame:
+    """Rank by error magnitude with a light size bonus, then reindex episode_id."""
+    episodes = episodes.copy()
+    episodes["rank_score"] = episodes["peak_mean_abs_err"] * (
+        1.0 + 0.15 * np.maximum(episodes["cluster_size"] - 2, 0)
+    )
+    episodes = episodes.sort_values(
+        ["rank_score", "peak_max_abs_err", "n_frames"], ascending=False
+    ).reset_index(drop=True)
+    episodes["episode_id"] = np.arange(len(episodes), dtype=int)
+    return episodes
+
+
+def collapse(
+    clusters: pd.DataFrame,
+    *,
+    episode_gap: int = 10,
+    auto_increase_cutoff: bool = True,
+    candidate_gaps: list[int] | None = None,
+    target_max_episodes: int = 800,
+    min_cluster_size: int = 2,
+    min_peak_mean_abs_err: float = 0.0,
+    max_selected: int = 120,
+    peak_exclusion_window: int = 120,
+    window_overlap_mode: str = "sensor_overlap",
+) -> tuple[pd.DataFrame, pd.DataFrame, dict]:
+    """Full collapse: raw clusters -> (episodes_all, episodes_selected, summary)."""
+    if clusters.empty:
+        raise ValueError("Input clusters are empty; nothing to collapse.")
+    clusters = clusters.copy()
+    clusters["sensor_set"] = clusters["sensor_ids"].map(canonical_sensor_set)
+
+    gaps = candidate_gaps if candidate_gaps is not None else [10, 20, 30, 60, 120]
+    if auto_increase_cutoff:
+        used_gap, episodes = choose_episode_gap(
+            clusters, episode_gap, gaps, target_max_episodes
+        )
+    else:
+        used_gap, episodes = episode_gap, collapse_to_episodes(clusters, episode_gap)
+
+    episodes = episodes[
+        (episodes["cluster_size"] >= min_cluster_size)
+        & (episodes["peak_mean_abs_err"] >= min_peak_mean_abs_err)
+    ]
+    if episodes.empty:
+        raise ValueError(
+            "No episodes after filtering; lower --min_cluster_size / "
+            "--min_peak_mean_abs_err."
+        )
+    episodes = rank_episodes(episodes)
+
+    selected = select_with_peak_window(
+        episodes,
+        max_selected=max_selected,
+        window=max(0, peak_exclusion_window),
+        overlap_mode=window_overlap_mode,
+    ).reset_index(drop=True)
+    if not selected.empty:
+        selected["episode_id"] = np.arange(len(selected), dtype=int)
+
+    summary = {
+        "input_rows": int(len(clusters)),
+        "episodes_after_collapse": int(len(episodes)),
+        "selected": int(len(selected)),
+        "used_episode_gap": int(used_gap),
+        "peak_exclusion_window": int(peak_exclusion_window),
+        "window_overlap_mode": str(window_overlap_mode),
+        "auto_increase_cutoff": bool(auto_increase_cutoff),
+        "target_max_episodes": int(target_max_episodes),
+        "min_cluster_size": int(min_cluster_size),
+        "min_peak_mean_abs_err": float(min_peak_mean_abs_err),
+    }
+    return episodes, selected, summary
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Collapse map_hot clusters into episodes (no plotting)",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--out_dir", default=None, help="forecaster out_dir; used to derive default paths")
+    p.add_argument(
+        "--input_csv",
+        default=None,
+        help="clusters CSV (default: <out_dir>/downstream/map_freq_hot_clusters_all.csv)",
+    )
+    p.add_argument(
+        "--results_dir",
+        default=None,
+        help="where to write episode CSVs (default: <out_dir>/downstream)",
+    )
+    p.add_argument("--episode_gap", type=int, default=10)
+    p.add_argument("--no_auto_increase_cutoff", action="store_true")
+    p.add_argument("--candidate_gaps", default="10,20,30,60,120")
+    p.add_argument("--target_max_episodes", type=int, default=800)
+    p.add_argument("--min_cluster_size", type=int, default=2)
+    p.add_argument("--min_peak_mean_abs_err", type=float, default=0.0)
+    p.add_argument("--max_selected", type=int, default=120)
+    p.add_argument("--peak_exclusion_window", type=int, default=120)
+    p.add_argument(
+        "--window_overlap_mode",
+        default="sensor_overlap",
+        choices=["sensor_overlap", "global"],
+    )
+    return p
+
+
+def main(argv=None) -> None:
+    args = build_argparser().parse_args(argv)
+
+    if args.input_csv:
+        input_csv = Path(args.input_csv)
+    elif args.out_dir:
+        input_csv = Path(args.out_dir) / "downstream" / "map_freq_hot_clusters_all.csv"
+    else:
+        raise SystemExit("provide --input_csv or --out_dir")
+    if not input_csv.exists():
+        raise SystemExit(f"missing input clusters CSV: {input_csv}")
+
+    results_dir = (
+        Path(args.results_dir)
+        if args.results_dir
+        else (Path(args.out_dir) / "downstream" if args.out_dir else input_csv.parent)
+    )
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    clusters = pd.read_csv(input_csv)
+    episodes, selected, summary = collapse(
+        clusters,
+        episode_gap=args.episode_gap,
+        auto_increase_cutoff=not args.no_auto_increase_cutoff,
+        candidate_gaps=[int(x) for x in args.candidate_gaps.split(",") if x.strip()],
+        target_max_episodes=args.target_max_episodes,
+        min_cluster_size=args.min_cluster_size,
+        min_peak_mean_abs_err=args.min_peak_mean_abs_err,
+        max_selected=args.max_selected,
+        peak_exclusion_window=args.peak_exclusion_window,
+        window_overlap_mode=args.window_overlap_mode,
+    )
+
+    all_path = results_dir / "map_freq_hot_cluster_episodes_all.csv"
+    sel_path = results_dir / "map_freq_hot_cluster_episodes_selected.csv"
+    episodes.to_csv(all_path, index=False)
+    selected.to_csv(sel_path, index=False)
+    with open(results_dir / "episodes_summary.json", "w") as f:
+        json.dump(summary, f, indent=2)
+
+    print(
+        f"[collapse] rows={summary['input_rows']} -> episodes="
+        f"{summary['episodes_after_collapse']} (gap={summary['used_episode_gap']}), "
+        f"selected={summary['selected']}"
+    )
+    print(f"[save]   {all_path}")
+    print(f"[save]   {sel_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fnet_temporal_anomaly_detection/downstream/downstream_io.py
+++ b/examples/fnet_temporal_anomaly_detection/downstream/downstream_io.py
@@ -1,0 +1,175 @@
+"""Downstream I/O adapter: forecaster ``--out_dir`` -> regional-detector inputs.
+
+The T-GCN downstream tasks read a different artifact layout than the
+integrated fnet example writes. This module is the single bridge: ``load_split``
+returns arrays + graph + timestamps in the shape / units / order the detectors
+expect, so the ported detector logic stays identical.
+
+Reconciled here:
+
+  * axis order  ``preds_{split}.npy`` ``[S, N, H, F_out]`` -> ``[S, H, N, F_out]``
+  * units       standardized preds/ys -> physical (``feat_mean/std`` restricted
+                to ``out_idx``); the fnet scorer already re-adds the last level
+                for ``predict_delta`` runs, so no delta handling is needed here
+  * mask        ``masks_{split}.npy`` returned as-is (imputed / missing targets
+                are 0 and get excluded from residuals downstream)
+  * graph       raw ``A_geo.npy`` (``exp(-d/sigma)``); ``A_hat`` is NOT used for
+                detection (its D^-1/2 normalization can't be inverted back)
+  * timestamps  from the strided ``tvec.npy`` via the contiguous slice-then-window
+                mapping (no parquet re-read): sample ``w`` of a split maps to
+                ``tvec[lo + Tin + w]``
+
+Only ``val`` / ``test`` / ``pred`` are available — the fnet example scores and
+saves those three splits, not ``train``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Union
+
+import numpy as np
+import pandas as pd
+
+# Dynamic-feature channel indices from the fnet example's
+# compute_dynamic_features: 0=freq_dev, 1=rocof, 2=angle_delta, 3=volt_dev.
+FREQ_CHANNEL = 0
+ROCOF_CHANNEL = 1
+
+_SCORED_SPLITS = ("val", "test", "pred")
+
+
+@dataclass
+class DownstreamData:
+    """Everything a regional detector needs, in standalone-compatible form."""
+
+    pred: np.ndarray        # [S, H, N, F_out]  physical units (unless physical=False)
+    true: np.ndarray        # [S, H, N, F_out]  recorded signal
+    mask: np.ndarray        # [S, H, N, F_out]  1.0 = observed target, 0.0 = imputed/missing
+    A_geo: np.ndarray       # [N, N]            raw exp(-d/sigma) similarity, symmetric, 0 diag
+    sensor_ids: np.ndarray  # [N]               fdr_id in node order (from sites.csv)
+    timestamps: np.ndarray  # [S]               seconds from series start (float64)
+    out_idx: np.ndarray     # [F_out]           dynamic channels present in the outputs
+    freq_pos: int           # column of freq_dev within out_idx, or -1 if absent
+    rocof_pos: int          # column of rocof within out_idx, or -1 (-1 -> estimate from freq)
+    split: str
+    meta: dict              # raw downstream_meta.json contents
+
+
+def _split_lo(split: str, n_train: int, n_val: int, n_test: int) -> int:
+    """Start index (strided X/tvec timeline) of a split's contiguous segment.
+
+    Mirrors preprocess_stage's seg_bounds: train [0, n_train), val
+    [n_train, +n_val), test [.., +n_test), pred [.., T).
+    """
+    return {
+        "train": 0,
+        "val": n_train,
+        "test": n_train + n_val,
+        "pred": n_train + n_val + n_test,
+    }[split]
+
+
+def _denormalize(
+    arr: np.ndarray, feat_mean: np.ndarray, feat_std: np.ndarray, out_idx: np.ndarray
+) -> np.ndarray:
+    """``[S, H, N, F_out]`` standardized -> physical, using the per-node train
+    scaler restricted to the output channels. Safe on empty arrays."""
+    if arr.size == 0:
+        return arr
+    center = feat_mean[:, out_idx]  # [N, F_out]
+    scale = feat_std[:, out_idx]  # [N, F_out]
+    return arr * scale[None, None, :, :] + center[None, None, :, :]
+
+
+def load_split(
+    out_dir: Union[str, Path],
+    split: str,
+    *,
+    physical: bool = True,
+    horizon_offset: str = "first",
+) -> DownstreamData:
+    """Load one scored split from a forecaster ``out_dir`` as a ``DownstreamData``.
+
+    Parameters
+    ----------
+    out_dir : path to the fnet example's ``--out_dir``.
+    split : one of ``val`` / ``test`` / ``pred``.
+    physical : if True, denormalize preds/true to physical units; if False, leave
+        them in the model's standardized space.
+    horizon_offset : which forecast step a window's single timestamp refers to —
+        ``first`` (step ``s+1``, matches horizon_reduce mean/first) or ``last``
+        (step ``s+H``, matches horizon_reduce last).
+    """
+    out_dir = Path(out_dir)
+    if split not in _SCORED_SPLITS:
+        raise ValueError(
+            f"split must be one of {_SCORED_SPLITS} (got {split!r}); the fnet "
+            "example only scores those three."
+        )
+    if horizon_offset not in ("first", "last"):
+        raise ValueError("horizon_offset must be 'first' or 'last'")
+
+    meta = json.loads((out_dir / "downstream_meta.json").read_text())
+
+    # [S, N, H, F_out] -> [S, H, N, F_out]
+    def _load_shft(name: str) -> np.ndarray:
+        return np.ascontiguousarray(
+            np.transpose(np.load(out_dir / name), (0, 2, 1, 3))
+        ).astype(np.float32)
+
+    pred = _load_shft(f"preds_{split}.npy")
+    true = _load_shft(f"ys_{split}.npy")
+    mask = _load_shft(f"masks_{split}.npy")
+
+    out_idx = np.load(out_dir / "out_idx.npy").astype(np.int64)
+
+    if physical:
+        feat_mean = np.load(out_dir / "feat_mean.npy")
+        feat_std = np.load(out_dir / "feat_std.npy")
+        pred = _denormalize(pred, feat_mean, feat_std, out_idx)
+        true = _denormalize(true, feat_mean, feat_std, out_idx)
+
+    A_geo = np.load(out_dir / "A_geo.npy").astype(np.float64)
+    A_geo = np.maximum(A_geo, A_geo.T)  # defensive; already symmetric
+    np.fill_diagonal(A_geo, 0.0)
+
+    sensor_ids = pd.read_csv(out_dir / "sites.csv")["fdr_id"].to_numpy()
+
+    # --- timestamps: strided tvec + contiguous slice-then-window mapping --------
+    tvec = np.load(out_dir / "tvec.npy").astype(np.float64)
+    T = len(tvec)
+    n_train = int(T * float(meta["train_frac"]))
+    n_val = int(T * float(meta["val_frac"]))
+    n_test = int(T * float(meta["test_frac"]))
+    lo = _split_lo(split, n_train, n_val, n_test)
+    Tin = int(meta["Tin"])
+    H = int(meta["horizon"])
+    S = pred.shape[0]
+    # Forecast window for sample w spans strided steps [lo+Tin+w, lo+Tin+w+H-1].
+    base = lo + Tin + (H - 1 if horizon_offset == "last" else 0)
+    idx = np.clip(base + np.arange(S), 0, T - 1)
+    timestamps = tvec[idx]
+
+    freq_pos = (
+        int(np.where(out_idx == FREQ_CHANNEL)[0][0]) if FREQ_CHANNEL in out_idx else -1
+    )
+    rocof_pos = (
+        int(np.where(out_idx == ROCOF_CHANNEL)[0][0]) if ROCOF_CHANNEL in out_idx else -1
+    )
+
+    return DownstreamData(
+        pred=pred,
+        true=true,
+        mask=mask,
+        A_geo=A_geo,
+        sensor_ids=sensor_ids,
+        timestamps=timestamps,
+        out_idx=out_idx,
+        freq_pos=freq_pos,
+        rocof_pos=rocof_pos,
+        split=split,
+        meta=meta,
+    )

--- a/examples/fnet_temporal_anomaly_detection/downstream/regional_detector.py
+++ b/examples/fnet_temporal_anomaly_detection/downstream/regional_detector.py
@@ -1,0 +1,370 @@
+"""Regional-anomaly cluster detection on the fnet forecaster residuals.
+
+Unifies the two T-GCN detectors behind ``--detector``:
+
+  * ``map_hot`` (default) — high freq_dev error only, connected by geographic
+    adjacency above a raw weight threshold. Loose filter -> many raw clusters,
+    intended to be reduced to episodes by the collapse stage.
+  * ``strict`` — high freq_dev AND RoCoF error simultaneously, connected by
+    strong (edge-quantile) adjacency, with extra guards against degenerate
+    clusters. Tight filter -> ~tens of clusters.
+
+Rewired onto the downstream adapter (``downstream_io.load_split``), so it reads a
+forecaster ``--out_dir`` and inherits: mask-aware residuals (imputed targets
+excluded), timestamps from ``tvec`` (no parquet re-read), and the RoCoF channel
+branch (use a real rocof output if present, else estimate from freq).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+
+try:  # package import (e.g. from tests) vs script import (same-dir on sys.path)
+    from .downstream_io import DownstreamData, load_split
+except ImportError:  # pragma: no cover - exercised only when run as a script
+    from downstream_io import DownstreamData, load_split
+
+
+# --------------------------------------------------------------------------- #
+# Config
+# --------------------------------------------------------------------------- #
+
+
+@dataclass
+class DetectConfig:
+    detector: str = "map_hot"  # "map_hot" | "strict"
+    horizon_reduce: str = "mean"  # "mean" | "first" | "last"
+    min_cluster_size: int = 2
+    max_rows: int = 200
+    # map_hot
+    color_max_quantile: float = 0.90
+    edge_threshold: float = 0.0
+    # strict
+    freq_quantile: float = 0.98
+    rocof_quantile: float = 0.98
+    edge_quantile: float = 0.85
+    true_rocof_min_abs: float = 5e-4
+
+
+# --------------------------------------------------------------------------- #
+# Core numerics
+# --------------------------------------------------------------------------- #
+
+
+def connected_components(adj_mask: np.ndarray) -> list[list[int]]:
+    """Connected components of a boolean adjacency (iterative DFS)."""
+    n = adj_mask.shape[0]
+    visited = np.zeros(n, dtype=bool)
+    comps: list[list[int]] = []
+    for i in range(n):
+        if visited[i]:
+            continue
+        stack = [i]
+        visited[i] = True
+        comp: list[int] = []
+        while stack:
+            u = stack.pop()
+            comp.append(u)
+            for v in np.flatnonzero(adj_mask[u]).tolist():
+                if not visited[v]:
+                    visited[v] = True
+                    stack.append(v)
+        comps.append(comp)
+    return comps
+
+
+def masked_horizon_reduce(
+    arr: np.ndarray, mask: np.ndarray, mode: str
+) -> tuple[np.ndarray, np.ndarray]:
+    """Reduce the H axis of ``[S, H, N, F]`` to ``[S, N, F]``, observed-only.
+
+    Returns ``(reduced, valid)`` where ``valid`` ``[S, N, F]`` is True where at
+    least one observed step contributed. ``mean`` averages over observed steps;
+    ``first`` / ``last`` take that horizon step (valid iff it is observed).
+    """
+    if mode == "mean":
+        num = (arr * mask).sum(axis=1)
+        den = mask.sum(axis=1)
+        reduced = num / np.clip(den, 1.0, None)
+        valid = den > 0.5
+        return reduced, valid
+    step = 0 if mode == "first" else -1
+    return arr[:, step], mask[:, step] > 0.5
+
+
+@dataclass
+class _Residuals:
+    pf: np.ndarray  # [S, N] pred freq (reduced, physical)
+    tf: np.ndarray  # [S, N] true freq
+    freq_dev: np.ndarray  # [S, N] |pf - tf| where valid, else 0
+    valid: np.ndarray  # [S, N] bool, freq observed
+    pr: np.ndarray | None  # [S, N] pred rocof (real channel or first-diff estimate)
+    tr: np.ndarray | None  # [S, N] true rocof
+    rocof_dev: np.ndarray | None  # [S, N] |pr - tr|
+    rocof_source: str  # "channel" | "estimated" | "none"
+
+
+def compute_residuals(data: DownstreamData, cfg: DetectConfig) -> _Residuals:
+    if data.freq_pos < 0:
+        raise ValueError(
+            "freq_dev (channel 0) is not among the forecaster outputs (out_idx="
+            f"{data.out_idx.tolist()}); regional detection needs it."
+        )
+    red_p, valid_p = masked_horizon_reduce(data.pred, data.mask, cfg.horizon_reduce)
+    red_t, _ = masked_horizon_reduce(data.true, data.mask, cfg.horizon_reduce)
+
+    fp = data.freq_pos
+    pf, tf = red_p[:, :, fp], red_t[:, :, fp]
+    valid = valid_p[:, :, fp]
+    freq_dev = np.abs(pf - tf) * valid
+
+    pr = tr = rocof_dev = None
+    rocof_source = "none"
+    need_rocof = cfg.detector == "strict"
+    if need_rocof:
+        if data.rocof_pos >= 0:
+            rp = data.rocof_pos
+            pr, tr = red_p[:, :, rp], red_t[:, :, rp]
+            rocof_source = "channel"
+        else:
+            # Fallback: estimate rocof as first difference over samples of the
+            # reduced freq (identical to the forecaster's own rocof =
+            # np.diff(freq_dev)).
+            pr = np.zeros_like(pf)
+            tr = np.zeros_like(tf)
+            pr[1:] = pf[1:] - pf[:-1]
+            tr[1:] = tf[1:] - tf[:-1]
+            rocof_source = "estimated"
+        rocof_dev = np.abs(pr - tr) * valid
+
+    return _Residuals(pf, tf, freq_dev, valid, pr, tr, rocof_dev, rocof_source)
+
+
+def _thresholded_adjacency(A_geo: np.ndarray, cfg: DetectConfig) -> tuple[np.ndarray, float]:
+    """Boolean edge mask + the threshold used, per detector."""
+    A = np.maximum(A_geo, A_geo.T).astype(float)
+    np.fill_diagonal(A, 0.0)
+    if cfg.detector == "strict":
+        pos = A[A > 0]
+        thr = (
+            float(np.quantile(pos, min(max(cfg.edge_quantile, 0.01), 0.9999)))
+            if pos.size
+            else 0.0
+        )
+        return A >= thr, thr
+    return A > float(cfg.edge_threshold), float(cfg.edge_threshold)
+
+
+# --------------------------------------------------------------------------- #
+# Detection
+# --------------------------------------------------------------------------- #
+
+
+def detect_clusters(
+    data: DownstreamData, cfg: DetectConfig, name_map: dict | None = None
+) -> tuple[pd.DataFrame, pd.DataFrame, dict]:
+    """Return ``(clusters_all, clusters_top, thresholds)``.
+
+    Same connected-components core for both detectors; the activation criterion,
+    adjacency threshold, ranking, and degeneracy guards are detector-specific.
+    ``name_map`` optionally maps fdr_id -> human name (else ``Sensor-<id>``).
+    """
+    res = compute_residuals(data, cfg)
+    N = data.sensor_ids.shape[0]
+    edge_mask, edge_thr = _thresholded_adjacency(data.A_geo, cfg)
+
+    # Activation thresholds over observed cells only.
+    obs = res.valid
+    freq_obs = res.freq_dev[obs]
+    if freq_obs.size == 0:
+        raise ValueError("No observed forecast cells in this split; nothing to detect.")
+    freq_thr = float(
+        np.quantile(freq_obs, min(max(cfg.color_max_quantile if cfg.detector == "map_hot" else cfg.freq_quantile, 0.01), 0.9999))
+    )
+    if cfg.detector == "strict":
+        rocof_obs = res.rocof_dev[obs]
+        rocof_thr = float(
+            np.quantile(rocof_obs, min(max(cfg.rocof_quantile, 0.5), 0.9999))
+        )
+        active = (res.freq_dev >= freq_thr) & (res.rocof_dev >= rocof_thr) & obs
+    else:
+        rocof_thr = None
+        active = (res.freq_dev >= freq_thr) & obs
+
+    name_map = name_map or {}
+
+    rows: list[dict] = []
+    cluster_id = 0
+    for t in range(active.shape[0]):
+        active_nodes = np.flatnonzero(active[t])
+        if active_nodes.size < cfg.min_cluster_size:
+            continue
+        induced = edge_mask[np.ix_(active_nodes, active_nodes)]
+        for comp in connected_components(induced):
+            if len(comp) < cfg.min_cluster_size:
+                continue
+            nodes = active_nodes[np.array(comp, dtype=int)]
+
+            if cfg.detector == "strict":
+                tr_vals = res.tr[t, nodes]
+                if float(np.max(np.abs(tr_vals))) <= float(cfg.true_rocof_min_abs):
+                    continue
+                tf_vals = res.tf[t, nodes]
+                if (
+                    float(np.max(tf_vals) - np.min(tf_vals)) <= 1e-12
+                    and float(np.max(tr_vals) - np.min(tr_vals)) <= 1e-12
+                ):
+                    continue
+                freq_mean = float(np.mean(res.freq_dev[t, nodes]))
+                rocof_mean = float(np.mean(res.rocof_dev[t, nodes]))
+                if freq_mean <= 1e-12 or rocof_mean <= 1e-12:
+                    continue
+                magnitude = freq_mean + rocof_mean
+                score = len(nodes) * magnitude
+            else:
+                freq_mean = float(np.mean(res.freq_dev[t, nodes]))
+                rocof_mean = None
+                magnitude = freq_mean
+                score = len(nodes) * magnitude
+
+            ids = [int(data.sensor_ids[i]) for i in nodes.tolist()]
+            row = {
+                "cluster_id": cluster_id,
+                "time_idx": int(t),
+                "timestamp": f"{float(data.timestamps[t]):.3f}s",
+                "cluster_size": int(len(nodes)),
+                "mean_abs_err": freq_mean,
+                "max_abs_err": float(np.max(res.freq_dev[t, nodes])),
+                "score": float(score),
+                "magnitude": float(magnitude),
+                "sensor_ids": ";".join(str(x) for x in ids),
+                "sensor_names": ";".join(name_map.get(x, f"Sensor-{x}") for x in ids),
+                "sensor_indices": ";".join(str(int(x)) for x in nodes.tolist()),
+            }
+            if cfg.detector == "strict":
+                row["mean_freq_dev"] = freq_mean
+                row["mean_rocof_dev"] = rocof_mean
+            rows.append(row)
+            cluster_id += 1
+
+    if not rows:
+        raise ValueError(
+            "No clusters detected. Lower the quantile / min_cluster_size, or check "
+            "that the split has real disturbances."
+        )
+
+    clusters_all = pd.DataFrame(rows)
+    if cfg.detector == "strict":
+        clusters_all = clusters_all.sort_values(
+            ["score", "cluster_size", "magnitude"], ascending=False
+        ).reset_index(drop=True)
+    else:
+        clusters_all = clusters_all.sort_values(
+            ["cluster_size", "mean_abs_err", "max_abs_err"], ascending=False
+        ).reset_index(drop=True)
+    clusters_top = clusters_all.head(max(1, cfg.max_rows)).copy()
+
+    thresholds = {
+        "detector": cfg.detector,
+        "freq_threshold": freq_thr,
+        "rocof_threshold": rocof_thr,
+        "edge_threshold": edge_thr,
+        "rocof_source": res.rocof_source,
+        "horizon_reduce": cfg.horizon_reduce,
+        "num_samples": int(active.shape[0]),
+        "num_sensors": int(N),
+        "clusters_detected": int(len(clusters_all)),
+    }
+    return clusters_all, clusters_top, thresholds
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+
+
+def _out_names(detector: str) -> tuple[str, str]:
+    if detector == "map_hot":
+        return "map_freq_hot_clusters_all.csv", "map_freq_hot_clusters_top.csv"
+    return "clusters_all.csv", "clusters_top.csv"
+
+
+def build_argparser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description="Regional-anomaly cluster detection on forecaster residuals",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--out_dir", required=True, help="forecaster output dir (from the fnet example)")
+    p.add_argument("--split", default="pred", choices=["val", "test", "pred"])
+    p.add_argument("--detector", default="map_hot", choices=["map_hot", "strict"])
+    p.add_argument("--results_dir", default=None, help="where to write cluster CSVs (default: <out_dir>/downstream)")
+    p.add_argument("--horizon_reduce", default="mean", choices=["mean", "first", "last"])
+    p.add_argument("--min_cluster_size", type=int, default=2)
+    p.add_argument("--max_rows", type=int, default=200)
+    # map_hot
+    p.add_argument("--color_max_quantile", type=float, default=0.90)
+    p.add_argument("--edge_threshold", type=float, default=0.0)
+    # strict
+    p.add_argument("--freq_quantile", type=float, default=0.98)
+    p.add_argument("--rocof_quantile", type=float, default=0.98)
+    p.add_argument("--edge_quantile", type=float, default=0.85)
+    p.add_argument("--true_rocof_min_abs", type=float, default=5e-4)
+    return p
+
+
+def main(argv=None) -> None:
+    args = build_argparser().parse_args(argv)
+    cfg = DetectConfig(
+        detector=args.detector,
+        horizon_reduce=args.horizon_reduce,
+        min_cluster_size=args.min_cluster_size,
+        max_rows=args.max_rows,
+        color_max_quantile=args.color_max_quantile,
+        edge_threshold=args.edge_threshold,
+        freq_quantile=args.freq_quantile,
+        rocof_quantile=args.rocof_quantile,
+        edge_quantile=args.edge_quantile,
+        true_rocof_min_abs=args.true_rocof_min_abs,
+    )
+    data = load_split(args.out_dir, args.split, horizon_offset="first")
+
+    # Human-readable node names from sites.csv (grid_name), aligned by fdr_id.
+    name_map = {}
+    sites_csv = Path(args.out_dir) / "sites.csv"
+    if sites_csv.exists():
+        sites = pd.read_csv(sites_csv)
+        if "grid_name" in sites.columns:
+            name_map = {
+                int(fid): str(nm)
+                for fid, nm in zip(sites["fdr_id"], sites["grid_name"])
+            }
+
+    clusters_all, clusters_top, thresholds = detect_clusters(data, cfg, name_map)
+
+    results_dir = Path(args.results_dir) if args.results_dir else Path(args.out_dir) / "downstream"
+    results_dir.mkdir(parents=True, exist_ok=True)
+    all_name, top_name = _out_names(cfg.detector)
+    clusters_all.to_csv(results_dir / all_name, index=False)
+    clusters_top.to_csv(results_dir / top_name, index=False)
+    with open(results_dir / f"{cfg.detector}_thresholds.json", "w") as f:
+        json.dump(thresholds, f, indent=2)
+
+    print(f"[detect] detector={cfg.detector} split={args.split} rocof={thresholds['rocof_source']}")
+    print(
+        f"[detect] freq_thr={thresholds['freq_threshold']:.5f} "
+        + (f"rocof_thr={thresholds['rocof_threshold']:.5f} " if thresholds["rocof_threshold"] else "")
+        + f"edge_thr={thresholds['edge_threshold']:.5f}"
+    )
+    print(f"[detect] clusters: all={len(clusters_all)} top={len(clusters_top)}")
+    print(f"[save]   {results_dir / all_name}")
+    print(f"[save]   {results_dir / top_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
+++ b/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
@@ -879,11 +879,14 @@ def preprocess_stage(args, cache_dir: Path):
     n_train = int(T * args.train_frac)
     n_val = int(T * args.val_frac)
     n_test = int(T * args.test_frac)
+    n_pred = int(T * args.pred_frac)
+    pred_start = n_train + n_val + n_test
+
     seg_bounds = [
         ("train", 0, n_train),
         ("val", n_train, n_train + n_val),
-        ("test", n_train + n_val, n_train + n_val + n_test),
-        ("pred", n_train + n_val + n_test, T),
+        ("test", n_train + n_val, pred_start),
+        ("pred", pred_start, min(pred_start + n_pred, T)),
     ]
     out_idx = np.array(args.out_features, dtype=np.int64)
     seg_data = {

--- a/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
+++ b/examples/fnet_temporal_anomaly_detection/fnet_temporal_anomaly_detection.py
@@ -495,6 +495,10 @@ def build_geo_knn_graph(meta_active: pd.DataFrame, k: int, sigma_km: float):
     edge_index  : LongTensor [2, E]   directed (symmetric) edges
     edge_weight : FloatTensor [E]
     A_hat       : np.ndarray [N, N]   GCN-normalized adjacency (D^-0.5 (A+I) D^-0.5)
+    A_geo       : np.ndarray [N, N]   raw exp(-d/sigma) similarity, symmetric,
+                                      zero diagonal (pre-normalization). Downstream
+                                      cluster detection thresholds on the
+                                      raw weights, which A_hat cannot recover.
     """
     coords = meta_active[["Latitude", "Longitude"]].to_numpy(dtype=np.float64)
     coords_rad = np.radians(coords)
@@ -526,7 +530,9 @@ def build_geo_knn_graph(meta_active: pd.DataFrame, k: int, sigma_km: float):
     deg = A_self.sum(axis=1)
     D_inv_sqrt = np.diag(1.0 / np.sqrt(np.clip(deg, 1e-12, None)))
     A_hat = D_inv_sqrt @ A_self @ D_inv_sqrt
-    return edge_index, edge_weight, A_hat
+    # A is the raw exp(-d/sigma) similarity (symmetric, zero-diagonal); return it
+    # too so downstream detection can threshold on the un-normalized weights.
+    return edge_index, edge_weight, A_hat, A.astype(np.float32)
 
 
 def build_grid_embeddings(
@@ -835,7 +841,7 @@ def preprocess_stage(args, cache_dir: Path):
             args.medium_gap_steps,
         )
 
-    edge_index, edge_weight, A_hat = build_geo_knn_graph(
+    edge_index, edge_weight, A_hat, A_geo = build_geo_knn_graph(
         meta_active, k=args.k, sigma_km=args.sigma_km
     )
     print(
@@ -924,6 +930,7 @@ def preprocess_stage(args, cache_dir: Path):
         "edge_index": edge_index,
         "edge_weight": edge_weight,
         "A_hat": A_hat,
+        "A_geo": A_geo,
         "grid_embed": grid_embed,
         "grid_name_to_idx": grid_name_to_idx,
         "grid_names": grid_names,
@@ -1087,6 +1094,7 @@ def train_stage(args, cache_dir: Path):
     np.save(out_dir / "tvec.npy", meta["tvec"])
     np.save(out_dir / "X.npy", meta["X"])
     np.save(out_dir / "A_hat.npy", meta["A_hat"])
+    np.save(out_dir / "A_geo.npy", meta["A_geo"])
     np.save(out_dir / "grid_embed.npy", meta["grid_embed"])
     np.save(out_dir / "preds_val.npy", preds_val)
     np.save(out_dir / "ys_val.npy", ys_val)
@@ -1103,6 +1111,29 @@ def train_stage(args, cache_dir: Path):
         np.save(out_dir / "feat_mean.npy", meta["feat_mean"])
         np.save(out_dir / "feat_std.npy", meta["feat_std"])
         np.save(out_dir / "out_idx.npy", meta["out_idx"])
+    # Run metadata Downstream needs but that the saved arrays don't encode: Tin and
+    # the split fractions (to recover each split's segment start) plus context
+    # (dt, scaling, predict_delta). H / F_out / N are recoverable from the preds
+    # array shapes, so they are informational here. tvec.npy is already strided,
+    # so the window->timestamp math runs entirely in strided-index space.
+    with open(out_dir / "downstream_meta.json", "w") as f:
+        json.dump(
+            {
+                "Tin": int(meta["Tin"]),
+                "horizon": int(meta["horizon"]),
+                "train_frac": float(args.train_frac),
+                "val_frac": float(args.val_frac),
+                "test_frac": float(args.test_frac),
+                "stride": int(args.stride),
+                "dt": float(meta["dt"]),
+                "scaling": meta.get("scaling"),
+                "predict_delta": bool(meta.get("predict_delta", False)),
+                "n_nodes": int(len(meta["fdr_ids"])),
+                "F_out": int(meta["F_out"]),
+            },
+            f,
+            indent=2,
+        )
     pd.DataFrame(
         {
             "site": meta["sites"],

--- a/examples/fnet_temporal_anomaly_detection/score_train_split.py
+++ b/examples/fnet_temporal_anomaly_detection/score_train_split.py
@@ -153,13 +153,22 @@ def main():
 
     raw_model = (model.module if hasattr(model, "module") else model).to(device)
     print("[score] Scoring train split ...")
-    preds_train, ys_train = _score_split(raw_model, train_loader, meta, device)
-    train_mse = float(np.mean((preds_train - ys_train) ** 2)) if preds_train.size else float("nan")
+    preds_train, ys_train, masks_train = _score_split(
+        raw_model, train_loader, meta, device
+    )
+    # Masked MSE over observed targets only (matches the cov80 masked metrics).
+    if preds_train.size:
+        valid = masks_train.reshape(-1) > 0.5
+        err = preds_train.reshape(-1)[valid] - ys_train.reshape(-1)[valid]
+        train_mse = float(np.mean(err**2)) if err.size else float("nan")
+    else:
+        train_mse = float("nan")
     print(f"[score] train MSE = {train_mse:.6e}  shape={preds_train.shape}")
 
     np.save(out_dir / "preds_train.npy", preds_train)
     np.save(out_dir / "ys_train.npy", ys_train)
-    print(f"[save]  wrote preds_train.npy / ys_train.npy to {out_dir}/")
+    np.save(out_dir / "masks_train.npy", masks_train)
+    print(f"[save]  wrote preds_train / ys_train / masks_train .npy to {out_dir}/")
 
 
 if __name__ == "__main__":

--- a/tests/test_downstream_episodes.py
+++ b/tests/test_downstream_episodes.py
@@ -1,0 +1,131 @@
+"""Unit tests for downstream episode collapse (collapse_episodes).
+
+Pure pandas, no model, no parquet. Exercises the gap-based collapse, the
+auto-gap selection, the peak-window suppression, and the end-to-end collapse().
+"""
+
+import importlib.util
+import os
+import sys
+
+import pandas as pd
+import pytest
+
+_HERE = os.path.dirname(__file__)
+_MODULE = os.path.join(
+    _HERE,
+    "..",
+    "examples",
+    "fnet_temporal_anomaly_detection",
+    "downstream",
+    "collapse_episodes.py",
+)
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("collapse_episodes", _MODULE)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+ce = _load()
+
+
+def _clusters(rows):
+    df = pd.DataFrame(rows)
+    for col, default in (
+        ("cluster_size", 3),
+        ("max_abs_err", 0.0),
+        ("sensor_names", ""),
+        ("sensor_indices", ""),
+        ("timestamp", ""),
+    ):
+        if col not in df.columns:
+            df[col] = default
+    return df
+
+
+@pytest.mark.mpi_skip()
+def pytest_canonical_sensor_set_is_order_independent():
+    assert ce.canonical_sensor_set("2;0;1") == "0;1;2"
+    assert ce.canonical_sensor_set("0;1;2") == ce.canonical_sensor_set("1;2;0")
+
+
+@pytest.mark.mpi_skip()
+def pytest_collapse_splits_on_time_gap():
+    """Same sensor set, a 38-step gap -> two episodes; peak = max mean_abs_err."""
+    df = _clusters(
+        [
+            {"time_idx": 10, "sensor_ids": "0;1;2", "mean_abs_err": 0.5},
+            {"time_idx": 11, "sensor_ids": "0;1;2", "mean_abs_err": 0.9},  # peak 1
+            {"time_idx": 12, "sensor_ids": "0;1;2", "mean_abs_err": 0.4},
+            {"time_idx": 50, "sensor_ids": "0;1;2", "mean_abs_err": 0.7},  # peak 2
+            {"time_idx": 51, "sensor_ids": "0;1;2", "mean_abs_err": 0.3},
+        ]
+    )
+    df["sensor_set"] = df["sensor_ids"].map(ce.canonical_sensor_set)
+    eps = ce.collapse_to_episodes(df, episode_gap=10)
+
+    assert len(eps) == 2
+    e0 = eps[eps["start_time_idx"] == 10].iloc[0]
+    assert e0["end_time_idx"] == 12 and e0["peak_time_idx"] == 11 and e0["n_frames"] == 3
+    assert e0["peak_mean_abs_err"] == pytest.approx(0.9)
+    e1 = eps[eps["start_time_idx"] == 50].iloc[0]
+    assert e1["peak_time_idx"] == 50 and e1["n_frames"] == 2
+
+
+@pytest.mark.mpi_skip()
+def pytest_choose_gap_picks_smallest_under_target():
+    """A 15-step separation: gap=10 -> 2 episodes, gap=20 -> 1; target 1 -> gap 20."""
+    df = _clusters(
+        [
+            {"time_idx": 0, "sensor_ids": "0;1", "mean_abs_err": 0.5},
+            {"time_idx": 1, "sensor_ids": "0;1", "mean_abs_err": 0.6},
+            {"time_idx": 16, "sensor_ids": "0;1", "mean_abs_err": 0.7},
+            {"time_idx": 17, "sensor_ids": "0;1", "mean_abs_err": 0.4},
+        ]
+    )
+    df["sensor_set"] = df["sensor_ids"].map(ce.canonical_sensor_set)
+    used, eps = ce.choose_episode_gap(df, 10, [10, 20], target_max_episodes=1)
+    assert used == 20 and len(eps) == 1
+
+
+@pytest.mark.mpi_skip()
+def pytest_peak_window_overlap_vs_global():
+    """Within the window: sensor_overlap keeps a non-overlapping episode, global
+    suppresses it regardless."""
+    eps = pd.DataFrame(
+        [
+            {"peak_time_idx": 100, "sensor_ids": "0;1"},
+            {"peak_time_idx": 110, "sensor_ids": "3;4"},  # within window, no overlap
+            {"peak_time_idx": 300, "sensor_ids": "5;6"},  # far away
+        ]
+    )
+    sel_so = ce.select_with_peak_window(
+        eps, max_selected=10, window=50, overlap_mode="sensor_overlap"
+    )
+    assert len(sel_so) == 3  # non-overlapping neighbor kept
+    sel_g = ce.select_with_peak_window(
+        eps, max_selected=10, window=50, overlap_mode="global"
+    )
+    assert len(sel_g) == 2  # peak 110 suppressed by 100
+
+
+@pytest.mark.mpi_skip()
+def pytest_collapse_end_to_end_filters_small_clusters():
+    clusters = _clusters(
+        [
+            {"time_idx": 10, "sensor_ids": "0;1;2", "mean_abs_err": 0.9, "cluster_size": 3},
+            {"time_idx": 11, "sensor_ids": "0;1;2", "mean_abs_err": 0.5, "cluster_size": 3},
+            {"time_idx": 40, "sensor_ids": "7;8", "mean_abs_err": 0.8, "cluster_size": 2},
+        ]
+    )
+    episodes, selected, summary = ce.collapse(
+        clusters, episode_gap=10, auto_increase_cutoff=False, min_cluster_size=3
+    )
+    assert len(episodes) == 1  # the size-2 "7;8" cluster is filtered out
+    assert summary["episodes_after_collapse"] == 1
+    assert not selected.empty
+    assert episodes.iloc[0]["sensor_set"] == "0;1;2"

--- a/tests/test_downstream_io.py
+++ b/tests/test_downstream_io.py
@@ -1,0 +1,215 @@
+"""Parquet-free unit tests for the downstream adapter.
+
+Builds a tiny synthetic forecaster ``out_dir`` on disk (random arrays, a 3-row
+sites.csv, a strided tvec, and downstream_meta.json) and checks the four transforms
+the adapter is responsible for:
+
+  * axis swap        preds_{split} [S,N,H,F_out] -> [S,H,N,F_out]
+  * denormalize      standardized -> physical via feat_mean/std restricted to out_idx
+  * timestamps       strided-tvec window mapping  tvec[lo + Tin + w]
+  * out_idx branch   freq_pos / rocof_pos (DB4: default [0,2,3] drops rocof)
+
+The adapter imports only numpy/pandas (no hydragnn, no torch), so it is loaded
+directly from its file path.
+"""
+
+import importlib.util
+import json
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+_ADAPTER = os.path.join(
+    os.path.dirname(__file__),
+    "..",
+    "examples",
+    "fnet_temporal_anomaly_detection",
+    "downstream",
+    "downstream_io.py",
+)
+
+
+def _load_adapter():
+    spec = importlib.util.spec_from_file_location("downstream_io", _ADAPTER)
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so @dataclass can resolve the module in sys.modules
+    # (dataclasses looks up cls.__module__ there during class processing).
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+tb = _load_adapter()
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic out_dir builder
+# --------------------------------------------------------------------------- #
+
+_F_DYN = 4  # freq_dev, rocof, angle_delta, volt_dev
+_T = 200
+_TRAIN, _VAL, _TEST = 0.8, 0.05, 0.05  # -> n_train=160, n_val=10, n_test=10
+_TIN, _H = 5, 3
+
+
+def _write_out_dir(out_dir, split, out_idx, S, N):
+    """Write a minimal forecaster out_dir; return the raw (pre-transform) arrays."""
+    out_dir = str(out_dir)
+    os.makedirs(out_dir, exist_ok=True)
+    F_out = len(out_idx)
+    out_idx = np.asarray(out_idx, dtype=np.int64)
+
+    # preds/ys stored as [S, N, H, F_out]; encode indices so the transpose is
+    # unambiguously checkable: value = s*1000 + n*100 + h*10 + f.
+    s, n, h, f = np.meshgrid(
+        np.arange(S), np.arange(N), np.arange(_H), np.arange(F_out), indexing="ij"
+    )
+    preds_raw = (s * 1000 + n * 100 + h * 10 + f).astype(np.float32)
+    ys_raw = preds_raw + 0.5
+    masks_raw = (((s + n + h + f) % 2) == 0).astype(np.float32)  # 0/1 checkerboard
+
+    np.save(os.path.join(out_dir, f"preds_{split}.npy"), preds_raw)
+    np.save(os.path.join(out_dir, f"ys_{split}.npy"), ys_raw)
+    np.save(os.path.join(out_dir, f"masks_{split}.npy"), masks_raw)
+    np.save(os.path.join(out_dir, "out_idx.npy"), out_idx)
+
+    # Non-trivial per-node scaler over all F_dyn channels.
+    feat_mean = (np.arange(N * _F_DYN).reshape(N, _F_DYN) + 1.0).astype(np.float32)
+    feat_std = (np.arange(N * _F_DYN).reshape(N, _F_DYN) * 0.1 + 2.0).astype(np.float32)
+    np.save(os.path.join(out_dir, "feat_mean.npy"), feat_mean)
+    np.save(os.path.join(out_dir, "feat_std.npy"), feat_std)
+
+    # Asymmetric raw graph with a diagonal -> adapter must symmetrize + zero diag.
+    A = np.zeros((N, N), dtype=np.float32)
+    for i in range(N - 1):
+        A[i, i + 1] = 0.3 + 0.1 * i
+    np.fill_diagonal(A, 5.0)
+    np.save(os.path.join(out_dir, "A_geo.npy"), A)
+
+    pd.DataFrame(
+        {
+            "site": [f"S{i}" for i in range(N)],
+            "fdr_id": [1000 + i for i in range(N)],
+            "grid_name": [f"grid{i}" for i in range(N)],
+        }
+    ).to_csv(os.path.join(out_dir, "sites.csv"), index=False)
+
+    tvec = (np.arange(_T) * 0.5).astype(np.float32)  # 2 Hz
+    np.save(os.path.join(out_dir, "tvec.npy"), tvec)
+
+    meta = {
+        "Tin": _TIN,
+        "horizon": _H,
+        "train_frac": _TRAIN,
+        "val_frac": _VAL,
+        "test_frac": _TEST,
+        "stride": 1,
+        "dt": 0.5,
+        "scaling": "per_node",
+        "predict_delta": False,
+        "n_nodes": N,
+        "F_out": F_out,
+    }
+    with open(os.path.join(out_dir, "downstream_meta.json"), "w") as fp:
+        json.dump(meta, fp)
+
+    return preds_raw, ys_raw, masks_raw, feat_mean, feat_std, tvec
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.mpi_skip()
+def pytest_downstream_axis_swap_and_mask(tmp_path):
+    """preds [S,N,H,F] -> [S,H,N,F]; mask same shape, values in {0,1}."""
+    S, N, out_idx = 8, 4, [0, 2, 3]
+    preds_raw, _, masks_raw, _, _, _ = _write_out_dir(tmp_path, "test", out_idx, S, N)
+
+    d = tb.load_split(tmp_path, "test", physical=False)
+
+    assert d.pred.shape == (S, _H, N, len(out_idx))
+    assert d.mask.shape == d.pred.shape
+    # Spot-check the transpose: loaded[s,h,n,f] == raw[s,n,h,f].
+    for (si, hi, ni, fi) in [(0, 0, 0, 0), (7, 2, 3, 2), (3, 1, 2, 1)]:
+        assert d.pred[si, hi, ni, fi] == preds_raw[si, ni, hi, fi]
+        assert d.mask[si, hi, ni, fi] == masks_raw[si, ni, hi, fi]
+    assert set(np.unique(d.mask).tolist()).issubset({0.0, 1.0})
+
+
+@pytest.mark.mpi_skip()
+def pytest_downstream_denormalize(tmp_path):
+    """physical=True applies feat_mean/std restricted to out_idx, per node."""
+    S, N, out_idx = 8, 4, [0, 2, 3]
+    _, _, _, feat_mean, feat_std, _ = _write_out_dir(tmp_path, "test", out_idx, S, N)
+
+    std = tb.load_split(tmp_path, "test", physical=False)
+    phys = tb.load_split(tmp_path, "test", physical=True)
+
+    oi = np.asarray(out_idx)
+    expected = std.pred * feat_std[:, oi][None, None, :, :] + feat_mean[:, oi][
+        None, None, :, :
+    ]
+    assert np.allclose(phys.pred, expected, atol=1e-4)
+    # Sanity: denormalization actually changed the values.
+    assert not np.allclose(phys.pred, std.pred)
+
+
+@pytest.mark.mpi_skip()
+def pytest_downstream_timestamps(tmp_path):
+    """Window w of a split maps to tvec[lo + Tin + w] (strided-index space)."""
+    S, N, out_idx = 8, 4, [0, 2, 3]
+    _, _, _, _, _, tvec = _write_out_dir(tmp_path, "test", out_idx, S, N)
+
+    d = tb.load_split(tmp_path, "test", horizon_offset="first")
+
+    n_train = int(_T * _TRAIN)  # 160
+    n_val = int(_T * _VAL)  # 10
+    lo = n_train + n_val  # test segment start = 170
+    base = lo + _TIN  # 175
+    expected = tvec[base + np.arange(S)]
+    assert np.allclose(d.timestamps, expected)
+
+    # horizon_offset='last' shifts by H-1.
+    d_last = tb.load_split(tmp_path, "test", horizon_offset="last")
+    assert np.allclose(d_last.timestamps, tvec[base + (_H - 1) + np.arange(S)])
+
+
+@pytest.mark.mpi_skip()
+def pytest_downstream_out_idx_branch(tmp_path):
+    """DB4: default outputs [0,2,3] drop rocof (rocof_pos=-1); [0,1,2,3] keep it."""
+    d_default = tb.load_split(
+        _fresh(tmp_path, "a", [0, 2, 3]), "test", physical=False
+    )
+    assert d_default.freq_pos == 0
+    assert d_default.rocof_pos == -1
+
+    d_full = tb.load_split(_fresh(tmp_path, "b", [0, 1, 2, 3]), "test", physical=False)
+    assert d_full.freq_pos == 0
+    assert d_full.rocof_pos == 1
+
+
+@pytest.mark.mpi_skip()
+def pytest_downstream_graph_symmetrized(tmp_path):
+    """A_geo is symmetrized with a zeroed diagonal even from an asymmetric save."""
+    d = tb.load_split(_fresh(tmp_path, "g", [0, 2, 3]), "test", physical=False)
+    assert np.allclose(d.A_geo, d.A_geo.T)
+    assert np.allclose(np.diag(d.A_geo), 0.0)
+
+
+@pytest.mark.mpi_skip()
+def pytest_downstream_rejects_train_split(tmp_path):
+    """train is never scored/saved by the fnet example -> explicit error."""
+    _write_out_dir(tmp_path, "test", [0, 2, 3], 8, 4)
+    with pytest.raises(ValueError):
+        tb.load_split(tmp_path, "train")
+
+
+def _fresh(tmp_path, name, out_idx):
+    d = tmp_path / name
+    _write_out_dir(d, "test", out_idx, 8, 4)
+    return d

--- a/tests/test_downstream_regional.py
+++ b/tests/test_downstream_regional.py
@@ -1,0 +1,217 @@
+"""Unit tests for downstream regional cluster detection (regional_detector).
+
+No parquet, no model. Building blocks (connected components, mask-aware horizon
+reduce, rocof branch, adjacency thresholding) are tested directly; the two
+detectors are run end-to-end on tiny hand-built DownstreamData where the cell
+counts are fixed so the internal quantile thresholds land at known values.
+"""
+
+import importlib.util
+import os
+import sys
+
+import numpy as np
+import pytest
+
+_HERE = os.path.dirname(__file__)
+_DOWNSTREAM = os.path.join(
+    _HERE, "..", "examples", "fnet_temporal_anomaly_detection", "downstream"
+)
+
+
+def _load(name, filename):
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_DOWNSTREAM, filename)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod  # register so dataclass / absolute import resolve
+    spec.loader.exec_module(mod)
+    return mod
+
+
+tb = _load("downstream_io", "downstream_io.py")  # load first (regional imports it)
+rd = _load("regional_detector", "regional_detector.py")
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+
+
+def _path_graph(n):
+    """Undirected path 0-1-...-(n-1), unit weights."""
+    A = np.zeros((n, n), dtype=np.float64)
+    for i in range(n - 1):
+        A[i, i + 1] = A[i + 1, i] = 1.0
+    return A
+
+
+def _mk_data(pred, true, mask, A, out_idx, timestamps=None):
+    out_idx = np.asarray(out_idx, dtype=np.int64)
+    N = pred.shape[2]
+    S = pred.shape[0]
+    freq_pos = int(np.where(out_idx == 0)[0][0]) if 0 in out_idx else -1
+    rocof_pos = int(np.where(out_idx == 1)[0][0]) if 1 in out_idx else -1
+    return tb.DownstreamData(
+        pred=pred.astype(np.float32),
+        true=true.astype(np.float32),
+        mask=mask.astype(np.float32),
+        A_geo=A,
+        sensor_ids=np.array([100 + i for i in range(N)]),
+        timestamps=(np.arange(S, dtype=float) if timestamps is None else timestamps),
+        out_idx=out_idx,
+        freq_pos=freq_pos,
+        rocof_pos=rocof_pos,
+        split="test",
+        meta={},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Building blocks
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.mpi_skip()
+def pytest_connected_components_path():
+    A = _path_graph(4) > 0
+    comps = rd.connected_components(A)
+    assert len(comps) == 1 and sorted(comps[0]) == [0, 1, 2, 3]
+    # Break the middle edge -> two components.
+    A2 = A.copy()
+    A2[1, 2] = A2[2, 1] = False
+    comps2 = rd.connected_components(A2)
+    assert sorted(sorted(c) for c in comps2) == [[0, 1], [2, 3]]
+
+
+@pytest.mark.mpi_skip()
+def pytest_masked_horizon_reduce_excludes_unobserved():
+    """Masked steps are excluded from the mean; all-masked -> invalid."""
+    # [S=1, H=2, N=2, F=1]; node0 has 2nd step masked, node1 fully masked.
+    arr = np.array([[[[2.0], [9.0]], [[6.0], [9.0]]]])  # [1,2,2,1]
+    mask = np.array([[[[1.0], [0.0]], [[1.0], [0.0]]]])
+    red, valid = rd.masked_horizon_reduce(arr, mask, "mean")
+    assert red.shape == (1, 2, 1) and valid.shape == (1, 2, 1)
+    assert red[0, 0, 0] == pytest.approx(4.0)  # (2 + 6) / 2
+    assert valid[0, 0, 0]
+    assert red[0, 1, 0] == pytest.approx(0.0)  # fully masked -> 0
+    assert not valid[0, 1, 0]
+
+
+@pytest.mark.mpi_skip()
+def pytest_thresholded_adjacency_modes():
+    A = _path_graph(3)
+    A[0, 0] = 5.0  # self-loop that must be zeroed
+    cfg_map = rd.DetectConfig(detector="map_hot", edge_threshold=0.0)
+    mask_map, thr_map = rd._thresholded_adjacency(A, cfg_map)
+    assert thr_map == 0.0
+    assert mask_map[0, 1] and not mask_map[0, 0]  # diagonal removed
+    cfg_str = rd.DetectConfig(detector="strict", edge_quantile=0.5)
+    mask_str, thr_str = rd._thresholded_adjacency(A, cfg_str)
+    assert thr_str == 1.0  # all positive weights equal 1.0
+    assert mask_str[1, 2]
+
+
+@pytest.mark.mpi_skip()
+def pytest_rocof_source_channel_vs_estimated():
+    S, N = 4, 3
+    z = np.zeros((S, 1, N, 2), dtype=np.float32)
+    m = np.ones((S, 1, N, 2), dtype=np.float32)
+    data_ch = _mk_data(z.copy(), z.copy(), m, _path_graph(N), [0, 1])
+    res_ch = rd.compute_residuals(data_ch, rd.DetectConfig(detector="strict"))
+    assert res_ch.rocof_source == "channel"
+
+    z1 = np.zeros((S, 1, N, 1), dtype=np.float32)
+    m1 = np.ones((S, 1, N, 1), dtype=np.float32)
+    data_est = _mk_data(z1.copy(), z1.copy(), m1, _path_graph(N), [0])
+    res_est = rd.compute_residuals(data_est, rd.DetectConfig(detector="strict"))
+    assert res_est.rocof_source == "estimated"
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end detection (deterministic thresholds)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.mpi_skip()
+def pytest_map_hot_detects_injected_cluster():
+    """9 zeros + [10,12,14] at t=2; q=0.75 -> thr=2.5 -> one size-3 cluster."""
+    S, N = 4, 3
+    pred = np.zeros((S, 1, N, 1), dtype=np.float32)
+    true = np.zeros((S, 1, N, 1), dtype=np.float32)
+    pred[2, 0, :, 0] = [10.0, 12.0, 14.0]
+    mask = np.ones((S, 1, N, 1), dtype=np.float32)
+    data = _mk_data(pred, true, mask, _path_graph(N), [0])
+
+    cfg = rd.DetectConfig(
+        detector="map_hot", color_max_quantile=0.75, min_cluster_size=2
+    )
+    clusters_all, clusters_top, thr = rd.detect_clusters(data, cfg)
+
+    assert len(clusters_all) == 1
+    row = clusters_all.iloc[0]
+    assert row["time_idx"] == 2
+    assert row["cluster_size"] == 3
+    assert row["sensor_indices"] == "0;1;2"
+    assert row["sensor_ids"] == "100;101;102"
+    assert thr["rocof_source"] == "none"
+    assert abs(thr["freq_threshold"] - 2.5) < 1e-9
+
+
+@pytest.mark.mpi_skip()
+def pytest_strict_requires_freq_and_rocof():
+    """Sustained step at t>=2: freq active t=2,t=3 but estimated rocof only t=2,
+    so strict fires exactly once (t=2)."""
+    S, N = 4, 3
+    pred = np.zeros((S, 1, N, 1), dtype=np.float32)
+    true = np.zeros((S, 1, N, 1), dtype=np.float32)
+    true[2, 0, :, 0] = [10.0, 12.0, 14.0]
+    true[3, 0, :, 0] = [10.0, 12.0, 14.0]
+    mask = np.ones((S, 1, N, 1), dtype=np.float32)
+    data = _mk_data(pred, true, mask, _path_graph(N), [0])
+
+    cfg = rd.DetectConfig(
+        detector="strict",
+        freq_quantile=0.5,  # -> thr 5.0 (freq active t=2,t=3)
+        rocof_quantile=0.8,  # -> thr 8.0 (rocof active t=2 only)
+        edge_quantile=0.5,
+        min_cluster_size=2,
+        true_rocof_min_abs=1e-6,
+    )
+    clusters_all, _, thr = rd.detect_clusters(data, cfg)
+
+    assert thr["rocof_source"] == "estimated"
+    assert len(clusters_all) == 1
+    row = clusters_all.iloc[0]
+    assert row["time_idx"] == 2
+    assert row["cluster_size"] == 3
+    assert "mean_rocof_dev" in clusters_all.columns
+
+
+@pytest.mark.mpi_skip()
+def pytest_strict_spread_guard_drops_flat_cluster():
+    """If every node in the cluster has the SAME true value (no cross-sensor
+    spread), strict's guard drops it -> no clusters."""
+    S, N = 4, 3
+    pred = np.zeros((S, 1, N, 1), dtype=np.float32)
+    true = np.zeros((S, 1, N, 1), dtype=np.float32)
+    true[2, 0, :, 0] = [12.0, 12.0, 12.0]  # identical -> zero spread
+    mask = np.ones((S, 1, N, 1), dtype=np.float32)
+    data = _mk_data(pred, true, mask, _path_graph(N), [0])
+
+    cfg = rd.DetectConfig(
+        detector="strict",
+        freq_quantile=0.5,
+        rocof_quantile=0.5,
+        edge_quantile=0.5,
+        min_cluster_size=2,
+        true_rocof_min_abs=1e-6,
+    )
+    with pytest.raises(ValueError):
+        rd.detect_clusters(data, cfg)
+
+
+@pytest.mark.mpi_skip()
+def pytest_out_names_per_detector():
+    assert rd._out_names("map_hot")[0] == "map_freq_hot_clusters_all.csv"
+    assert rd._out_names("strict")[0] == "clusters_all.csv"


### PR DESCRIPTION
Post-hoc disturbance detection on the T-GCN forecaster's residuals.
**No retraining** — everything reads a forecaster `--out_dir` and writes CSVs under `<out_dir>/downstream/`. Ports T-GCN's `t-gcn/downstream_tasks/task1` onto HydraGNN, rewired through a single adapter so it consumes the integrated forecaster's masked, standardized outputs.

### What's included

- **Adapter** (`downstream/downstream_io.py`) — maps the forecaster `out_dir` artifacts into `DownstreamData`: axis swap `[W,N,H,F]→[S,H,N,F]`, denormalize to physical units (`feat_mean/std` × `out_idx`), raw `A_geo`, and per-window timestamps from `tvec` (no parquet re-read).
- **Forecaster exports** — `build_geo_knn_graph` now also saves `A_geo.npy` (raw `exp(-d/σ)`, needed for edge-quantile thresholding; `A_hat`'s normalization isn't invertible) and a small `downstream_meta.json` (Tin / split fractions / stride / scaling). 
- **Detector** (`downstream/regional_detector.py`) — folds the two task1 detectors behind `--detector strict|map_hot` (default `map_hot`). Mask-aware residuals (imputed targets excluded), real-or-estimated RoCoF branch.
- **Episode collapse** (`downstream/collapse_episodes.py`) — reduces the many per-timestamp `map_hot` clusters into distinct episodes (gap collapse + peak-window suppression + ranking). Framework only, no plotting.
- Docs: `downstream/README.md` + example outputs list.

### Note: cov80 review follow-up

Two fixes for the Copilot review on the merged cov80 PR:
- `--pred_frac` is now honored (was a silent no-op; the pred segment took the whole remainder). Identical at default fractions.
- `score_train_split.py` unpacked `_score_split` as 2 values but it returns `(preds, ys, masks)` → `ValueError` on every run. Fixed + made the train MSE mask-aware + saves `masks_train.npy`.

The other 4 Copilot comments (test functions "won't be collected") are false positives: `pytest.ini` sets `python_functions = pytest_`, so the repo collects `pytest_`-prefixed tests, not `test_`-prefixed ones.

### Testing

- Parquet-free unit tests: `test_downstream_io.py`, `test_downstream_regional.py`, `test_downstream_episodes.py` (adapter transforms, both detectors on deterministic fixtures, gap collapse / peak-window / ranking).
- End-to-end smoke on real FNET data (1 day, 101 nodes): fnet `--do_all` → `regional_detector` (both `map_hot` and `strict`) → `collapse_episodes`.
