### PR TITLE
Upgrade python314 dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('requirements-base.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('requirements-torch.txt') }}-${{ hashFiles('requirements-pyg.txt') }}-${{ hashFiles('requirements-deepspeed.txt') }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip setuptools wheel meson-python ninja
           python -m pip install --upgrade --no-build-isolation -v -r requirements-base.txt -r requirements-dev.txt
           python -m pip install --upgrade --no-build-isolation -v -r requirements-torch.txt --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple
           python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links https://data.pyg.org/whl/torch-2.13.0+cpu.html

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel meson-python ninja
+          python -m pip install numpy==2.2.6
           python -m pip install --upgrade --no-build-isolation -v -r requirements-base.txt -r requirements-dev.txt
           python -m pip install --upgrade --no-build-isolation -v -r requirements-torch.txt --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple
           python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links https://data.pyg.org/whl/torch-2.13.0+cpu.html

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,7 +37,7 @@ jobs:
           key: ${{ env.pythonLocation }}-${{ hashFiles('requirements-base.txt') }}-${{ hashFiles('requirements-dev.txt') }}-${{ hashFiles('requirements-torch.txt') }}-${{ hashFiles('requirements-pyg.txt') }}-${{ hashFiles('requirements-deepspeed.txt') }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip setuptools wheel meson-python ninja
+          python -m pip install --upgrade pip setuptools wheel meson-python ninja cython
           python -m pip install numpy==2.2.6
           python -m pip install --upgrade --no-build-isolation -v -r requirements-base.txt -r requirements-dev.txt
           python -m pip install --upgrade --no-build-isolation -v -r requirements-torch.txt --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python }}
       - name: Checkout GCNN

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.10", "3.11", "3.12"]
+        python: ["3.11", "3.12", "3.14"]
 
     steps:
       - name: Setup Python
@@ -40,7 +40,7 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install --upgrade --no-build-isolation -v -r requirements-base.txt -r requirements-dev.txt
           python -m pip install --upgrade --no-build-isolation -v -r requirements-torch.txt --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple
-          python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links https://data.pyg.org/whl/torch-2.8.0+cpu.html
+          python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links https://data.pyg.org/whl/torch-2.13.0+cpu.html
           python -m pip install --upgrade --no-build-isolation -v -r requirements-deepspeed.txt || echo "DeepSpeed installation failed, continuing without it"
       - name: Show installed packages
         run: |

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -4,13 +4,13 @@
 click==8.0.0
 matplotlib==3.10.6
 ase==3.26.0
-tqdm>=4.67.3,<5
+tqdm==4.70.0
 tensorboard==2.20.0
 psutil==7.1.0
 sympy==1.14.0
 matscipy
 scikit-learn==1.5.1
-numpy==1.26.4
-scipy==1.14.1
+numpy==2.2.6
+scipy==1.18.0
 mpi4py==4.1.1
 vesin==0.4.2

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -9,7 +9,7 @@ tensorboard==2.20.0
 psutil==7.1.0
 sympy==1.14.0
 matscipy
-scikit-learn==1.5.1
+scikit-learn==1.7.2
 numpy==2.2.6
 scipy==1.17.1
 mpi4py==4.1.1

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -11,6 +11,6 @@ sympy==1.14.0
 matscipy
 scikit-learn==1.5.1
 numpy==2.2.6
-scipy==1.18.0
+scipy==1.17.1
 mpi4py==4.1.1
 vesin==0.4.2

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -1,7 +1,6 @@
 # Base HydraGNN dependencies
 # Scientific computing, materials science, visualization, and utility packages
 # Install with: pip install -r requirements-base.txt
-click==8.0.0
 matplotlib==3.10.6
 ase==3.26.0
 tqdm==4.70.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,4 +2,4 @@ black==26.5.1
 pre-commit
 pytest==8.4.2
 pytest-mpi
-mendeleev==0.16.0
+mendeleev==1.2.0

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -9,4 +9,5 @@ orjson # needed to use FAIRChem functionalities released by the Meta Research AI
 pandas==2.3.3 # needed for HPO examples and FAIRChem functionalities
 PyYAML # needed for FAIRChem configuration files
 wandb # needed for FAIRChem logging functionalities
+click==8.0.0 # black==21.5b1 requires click<8.1 (click 8.1 removed click.escape())
 

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -2,7 +2,7 @@ pymatgen
 jarvis-tools # needed for MPTrj dataset
 optuna # hyperparameter optimization
 deephyper # hyperparameter optimization
-h5py==3.14.0 # utils to read hdf5 files
+h5py==3.16.0 # utils to read hdf5 files
 p7zip # to uncompress .7z file after download - needed for qm7x example
 lmdb # needed to use FAIRChem functionalities released by the Meta Research AI group
 orjson # needed to use FAIRChem functionalities released by the Meta Research AI group

--- a/requirements-optional.txt
+++ b/requirements-optional.txt
@@ -9,5 +9,4 @@ orjson # needed to use FAIRChem functionalities released by the Meta Research AI
 pandas==2.3.3 # needed for HPO examples and FAIRChem functionalities
 PyYAML # needed for FAIRChem configuration files
 wandb # needed for FAIRChem logging functionalities
-click==8.0.0 # black==21.5b1 requires click<8.1 (click 8.1 removed click.escape())
 

--- a/requirements-pyg.txt
+++ b/requirements-pyg.txt
@@ -1,4 +1,4 @@
-torch_geometric==2.6.1
+torch_geometric==2.8.0
 torch_scatter==2.1.2
 torch_sparse==0.6.18
 torch_cluster==1.6.3

--- a/requirements-pyg.txt
+++ b/requirements-pyg.txt
@@ -1,4 +1,5 @@
 torch_geometric==2.8.0
+pyg_lib==0.8.0
 torch_scatter==2.1.2
 torch_sparse==0.6.18
 torch_cluster==1.6.3

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,6 +1,6 @@
-torch==2.8.0
-torchvision==0.23.0
-torchaudio==2.8.0
+torch==2.13.0
+torchvision==0.28.0
+torchaudio==2.11.0
 e3nn==0.5.1
 torch-ema==0.3
 torchmetrics==1.4.0

--- a/tests/test_deepspeed.py
+++ b/tests/test_deepspeed.py
@@ -7,7 +7,7 @@ try:
     import deepspeed
 
     deepspeed_available = True
-except ImportError:
+except Exception:
     deepspeed_available = False
 
 

--- a/tests/test_model_loadpred.py
+++ b/tests/test_model_loadpred.py
@@ -100,8 +100,9 @@ def pytest_model_loadpred():
     if not case_exist:
         unittest_train_model(
             config["NeuralNetwork"]["Architecture"]["model_type"],
+            None,
+            None,
             "ci_multihead.json",
-            False,
             False,
         )
     unittest_model_prediction(config)


### PR DESCRIPTION
Branch: upgrade-python314-dependencies -> ORNL/HydraGNN:main

Summary of changes:

Python 3.14 CI matrix
- Replaced Python 3.10 with Python 3.14 in the test matrix.
- Updated the PyG wheel URL to match torch 2.13.0.
- Upgraded actions/setup-python from v4 to v5 (required for Python 3.14 support).

Dependency upgrades for Python 3.14 compatibility
- Upgraded core dependencies across requirements-*.txt files to versions
  that ship Python 3.14 wheels.
- Upgraded scikit-learn from 1.5.1 to 1.7.2, the first release with
  Python 3.14 wheels; added cython to the CI bootstrap step.
- Fixed a scipy pin regression: reverted 1.18.0 to 1.17.1 because 1.18.0
  requires Python >=3.12, which would have broken the Python 3.11 CI leg.

matscipy / build-isolation fixes
- Pre-installed meson-python and ninja before the matscipy build step to
  satisfy --no-build-isolation on Python 3.14.
- Pre-installed numpy before the matscipy metadata step so meson can call
  numpy.get_include() at configuration time.

DeepSpeed test collection fix
- Changed "except ImportError" to "except Exception" in
  tests/test_deepspeed.py. On Python 3.14, deepspeed raises a ValueError
  (not ImportError) during class definition at import time, which was
  aborting pytest collection even when DeepSpeed was intentionally skipped.