### PR TITLE
Standardize copyright headers across Python sources

### DIFF
--- a/examples/LennardJones/LJ_data.py
+++ b/examples/LennardJones/LJ_data.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/LennardJones/LennardJones.py
+++ b/examples/LennardJones/LennardJones.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/alexandria/find_json_files.py
+++ b/examples/alexandria/find_json_files.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/alexandria/find_json_files.py
+++ b/examples/alexandria/find_json_files.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import shutil
 import subprocess

--- a/examples/alexandria/generate_dictionaries_pure_elements.py
+++ b/examples/alexandria/generate_dictionaries_pure_elements.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/alexandria/generate_dictionaries_pure_elements.py
+++ b/examples/alexandria/generate_dictionaries_pure_elements.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 def generate_dictionary_bulk_energies():
 
     energy_bulk_metal = {

--- a/examples/alexandria/train.py
+++ b/examples/alexandria/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import bz2
 
 import os, json, yaml

--- a/examples/ani1_x/ani1x_mlip_inference.py
+++ b/examples/ani1_x/ani1x_mlip_inference.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/ani1_x/train.py
+++ b/examples/ani1_x/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/ani1_x/train_mlip.py
+++ b/examples/ani1_x/train_mlip.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/csce/train_gap.py
+++ b/examples/csce/train_gap.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import mpi4py
 
 mpi4py.rc.thread_level = "serialized"

--- a/examples/csce/train_gap.py
+++ b/examples/csce/train_gap.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/dftb_uv_spectrum/train_discrete_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_discrete_uv_spectrum.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import mpi4py
 
 mpi4py.rc.thread_level = "serialized"

--- a/examples/dftb_uv_spectrum/train_discrete_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_discrete_uv_spectrum.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import mpi4py
 
 mpi4py.rc.thread_level = "serialized"

--- a/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
+++ b/examples/dftb_uv_spectrum/train_smooth_uv_spectrum.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/eam/eam.py
+++ b/examples/eam/eam.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/eam/eam.py
+++ b/examples/eam/eam.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/ising_model/create_configurations.py
+++ b/examples/ising_model/create_configurations.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2022, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import shutil
 import numpy as np

--- a/examples/ising_model/create_configurations.py
+++ b/examples/ising_model/create_configurations.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2022, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/ising_model/train_ising.py
+++ b/examples/ising_model/train_ising.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import mpi4py
 
 mpi4py.rc.thread_level = "serialized"

--- a/examples/ising_model/train_ising.py
+++ b/examples/ising_model/train_ising.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/lsms/lsms.py
+++ b/examples/lsms/lsms.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/lsms/lsms.py
+++ b/examples/lsms/lsms.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/md17/md17.py
+++ b/examples/md17/md17.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import sys
 import pdb

--- a/examples/md17/md17.py
+++ b/examples/md17/md17.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/md17/md17_mlip.py
+++ b/examples/md17/md17_mlip.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import sys
 import pdb

--- a/examples/md17/md17_mlip.py
+++ b/examples/md17/md17_mlip.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/mptrj/train.py
+++ b/examples/mptrj/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/mptrj/utils/__init__.py
+++ b/examples/mptrj/utils/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/mptrj/utils/__init__.py
+++ b/examples/mptrj/utils/__init__.py
@@ -1,1 +1,11 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .generate_dictionary import generate_dictionary_elements

--- a/examples/mptrj/utils/generate_dictionary.py
+++ b/examples/mptrj/utils/generate_dictionary.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/mptrj/utils/generate_dictionary.py
+++ b/examples/mptrj/utils/generate_dictionary.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 def generate_dictionary_elements():
 
     # Original dictionary

--- a/examples/multibranch/energy_per_atom_linear_regression.py
+++ b/examples/multibranch/energy_per_atom_linear_regression.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import sys
 from mpi4py import MPI

--- a/examples/multibranch/energy_per_atom_linear_regression.py
+++ b/examples/multibranch/energy_per_atom_linear_regression.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/multibranch/inference.py
+++ b/examples/multibranch/inference.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/multibranch/inference.py
+++ b/examples/multibranch/inference.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/multibranch/train.py
+++ b/examples/multibranch/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/multibranch_hpo/train.py
+++ b/examples/multibranch_hpo/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/multidataset/dataset_histogram_plot.py
+++ b/examples/multidataset/dataset_histogram_plot.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import adios2 as ad2
 import numpy as np
 import pickle

--- a/examples/multidataset/dataset_histogram_plot.py
+++ b/examples/multidataset/dataset_histogram_plot.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/multidataset/energy_linear_regression.py
+++ b/examples/multidataset/energy_linear_regression.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import sys
 from mpi4py import MPI

--- a/examples/multidataset/energy_linear_regression.py
+++ b/examples/multidataset/energy_linear_regression.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/multidataset/energy_per_atom_linear_regression.py
+++ b/examples/multidataset/energy_per_atom_linear_regression.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import sys
 from mpi4py import MPI

--- a/examples/multidataset/energy_per_atom_linear_regression.py
+++ b/examples/multidataset/energy_per_atom_linear_regression.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/multidataset/train.py
+++ b/examples/multidataset/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/multidataset_deepspeed/launch_helper.py
+++ b/examples/multidataset_deepspeed/launch_helper.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import subprocess
 import argparse
 

--- a/examples/multidataset_deepspeed/launch_helper.py
+++ b/examples/multidataset_deepspeed/launch_helper.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/multidataset_deepspeed/train.py
+++ b/examples/multidataset_deepspeed/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/multidataset_hpo/gfm.py
+++ b/examples/multidataset_hpo/gfm.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/multidataset_hpo/gfm.py
+++ b/examples/multidataset_hpo/gfm.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/multidataset_hpo/gfm_deephyper_multi.py
+++ b/examples/multidataset_hpo/gfm_deephyper_multi.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, sys
 
 import torch

--- a/examples/multidataset_hpo/gfm_deephyper_multi.py
+++ b/examples/multidataset_hpo/gfm_deephyper_multi.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/multidataset_hpo/gfm_deephyper_multi_perlmutter.py
+++ b/examples/multidataset_hpo/gfm_deephyper_multi_perlmutter.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, sys
 
 import torch

--- a/examples/multidataset_hpo/gfm_deephyper_multi_perlmutter.py
+++ b/examples/multidataset_hpo/gfm_deephyper_multi_perlmutter.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/multidataset_hpo_sc26/branch_weighting_mlp.py
+++ b/examples/multidataset_hpo_sc26/branch_weighting_mlp.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """Train a composition-conditioned MLP to weight branch predictions.
 
 This script loads a pretrained multi-branch HydraGNN model, computes per-branch

--- a/examples/multidataset_hpo_sc26/branch_weighting_mlp_cached.py
+++ b/examples/multidataset_hpo_sc26/branch_weighting_mlp_cached.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """Cached stacking for branch weighting with optional top-k gating.
 
 Workflow:

--- a/examples/multidataset_hpo_sc26/combine_adios.py
+++ b/examples/multidataset_hpo_sc26/combine_adios.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """
 combine_adios.py
 

--- a/examples/multidataset_hpo_sc26/dataset_histogram_plot.py
+++ b/examples/multidataset_hpo_sc26/dataset_histogram_plot.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """Compute element occurrence probabilities from multiple HydraGNN ADIOS datasets.
 
 This script follows the same dataset-loading pattern used in

--- a/examples/multidataset_hpo_sc26/gfm_deephyper_multi_all_mpnn.py
+++ b/examples/multidataset_hpo_sc26/gfm_deephyper_multi_all_mpnn.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, sys
 
 import math

--- a/examples/multidataset_hpo_sc26/gfm_mlip_all_mpnn.py
+++ b/examples/multidataset_hpo_sc26/gfm_mlip_all_mpnn.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json, copy
 import logging
 import sys

--- a/examples/multidataset_hpo_sc26/inference.py
+++ b/examples/multidataset_hpo_sc26/inference.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 
 import argparse
 import glob

--- a/examples/multidataset_hpo_sc26/inference_fused.py
+++ b/examples/multidataset_hpo_sc26/inference_fused.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """Fused inference: HydraGNN (multi-branch) + BranchWeightMLP.
 
 Loads a pretrained multi-branch HydraGNN model and a trained BranchWeightMLP,

--- a/examples/multidataset_hpo_sc26/inference_fused_write_adios.py
+++ b/examples/multidataset_hpo_sc26/inference_fused_write_adios.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """Fused HydraGNN + BranchWeightMLP inference – per-GPU ADIOS2 BP5 to node-local NVMe.
 
 Each GPU writes a BP5 file where every ADIOS step is one atomistic structure.

--- a/examples/multidataset_hpo_sc26/inference_fused_write_json.py
+++ b/examples/multidataset_hpo_sc26/inference_fused_write_json.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """Fused HydraGNN + BranchWeightMLP inference – per-GPU JSON to node-local NVMe.
 
 Each GPU writes a JSON file with atom types, coordinates, weighted formation

--- a/examples/multidataset_hpo_sc26/inference_random_structures.py
+++ b/examples/multidataset_hpo_sc26/inference_random_structures.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """Inference on randomly generated atomistic structures using a trained HydraGNN model.
 
 Generates random structures with variable numbers of atoms, atom types, and

--- a/examples/multidataset_hpo_sc26/inference_random_structures_write_json.py
+++ b/examples/multidataset_hpo_sc26/inference_random_structures_write_json.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """Inference on randomly generated atomistic structures – writes per-GPU JSON results.
 
 Extends ``inference_random_structures.py`` with two additional capabilities:

--- a/examples/multidataset_hpo_sc26/structure_optimization_ASE.py
+++ b/examples/multidataset_hpo_sc26/structure_optimization_ASE.py
@@ -1,4 +1,14 @@
 #!/usr/bin/env python3
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """ASE structure optimization with fused HydraGNN + BranchWeightMLP inference.
 
 This replaces the obsolete single-model loading path with the same fused stack

--- a/examples/multidataset_hpo_sc26/utils.py
+++ b/examples/multidataset_hpo_sc26/utils.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 from typing import Optional, Tuple
 

--- a/examples/nabla2_dft/train.py
+++ b/examples/nabla2_dft/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import mpi4py
 from mpi4py import MPI
 

--- a/examples/ogb/train_gap.py
+++ b/examples/ogb/train_gap.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import matplotlib.pyplot as plt
 import random

--- a/examples/ogb/train_gap.py
+++ b/examples/ogb/train_gap.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/open_catalyst_2020/download_dataset.py
+++ b/examples/open_catalyst_2020/download_dataset.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import argparse
 import glob
 import logging

--- a/examples/open_catalyst_2020/download_dataset.py
+++ b/examples/open_catalyst_2020/download_dataset.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/open_catalyst_2020/train.py
+++ b/examples/open_catalyst_2020/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, re, json
 import logging
 import sys

--- a/examples/open_catalyst_2020/uncompress.py
+++ b/examples/open_catalyst_2020/uncompress.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/open_catalyst_2020/uncompress.py
+++ b/examples/open_catalyst_2020/uncompress.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """
 Uncompresses downloaded S2EF datasets to be used by the LMDB preprocessing
 script - preprocess_ef.py

--- a/examples/open_catalyst_2020/utils/__init__.py
+++ b/examples/open_catalyst_2020/utils/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/open_catalyst_2020/utils/__init__.py
+++ b/examples/open_catalyst_2020/utils/__init__.py
@@ -1,2 +1,12 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .atoms_to_graphs import AtomsToGraphs
 from .preprocess import write_images_to_adios

--- a/examples/open_catalyst_2020/utils/atoms_to_graphs.py
+++ b/examples/open_catalyst_2020/utils/atoms_to_graphs.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """
 Copyright (c) Facebook, Inc. and its affiliates.
 

--- a/examples/open_catalyst_2020/utils/preprocess.py
+++ b/examples/open_catalyst_2020/utils/preprocess.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/open_catalyst_2020/utils/preprocess.py
+++ b/examples/open_catalyst_2020/utils/preprocess.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """
 Creates LMDB files with extracted graph features from provided *.extxyz files
 for the S2EF task.

--- a/examples/open_catalyst_2022/train.py
+++ b/examples/open_catalyst_2022/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json, time
 import glob
 import logging

--- a/examples/open_catalyst_2025/oc25.py
+++ b/examples/open_catalyst_2025/oc25.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import glob
 import os
 import random

--- a/examples/open_catalyst_2025/train.py
+++ b/examples/open_catalyst_2025/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import json
 import logging

--- a/examples/open_direct_air_capture_2023/odac23.py
+++ b/examples/open_direct_air_capture_2023/odac23.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, random, torch, glob, sys, pickle, shutil, traceback
 import queue, threading
 import numpy as np

--- a/examples/open_direct_air_capture_2023/train.py
+++ b/examples/open_direct_air_capture_2023/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, re, json
 import logging
 import sys

--- a/examples/open_materials_2024/download_dataset.py
+++ b/examples/open_materials_2024/download_dataset.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import argparse
 import glob
 import logging

--- a/examples/open_materials_2024/download_dataset.py
+++ b/examples/open_materials_2024/download_dataset.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/open_materials_2024/omat24.py
+++ b/examples/open_materials_2024/omat24.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, random, torch, glob, sys, traceback
 import numpy as np
 from fairchem.core.datasets import AseDBDataset

--- a/examples/open_materials_2024/train.py
+++ b/examples/open_materials_2024/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, re, json
 import logging
 import sys

--- a/examples/open_materials_2024/utils.py
+++ b/examples/open_materials_2024/utils.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import heapq, random
 
 

--- a/examples/open_materials_2024/utils.py
+++ b/examples/open_materials_2024/utils.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/open_molecules_2025/omol25.py
+++ b/examples/open_molecules_2025/omol25.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, random, torch, glob, sys, shutil, pdb
 import numpy as np
 from fairchem.core.datasets import AseDBDataset

--- a/examples/open_molecules_2025/train.py
+++ b/examples/open_molecules_2025/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, re, json
 import logging
 import sys

--- a/examples/open_polymers_2026/opoly26.py
+++ b/examples/open_polymers_2026/opoly26.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, random, torch, glob, sys, shutil, pdb
 import numpy as np
 from fairchem.core.datasets import AseDBDataset

--- a/examples/open_polymers_2026/train.py
+++ b/examples/open_polymers_2026/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, re, json
 import logging
 import sys

--- a/examples/qcml/train.py
+++ b/examples/qcml/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, json
 import logging
 import sys

--- a/examples/qcml/utils.py
+++ b/examples/qcml/utils.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 def balanced_block(rank: int, world_size: int, N: int):
     """
     Return [start, end) for this rank: consecutive indices start..end-1.

--- a/examples/qcml/utils.py
+++ b/examples/qcml/utils.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/qm7x/inference.py
+++ b/examples/qm7x/inference.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/qm7x/qm7x_mlip_inference.py
+++ b/examples/qm7x/qm7x_mlip_inference.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/qm7x/train.py
+++ b/examples/qm7x/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import mpi4py
 from mpi4py import MPI
 

--- a/examples/qm7x/train_mlip.py
+++ b/examples/qm7x/train_mlip.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import mpi4py
 from mpi4py import MPI
 

--- a/examples/qm9/qm9.py
+++ b/examples/qm9/qm9.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import pdb
 import json

--- a/examples/qm9/qm9.py
+++ b/examples/qm9/qm9.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/qm9_hpo/qm9.py
+++ b/examples/qm9_hpo/qm9.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import pdb
 import json

--- a/examples/qm9_hpo/qm9.py
+++ b/examples/qm9_hpo/qm9.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/qm9_hpo/qm9_deephyper.py
+++ b/examples/qm9_hpo/qm9_deephyper.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, sys, json
 import logging
 

--- a/examples/qm9_hpo/qm9_deephyper.py
+++ b/examples/qm9_hpo/qm9_deephyper.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/qm9_hpo/qm9_deephyper_multi.py
+++ b/examples/qm9_hpo/qm9_deephyper_multi.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, sys
 
 import torch

--- a/examples/qm9_hpo/qm9_deephyper_multi.py
+++ b/examples/qm9_hpo/qm9_deephyper_multi.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/qm9_hpo/qm9_optuna.py
+++ b/examples/qm9_hpo/qm9_optuna.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os, sys, json
 import logging
 

--- a/examples/qm9_hpo/qm9_optuna.py
+++ b/examples/qm9_hpo/qm9_optuna.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/qm9_hpo/test_deephyper.py
+++ b/examples/qm9_hpo/test_deephyper.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/qm9_hpo/test_deephyper.py
+++ b/examples/qm9_hpo/test_deephyper.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 def run(job):
     # The suggested parameters are accessible in job.parameters (dict)
     x = job.parameters["x"]

--- a/examples/transition1x/dataloader.py
+++ b/examples/transition1x/dataloader.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 # pylint: disable=stop-iteration-return
 
 import h5py

--- a/examples/transition1x/dataloader.py
+++ b/examples/transition1x/dataloader.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/transition1x/train.py
+++ b/examples/transition1x/train.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import mpi4py
 from mpi4py import MPI
 

--- a/examples/transition1x/utils/create_graph_data.py
+++ b/examples/transition1x/utils/create_graph_data.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 # pylint: disable=stop-iteration-return
 
 import h5py

--- a/examples/transition1x/utils/create_graph_data.py
+++ b/examples/transition1x/utils/create_graph_data.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/examples/zinc/zinc.py
+++ b/examples/zinc/zinc.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import sys
 import os, json
 import pdb

--- a/examples/zinc/zinc.py
+++ b/examples/zinc/zinc.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/__init__.py
+++ b/hydragnn/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from . import preprocess, models, train, postprocess, utils
 from .run_training import run_training
 from .run_prediction import run_prediction

--- a/hydragnn/__init__.py
+++ b/hydragnn/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/models/CGCNNStack.py
+++ b/hydragnn/models/CGCNNStack.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/models/DIMEStack.py
+++ b/hydragnn/models/DIMEStack.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/models/EGCLStack.py
+++ b/hydragnn/models/EGCLStack.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/models/GATStack.py
+++ b/hydragnn/models/GATStack.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/models/MACEStack.py
+++ b/hydragnn/models/MACEStack.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/models/MultiTaskModelMP.py
+++ b/hydragnn/models/MultiTaskModelMP.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import torch
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP

--- a/hydragnn/models/PAINNStack.py
+++ b/hydragnn/models/PAINNStack.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/models/PNAEqStack.py
+++ b/hydragnn/models/PNAEqStack.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/models/SCFStack.py
+++ b/hydragnn/models/SCFStack.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/models/__init__.py
+++ b/hydragnn/models/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .Base import Base
 from .GATStack import GATStack
 from .GINStack import GINStack

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/postprocess/__init__.py
+++ b/hydragnn/postprocess/__init__.py
@@ -1,2 +1,12 @@
+##############################################################################
+# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .visualizer import Visualizer
 from .postprocess import output_denormalize, unscale_features_by_num_nodes

--- a/hydragnn/postprocess/__init__.py
+++ b/hydragnn/postprocess/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/postprocess/postprocess.py
+++ b/hydragnn/postprocess/postprocess.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2022, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/postprocess/visualizer.py
+++ b/hydragnn/postprocess/visualizer.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2022, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/preprocess/__init__.py
+++ b/hydragnn/preprocess/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/preprocess/__init__.py
+++ b/hydragnn/preprocess/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .dataset_descriptors import AtomFeatures, StructureFeatures
 
 from .graph_samples_checks_and_updates import (

--- a/hydragnn/preprocess/cfg_raw_dataset_loader.py
+++ b/hydragnn/preprocess/cfg_raw_dataset_loader.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/preprocess/energy_linear_regression.py
+++ b/hydragnn/preprocess/energy_linear_regression.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 from mpi4py import MPI
 import argparse

--- a/hydragnn/preprocess/graph_samples_checks_and_updates.py
+++ b/hydragnn/preprocess/graph_samples_checks_and_updates.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/preprocess/load_data.py
+++ b/hydragnn/preprocess/load_data.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/preprocess/lsms_raw_dataset_loader.py
+++ b/hydragnn/preprocess/lsms_raw_dataset_loader.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2023, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/preprocess/raw_dataset_loader.py
+++ b/hydragnn/preprocess/raw_dataset_loader.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/preprocess/stratified_sampling.py
+++ b/hydragnn/preprocess/stratified_sampling.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/preprocess/stratified_sampling.py
+++ b/hydragnn/preprocess/stratified_sampling.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import torch
 from torch_geometric.data import Data
 from hydragnn.utils.print.print_utils import print_distributed, iterate_tqdm

--- a/hydragnn/run_prediction.py
+++ b/hydragnn/run_prediction.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/run_training.py
+++ b/hydragnn/run_training.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/train/__init__.py
+++ b/hydragnn/train/__init__.py
@@ -1,1 +1,11 @@
+##############################################################################
+# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .train_validate_test import train_validate_test, train, validate, test

--- a/hydragnn/train/__init__.py
+++ b/hydragnn/train/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/datasets/__init__.py
+++ b/hydragnn/utils/datasets/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .abstractbasedataset import AbstractBaseDataset
 from .abstractrawdataset import AbstractRawDataset
 from .adiosdataset import AdiosDataset, AdiosMultiDataset, AdiosWriter

--- a/hydragnn/utils/datasets/abstractbasedataset.py
+++ b/hydragnn/utils/datasets/abstractbasedataset.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from abc import ABC, abstractmethod
 
 import torch

--- a/hydragnn/utils/datasets/abstractrawdataset.py
+++ b/hydragnn/utils/datasets/abstractrawdataset.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import numpy as np
 import random

--- a/hydragnn/utils/datasets/abstractrawdataset.py
+++ b/hydragnn/utils/datasets/abstractrawdataset.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/datasets/adiosdataset.py
+++ b/hydragnn/utils/datasets/adiosdataset.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from mpi4py import MPI
 import pickle
 import time

--- a/hydragnn/utils/datasets/cfgdataset.py
+++ b/hydragnn/utils/datasets/cfgdataset.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/datasets/cfgdataset.py
+++ b/hydragnn/utils/datasets/cfgdataset.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import numpy as np
 

--- a/hydragnn/utils/datasets/compositional_data_splitting.py
+++ b/hydragnn/utils/datasets/compositional_data_splitting.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/datasets/distdataset.py
+++ b/hydragnn/utils/datasets/distdataset.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from mpi4py import MPI
 import numpy as np
 

--- a/hydragnn/utils/datasets/lsmsdataset.py
+++ b/hydragnn/utils/datasets/lsmsdataset.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/datasets/lsmsdataset.py
+++ b/hydragnn/utils/datasets/lsmsdataset.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from torch import tensor
 from torch_geometric.data import Data
 from hydragnn.utils.datasets.abstractrawdataset import AbstractRawDataset

--- a/hydragnn/utils/datasets/pickledataset.py
+++ b/hydragnn/utils/datasets/pickledataset.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/datasets/pickledataset.py
+++ b/hydragnn/utils/datasets/pickledataset.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import pickle
 

--- a/hydragnn/utils/datasets/serializeddataset.py
+++ b/hydragnn/utils/datasets/serializeddataset.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/datasets/serializeddataset.py
+++ b/hydragnn/utils/datasets/serializeddataset.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import pickle
 

--- a/hydragnn/utils/datasets/xyzdataset.py
+++ b/hydragnn/utils/datasets/xyzdataset.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/datasets/xyzdataset.py
+++ b/hydragnn/utils/datasets/xyzdataset.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import numpy as np
 

--- a/hydragnn/utils/descriptors_and_embeddings/__init__.py
+++ b/hydragnn/utils/descriptors_and_embeddings/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .atomicdescriptors import atomicdescriptors
 from .smiles_utils import (
     get_node_attribute_name,

--- a/hydragnn/utils/descriptors_and_embeddings/__init__.py
+++ b/hydragnn/utils/descriptors_and_embeddings/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/descriptors_and_embeddings/atomicdescriptors.py
+++ b/hydragnn/utils/descriptors_and_embeddings/atomicdescriptors.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/descriptors_and_embeddings/atomicdescriptors.py
+++ b/hydragnn/utils/descriptors_and_embeddings/atomicdescriptors.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import torch
 import torch.nn.functional as F

--- a/hydragnn/utils/descriptors_and_embeddings/smiles_utils.py
+++ b/hydragnn/utils/descriptors_and_embeddings/smiles_utils.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import sys
 import torch
 import pickle, csv

--- a/hydragnn/utils/descriptors_and_embeddings/smiles_utils.py
+++ b/hydragnn/utils/descriptors_and_embeddings/smiles_utils.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/descriptors_and_embeddings/xyz2mol.py
+++ b/hydragnn/utils/descriptors_and_embeddings/xyz2mol.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """
 Module for generating rdkit molobj/smiles/molecular graph from free atoms
 

--- a/hydragnn/utils/descriptors_and_embeddings/xyz2mol.py
+++ b/hydragnn/utils/descriptors_and_embeddings/xyz2mol.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/distributed/__init__.py
+++ b/hydragnn/utils/distributed/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .distributed import (
     get_comm_size_and_rank,
     get_device_list,

--- a/hydragnn/utils/distributed/__init__.py
+++ b/hydragnn/utils/distributed/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/distributed/distributed.py
+++ b/hydragnn/utils/distributed/distributed.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/hpo/__init__.py
+++ b/hydragnn/utils/hpo/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/hpo/__init__.py
+++ b/hydragnn/utils/hpo/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .deephyper import (
     master_from_host,
     read_node_list,

--- a/hydragnn/utils/hpo/deephyper.py
+++ b/hydragnn/utils/hpo/deephyper.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/hpo/deephyper.py
+++ b/hydragnn/utils/hpo/deephyper.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import subprocess
 

--- a/hydragnn/utils/input_config_parsing/__init__.py
+++ b/hydragnn/utils/input_config_parsing/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .config_utils import (
     update_config,
     update_config_minmax,

--- a/hydragnn/utils/input_config_parsing/__init__.py
+++ b/hydragnn/utils/input_config_parsing/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/lsms/__init__.py
+++ b/hydragnn/utils/lsms/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/lsms/__init__.py
+++ b/hydragnn/utils/lsms/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .convert_total_energy_to_formation_gibbs import (
     convert_raw_data_energy_to_gibbs,
     compute_formation_enthalpy,

--- a/hydragnn/utils/lsms/compositional_histogram_cutoff.py
+++ b/hydragnn/utils/lsms/compositional_histogram_cutoff.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/lsms/compositional_histogram_cutoff.py
+++ b/hydragnn/utils/lsms/compositional_histogram_cutoff.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import shutil
 import numpy as np

--- a/hydragnn/utils/lsms/convert_total_energy_to_formation_gibbs.py
+++ b/hydragnn/utils/lsms/convert_total_energy_to_formation_gibbs.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/model/__init__.py
+++ b/hydragnn/utils/model/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .model import (
     activation_function_selection,
     save_model,

--- a/hydragnn/utils/model/irreps_tools.py
+++ b/hydragnn/utils/model/irreps_tools.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/model/irreps_tools.py
+++ b/hydragnn/utils/model/irreps_tools.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 ###########################################################################################
 # Elementary tools for handling irreducible representations
 # Authors: Ilyes Batatia, Gregor Simm

--- a/hydragnn/utils/model/mace_utils/modules/__init__.py
+++ b/hydragnn/utils/model/mace_utils/modules/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/model/mace_utils/modules/__init__.py
+++ b/hydragnn/utils/model/mace_utils/modules/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 ###########################################################################################
 # __init__ file for Modules
 # Authors: Ilyes Batatia, Gregor Simm

--- a/hydragnn/utils/model/mace_utils/modules/blocks.py
+++ b/hydragnn/utils/model/mace_utils/modules/blocks.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 ###########################################################################################
 # Elementary Block for Building O(3) Equivariant Higher Order Message Passing Neural Network
 # Authors: Ilyes Batatia, Gregor Simm

--- a/hydragnn/utils/model/mace_utils/modules/radial.py
+++ b/hydragnn/utils/model/mace_utils/modules/radial.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/model/mace_utils/modules/radial.py
+++ b/hydragnn/utils/model/mace_utils/modules/radial.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 ###########################################################################################
 # Radial basis and cutoff
 # Authors: Ilyes Batatia, Gregor Simm

--- a/hydragnn/utils/model/mace_utils/modules/symmetric_contraction.py
+++ b/hydragnn/utils/model/mace_utils/modules/symmetric_contraction.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 ###########################################################################################
 # Implementation of the symmetric contraction algorithm presented in the MACE paper
 # (Batatia et al, MACE: Higher Order Equivariant Message Passing Neural Networks for Fast and Accurate Force Fields , Eq.10 and 11)

--- a/hydragnn/utils/model/mace_utils/modules/symmetric_contraction.py
+++ b/hydragnn/utils/model/mace_utils/modules/symmetric_contraction.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/model/mace_utils/tools/__init__.py
+++ b/hydragnn/utils/model/mace_utils/tools/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/model/mace_utils/tools/__init__.py
+++ b/hydragnn/utils/model/mace_utils/tools/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 ###########################################################################################
 # __init__ file for Tools
 # Authors: Ilyes Batatia, Gregor Simm

--- a/hydragnn/utils/model/mace_utils/tools/cg.py
+++ b/hydragnn/utils/model/mace_utils/tools/cg.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/model/mace_utils/tools/cg.py
+++ b/hydragnn/utils/model/mace_utils/tools/cg.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 ###########################################################################################
 # Higher Order Real Clebsch Gordan (based on e3nn by Mario Geiger)
 # Authors: Ilyes Batatia

--- a/hydragnn/utils/model/mace_utils/tools/compile.py
+++ b/hydragnn/utils/model/mace_utils/tools/compile.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/model/mace_utils/tools/compile.py
+++ b/hydragnn/utils/model/mace_utils/tools/compile.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 ###########################################################################################
 # Compilation utilities for MACE
 # Authors: Ilyes Batatia, Gregor Simm and David Kovacs

--- a/hydragnn/utils/model/model.py
+++ b/hydragnn/utils/model/model.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/optimizer/__init__.py
+++ b/hydragnn/utils/optimizer/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/optimizer/__init__.py
+++ b/hydragnn/utils/optimizer/__init__.py
@@ -1,1 +1,11 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .optimizer import select_optimizer

--- a/hydragnn/utils/optimizer/optimizer.py
+++ b/hydragnn/utils/optimizer/optimizer.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import torch
 from hydragnn.utils.distributed import get_device_name
 from torch.distributed.optim import ZeroRedundancyOptimizer

--- a/hydragnn/utils/optimizer/optimizer.py
+++ b/hydragnn/utils/optimizer/optimizer.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/print/__init__.py
+++ b/hydragnn/utils/print/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/print/__init__.py
+++ b/hydragnn/utils/print/__init__.py
@@ -1,1 +1,11 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .print_utils import print_distributed, iterate_tqdm, setup_log

--- a/hydragnn/utils/print/print_utils.py
+++ b/hydragnn/utils/print/print_utils.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/profiling_and_tracing/__init__.py
+++ b/hydragnn/utils/profiling_and_tracing/__init__.py
@@ -1,1 +1,11 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .time_utils import print_timers

--- a/hydragnn/utils/profiling_and_tracing/__init__.py
+++ b/hydragnn/utils/profiling_and_tracing/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/profiling_and_tracing/gptl4py_dummy.py
+++ b/hydragnn/utils/profiling_and_tracing/gptl4py_dummy.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/profiling_and_tracing/gptl4py_dummy.py
+++ b/hydragnn/utils/profiling_and_tracing/gptl4py_dummy.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """
 This is a dummy package for gptl4py (https://github.com/jychoi-hpc/gptl4py).
 When gptl4py is not available, use as follows:

--- a/hydragnn/utils/profiling_and_tracing/profile.py
+++ b/hydragnn/utils/profiling_and_tracing/profile.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/profiling_and_tracing/profile.py
+++ b/hydragnn/utils/profiling_and_tracing/profile.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import torch
 import contextlib
 from unittest.mock import MagicMock

--- a/hydragnn/utils/profiling_and_tracing/time_utils.py
+++ b/hydragnn/utils/profiling_and_tracing/time_utils.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/hydragnn/utils/profiling_and_tracing/tracer.py
+++ b/hydragnn/utils/profiling_and_tracing/tracer.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 """
 This is a tracer package to act as a wrapper to execute gptl and/or scorep.
 """

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 from setuptools import setup, find_packages
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2022, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 from .deterministic_graph_data import deterministic_graph_data
 from .test_config import pytest_config
 from .test_graphs import unittest_train_model

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2022, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/deterministic_graph_data.py
+++ b/tests/deterministic_graph_data.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2023, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_atomicdescriptors.py
+++ b/tests/test_atomicdescriptors.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2022, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_datasetclass_inheritance.py
+++ b/tests/test_datasetclass_inheritance.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_deepspeed.py
+++ b/tests/test_deepspeed.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import pytest
 
 from tests.test_graphs import unittest_train_model

--- a/tests/test_deepspeed.py
+++ b/tests/test_deepspeed.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2025, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_enthalpy.py
+++ b/tests/test_enthalpy.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_examples_graph_attr.py
+++ b/tests/test_examples_graph_attr.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_forces_equivariant.py
+++ b/tests/test_forces_equivariant.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_forces_equivariant_training.py
+++ b/tests/test_forces_equivariant_training.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_fsdp2_force_grad_regression.py
+++ b/tests/test_fsdp2_force_grad_regression.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import os
 import tempfile
 from importlib import import_module

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_graphs_graphattr.py
+++ b/tests/test_graphs_graphattr.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_interatomic_potential.py
+++ b/tests/test_interatomic_potential.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2024, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_loss_and_activation_functions.py
+++ b/tests/test_loss_and_activation_functions.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_model_loadpred.py
+++ b/tests/test_model_loadpred.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_periodic_boundary_conditions.py
+++ b/tests/test_periodic_boundary_conditions.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2025, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #

--- a/tests/test_precision_control.py
+++ b/tests/test_precision_control.py
@@ -1,3 +1,13 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
 import types
 
 import torch

--- a/tests/test_rotational_invariance.py
+++ b/tests/test_rotational_invariance.py
@@ -1,5 +1,5 @@
 ##############################################################################
-# Copyright (c) 2021, Oak Ridge National Laboratory                          #
+# Copyright (c) 2024, Oak Ridge National Laboratory                          #
 # All rights reserved.                                                       #
 #                                                                            #
 # This file is part of HydraGNN and is distributed under a BSD 3-clause      #


### PR DESCRIPTION
## Summary

- add the HydraGNN BSD-3-Clause copyright header to Python sources that do not already have it
- normalize copyright years using each file’s latest Git commit year
- keep this repository-wide administrative change separate from feature development

## Motivation

These changes were previously included in the AllScAIP and UMA integration PR, where they substantially increased the review surface despite being unrelated to that feature. This dedicated PR makes both changes independently reviewable.

## Impact

No runtime behavior is changed. This PR only adds or normalizes source-file headers.

## Validation

- verified the branch is based directly on ORNL main
- verified the diff contains only ten-line header additions or one-line copyright-year replacements
- git diff --check passes