### PR TITLE
Fix biased vector projections in PaiNN and PNAEq

### DIFF
--- a/hydragnn/models/PAINNStack.py
+++ b/hydragnn/models/PAINNStack.py
@@ -95,7 +95,7 @@ class PAINNStack(Base):
             nn.Tanh(),
             nn.Linear(output_dim, output_dim),
         )  # Tanh activation is necessary to prevent exploding gradients when learning from random signals in test_graphs.py
-        vec_embed_out = nn.Linear(input_dim, output_dim) if not last_layer else None
+        vec_embed_out = nn.Linear(input_dim, output_dim, bias=False) if not last_layer else None
 
         if not last_layer:
             return geom_nn.Sequential(
@@ -278,8 +278,8 @@ class PainnUpdate(nn.Module):
     def __init__(self, node_size: int, last_layer=False):
         super().__init__()
 
-        self.update_U = nn.Linear(node_size, node_size)
-        self.update_V = nn.Linear(node_size, node_size)
+        self.update_U = nn.Linear(node_size, node_size, bias=False)
+        self.update_V = nn.Linear(node_size, node_size, bias=False)
         self.last_layer = last_layer
 
         if not self.last_layer:

--- a/hydragnn/models/PNAEqStack.py
+++ b/hydragnn/models/PNAEqStack.py
@@ -145,7 +145,7 @@ class PNAEqStack(Base):
             nn.Linear(output_dim, output_dim),
         )
         vec_embed_out = (
-            geom_nn.Linear(input_dim, output_dim) if not last_layer else None
+            geom_nn.Linear(input_dim, output_dim, bias=False) if not last_layer else None
         )
 
         if not last_layer:
@@ -426,8 +426,8 @@ class PainnUpdate(MessagePassing):
     def __init__(self, node_size: int, last_layer=False):
         super().__init__()
 
-        self.update_X = nn.Linear(node_size, node_size)
-        self.update_V = nn.Linear(node_size, node_size)
+        self.update_X = nn.Linear(node_size, node_size, bias=False)
+        self.update_V = nn.Linear(node_size, node_size, bias=False)
         self.last_layer = last_layer
 
         if not self.last_layer:


### PR DESCRIPTION
Disable biases in linear layers that operate on vector-valued features in PAINN and PNAEq.

Both `torch.nn.Linear` and `torch_geometric.nn.Linear` set `bias=True` by default, so vector features adopt the form 
```math
\mathbf{v}'_{ic}
=
\sum_d W_{cd}\mathbf{v}_{id}
+
b_c
\begin{pmatrix}
1\\
1\\
1
\end{pmatrix}.
```
The first term is equivariant, but the bias introduces a preferred spatial direction and breaks rotational equivariance unless $b_c$ is exactly zero. 

Set `bias=False` for:
- PAINN vector embedding projection
- PAINN `update_U` and `update_V` projections
- PNAEq vector embedding projection
- PNAEq `update_X` and `update_V` projections
