### PR TITLE
Align HydraGNN GraphGPS with PyG

### DIFF
--- a/LICENSES/PYG-MIT.txt
+++ b/LICENSES/PYG-MIT.txt
@@ -1,0 +1,19 @@
+Copyright (c) 2023 PyG Team <team@pyg.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include LICENSES/PYG-MIT.txt

--- a/README.md
+++ b/README.md
@@ -172,8 +172,32 @@ Additionally, many important arguments fall within the `["NeuralNetwork"]` secti
   - `["Training"]`
     - `["global_attn_redraw_interval"]`
       Number of training batches between Performer random-feature projection
-      redraws (int, default `1000`); set to `null` to disable redraw. This has
-      no effect when `global_attn_type` is `multihead`.
+      redraws (positive int, default `1000`); set to `null` to keep the initial
+      projection fixed. This setting has no effect when `global_attn_type` is
+      `multihead` or while the model is in evaluation mode.
+
+Performer approximates softmax attention with features produced from a random
+projection matrix. Periodically replacing that matrix during training prevents
+the learned model from depending on a single random approximation. HydraGNN
+counts training batches and redraws the projection immediately before the next
+model forward when the configured interval is reached. Redraw bookkeeping is
+kept outside `HydraGPSConv.forward` so that execution strategies that repeat a
+forward pass, such as activation checkpointing, do not accidentally count one
+training batch more than once. For example:
+
+```json
+{
+  "NeuralNetwork": {
+    "Architecture": {
+      "global_attn_engine": "GPS",
+      "global_attn_type": "performer"
+    },
+    "Training": {
+      "global_attn_redraw_interval": 1000
+    }
+  }
+}
+```
 
 When GPS wraps an equivariant HydraGNN model, global attention operates only
 on invariant node channels. Equivariant channels are updated by the local MPNN

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Additionally, many important arguments fall within the `["NeuralNetwork"]` secti
     - `["global_attn_engine"]`
       Accepted types: `GPS`, `None`
     - `["global_attn_type"]`
-      Accepted types: `multihead`
+      Accepted types: `multihead`, `performer`
     - `["pe_dim"]`
       Dimension of positional encodings (int)
     - `["global_attn_heads"]`
@@ -168,6 +168,16 @@ Additionally, many important arguments fall within the `["NeuralNetwork"]` secti
       Dimension of node embeddings during convolution (int) - must be a multiple of "global_attn_heads" if "global_attn_engine" is not "None"
     - `["enable_interatomic_potential"]`  
       Enable MLIP mode with dynamic graph construction and energy-conserving force prediction (bool, default `false`)
+
+  - `["Training"]`
+    - `["global_attn_redraw_interval"]`
+      Number of training batches between Performer random-feature projection
+      redraws (int, default `1000`); set to `null` to disable redraw. This has
+      no effect when `global_attn_type` is `multihead`.
+
+When GPS wraps an equivariant HydraGNN model, global attention operates only
+on invariant node channels. Equivariant channels are updated by the local MPNN
+and propagated alongside the globally attended invariant representation.
 
   - `["Variables of Interest"]`
     - `["input_node_features"]`  

--- a/hydragnn/globalAtt/gps.py
+++ b/hydragnn/globalAtt/gps.py
@@ -40,8 +40,6 @@ class HydraGPSConv(torch.nn.Module):
     call signature and the tuple return value.
     """
 
-    pyg_source_version = "2.8.0"
-
     def __init__(
         self,
         channels: int,

--- a/hydragnn/globalAtt/gps.py
+++ b/hydragnn/globalAtt/gps.py
@@ -1,22 +1,21 @@
 ##############################################################################
 # Copyright (c) 2024, Oak Ridge National Laboratory                          #
-# All rights reserved.                                                       #
+# Copyright (c) 2023, PyG Team <team@pyg.org>                                #
 #                                                                            #
-# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
-# license. For the licensing terms see the LICENSE file in the top-level     #
-# directory.                                                                 #
+# Adapted from torch_geometric.nn.conv.GPSConv (PyG 2.8.0), distributed      #
+# under the MIT License. HydraGNN modifications are distributed under the    #
+# BSD 3-clause license. See LICENSE and LICENSES/PYG-MIT.txt.                 #
 #                                                                            #
-# SPDX-License-Identifier: BSD-3-Clause                                      #
+# SPDX-License-Identifier: MIT AND BSD-3-Clause                              #
 ##############################################################################
-
 
 import inspect
 from typing import Any, Dict, Optional
-import pdb
+
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch.nn import Dropout, Linear, Sequential, LazyLinear
+from torch.nn import Dropout, Linear, Sequential
 
 from torch_geometric.nn.attention import PerformerAttention
 from torch_geometric.nn.conv import MessagePassing
@@ -25,11 +24,24 @@ from torch_geometric.nn.resolver import (
     activation_resolver,
     normalization_resolver,
 )
-from torch_geometric.typing import Adj
 from torch_geometric.utils import to_dense_batch
 
 
-class GPSConv(torch.nn.Module):
+class HydraGPSConv(torch.nn.Module):
+    r"""PyG ``GPSConv`` adapted to HydraGNN's two-stream feature interface.
+
+    The local message-passing layer consumes and returns invariant and
+    equivariant node features. Global attention is applied only to invariant
+    features, while the updated equivariant features are propagated unchanged
+    by the global branch.
+
+    This implementation tracks ``torch_geometric.nn.conv.GPSConv`` from PyG
+    2.8.0. The differences are intentionally limited to the local-convolution
+    call signature and the tuple return value.
+    """
+
+    pyg_source_version = "2.8.0"
+
     def __init__(
         self,
         channels: int,
@@ -106,7 +118,7 @@ class GPSConv(torch.nn.Module):
         equiv_node_feat: Tensor,
         graph_batch: Optional[torch.Tensor] = None,
         **kwargs,
-    ) -> Tensor:
+    ) -> tuple[Tensor, Tensor]:
         """Runs the forward pass of the module."""
         hs = []
         if self.conv is not None:  # Local MPNN.
@@ -157,3 +169,7 @@ class GPSConv(torch.nn.Module):
             f"conv={self.conv}, heads={self.heads}, "
             f"attn_type={self.attn_type})"
         )
+
+
+# Backward-compatible name used by existing HydraGNN callers.
+GPSConv = HydraGPSConv

--- a/hydragnn/globalAtt/gps.py
+++ b/hydragnn/globalAtt/gps.py
@@ -100,12 +100,30 @@ class HydraGPSConv(torch.nn.Module):
             signature = inspect.signature(self.norm1.forward)
             self.norm_with_batch = "batch" in signature.parameters
 
-    def maybe_redraw_performer_projection(self, redraw_interval: Optional[int]) -> bool:
-        """Redraw Performer features after a configured number of train steps.
+    def _maybe_redraw_performer_projection(
+        self, redraw_interval: Optional[int]
+    ) -> bool:
+        """Redraw Performer's random-feature projection when it is due.
+
+        Performer uses random features to approximate softmax attention. A
+        periodic redraw during training prevents optimization from depending
+        on only the initial random approximation. ``redraw_interval`` counts
+        calls to this method, with one call expected per training batch.
 
         This method is intentionally called by the training loop rather than
         from :meth:`forward`, since a forward may be repeated by activation
         checkpointing or other execution strategies.
+
+        Args:
+            redraw_interval: Number of training batches between redraws. A
+                value of ``None`` keeps the initial projection fixed.
+
+        Returns:
+            ``True`` if the projection was redrawn, otherwise ``False``. No
+            redraw occurs for non-Performer attention or in evaluation mode.
+
+        Raises:
+            ValueError: If ``redraw_interval`` is not positive or ``None``.
         """
         if redraw_interval is None or self.attn_type != "performer":
             return False
@@ -197,9 +215,14 @@ class HydraGPSConv(torch.nn.Module):
 def redraw_performer_projections(
     model: torch.nn.Module, redraw_interval: Optional[int]
 ) -> int:
-    """Redraw all HydraGPSConv Performer projections once per training step."""
+    """Advance the redraw schedule for every ``HydraGPSConv`` in ``model``.
+
+    Call this exactly once per training batch, immediately before the model
+    forward. The return value is the number of layers whose Performer random
+    projection was redrawn by this call.
+    """
     return sum(
-        module.maybe_redraw_performer_projection(redraw_interval)
+        module._maybe_redraw_performer_projection(redraw_interval)
         for module in model.modules()
         if isinstance(module, HydraGPSConv)
     )

--- a/hydragnn/globalAtt/gps.py
+++ b/hydragnn/globalAtt/gps.py
@@ -194,10 +194,6 @@ class HydraGPSConv(torch.nn.Module):
         )
 
 
-# Backward-compatible name used by existing HydraGNN callers.
-GPSConv = HydraGPSConv
-
-
 def redraw_performer_projections(
     model: torch.nn.Module, redraw_interval: Optional[int]
 ) -> int:

--- a/hydragnn/globalAtt/gps.py
+++ b/hydragnn/globalAtt/gps.py
@@ -95,9 +95,32 @@ class HydraGPSConv(torch.nn.Module):
         self.norm3 = normalization_resolver(norm, channels, **norm_kwargs)
 
         self.norm_with_batch = False
+        self._performer_steps_since_redraw = 0
         if self.norm1 is not None:
             signature = inspect.signature(self.norm1.forward)
             self.norm_with_batch = "batch" in signature.parameters
+
+    def maybe_redraw_performer_projection(self, redraw_interval: Optional[int]) -> bool:
+        """Redraw Performer features after a configured number of train steps.
+
+        This method is intentionally called by the training loop rather than
+        from :meth:`forward`, since a forward may be repeated by activation
+        checkpointing or other execution strategies.
+        """
+        if redraw_interval is None or self.attn_type != "performer":
+            return False
+        if redraw_interval <= 0:
+            raise ValueError("Performer redraw interval must be positive or None")
+        if not self.training:
+            return False
+
+        self._performer_steps_since_redraw += 1
+        if self._performer_steps_since_redraw < redraw_interval:
+            return False
+
+        self.attn.redraw_projection_matrix()
+        self._performer_steps_since_redraw = 0
+        return True
 
     def reset_parameters(self):
         r"""Resets all learnable parameters of the module."""
@@ -173,3 +196,14 @@ class HydraGPSConv(torch.nn.Module):
 
 # Backward-compatible name used by existing HydraGNN callers.
 GPSConv = HydraGPSConv
+
+
+def redraw_performer_projections(
+    model: torch.nn.Module, redraw_interval: Optional[int]
+) -> int:
+    """Redraw all HydraGPSConv Performer projections once per training step."""
+    return sum(
+        module.maybe_redraw_performer_projection(redraw_interval)
+        for module in model.modules()
+        if isinstance(module, HydraGPSConv)
+    )

--- a/hydragnn/globalAtt/gps.py
+++ b/hydragnn/globalAtt/gps.py
@@ -140,6 +140,7 @@ class HydraGPSConv(torch.nn.Module):
 
     def reset_parameters(self):
         r"""Resets all learnable parameters of the module."""
+        self._performer_steps_since_redraw = 0
         if self.conv is not None:
             self.conv.reset_parameters()
         self.attn._reset_parameters()

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -27,7 +27,7 @@ import pdb
 from hydragnn.utils.distributed import get_device
 from hydragnn.utils.print.print_utils import print_master
 from hydragnn.utils.model.operations import get_edge_vectors_and_lengths
-from hydragnn.globalAtt.gps import GPSConv
+from hydragnn.globalAtt.gps import HydraGPSConv
 import hydragnn.utils.profiling_and_tracing.tracer as tr
 
 import inspect
@@ -236,7 +236,7 @@ class Base(Module):
         if self.use_global_attn:
             # specify global attention engine; use this to support more engines in future
             if self.global_attn_engine == "GPS":
-                return GPSConv(
+                return HydraGPSConv(
                     channels=self.hidden_dim,
                     conv=mpnn,
                     heads=self.global_attn_heads,

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -737,6 +737,9 @@ def train(
         tr.stop("get_head_indices")
         tr.start("forward", **syncopt)
         with record_function("forward"):
+            # Advance Performer redraw schedules once per training batch. Keep
+            # this outside model.forward(), which may be replayed by activation
+            # checkpointing and would otherwise advance the schedule twice.
             redraw_performer_projections(model, performer_redraw_interval)
             if trace_level > 0:
                 tr.start("h2d", **syncopt)

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -21,6 +21,7 @@ from hydragnn.utils.profiling_and_tracing.time_utils import Timer
 from hydragnn.utils.profiling_and_tracing.profile import Profiler
 from hydragnn.utils.distributed import get_device, check_remaining
 from hydragnn.utils.model.model import Checkpoint, EarlyStopping
+from hydragnn.globalAtt.gps import redraw_performer_projections
 
 import os
 
@@ -358,6 +359,9 @@ def train_validate_test(
                 use_deepspeed=use_deepspeed,
                 compute_grad_energy=compute_grad_energy,
                 precision=precision,
+                performer_redraw_interval=config["Training"].get(
+                    "global_attn_redraw_interval", 1000
+                ),
             )
             tr.stop("train")
             tr.disable()
@@ -660,6 +664,7 @@ def train(
     use_deepspeed=False,
     compute_grad_energy=False,
     precision="fp32",
+    performer_redraw_interval=1000,
 ):
     if profiler is None:
         profiler = Profiler()
@@ -732,6 +737,7 @@ def train(
         tr.stop("get_head_indices")
         tr.start("forward", **syncopt)
         with record_function("forward"):
+            redraw_performer_projections(model, performer_redraw_interval)
             if trace_level > 0:
                 tr.start("h2d", **syncopt)
             data = move_batch_to_device(data, param_dtype)

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -46,6 +46,9 @@ def update_config(config, train_loader, val_loader, test_loader):
         config["NeuralNetwork"]["Architecture"]["global_attn_heads"] = 0
     if "pe_dim" not in config["NeuralNetwork"]["Architecture"]:
         config["NeuralNetwork"]["Architecture"]["pe_dim"] = 0
+    if "global_attn_redraw_interval" not in config["NeuralNetwork"]["Training"]:
+        # Used only by Performer attention. None disables projection redraw.
+        config["NeuralNetwork"]["Training"]["global_attn_redraw_interval"] = 1000
 
     # update output_heads with latest config rules
     config["NeuralNetwork"]["Architecture"]["output_heads"] = update_multibranch_heads(

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
     extras_require={"test": test_requires},
     description="Distributed PyTorch implementation of multi-headed graph neural networks",
     license="BSD-3",
+    license_files=["LICENSE", "LICENSES/PYG-MIT.txt"],
     long_description_content_type="text/markdown",
     long_description=read("README.md"),
     url="https://github.com/ORNL/HydraGNN",

--- a/tests/test_graphgps_pyg_parity.py
+++ b/tests/test_graphgps_pyg_parity.py
@@ -1,0 +1,110 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+"""Numerical parity tests for HydraGNN's PyG-derived GraphGPS layer."""
+
+from __future__ import annotations
+
+import copy
+
+import pytest
+import torch
+from torch import Tensor
+from torch_geometric.nn import GCNConv
+from torch_geometric.nn import GPSConv as PyGGPSConv
+
+from hydragnn.globalAtt.gps import GPSConv, HydraGPSConv
+
+
+class _HydraLocalAdapter(torch.nn.Module):
+    """Expose a standard PyG convolution through HydraGNN's two-stream API."""
+
+    def __init__(self, conv: torch.nn.Module):
+        super().__init__()
+        self.conv = conv
+
+    def reset_parameters(self):
+        self.conv.reset_parameters()
+
+    def forward(
+        self,
+        inv_node_feat: Tensor,
+        equiv_node_feat: Tensor,
+        edge_index: Tensor,
+        **kwargs,
+    ) -> tuple[Tensor, Tensor]:
+        return self.conv(inv_node_feat, edge_index, **kwargs), equiv_node_feat
+
+
+def _inputs() -> tuple[Tensor, Tensor, Tensor, Tensor]:
+    torch.manual_seed(17)
+    x = torch.randn(7, 8)
+    equiv = torch.randn(7, 3, 4)
+    batch = torch.tensor([0, 0, 0, 0, 1, 1, 1])
+    edge_index = torch.tensor(
+        [
+            [0, 1, 1, 2, 2, 3, 3, 0, 4, 5, 5, 6, 6, 4],
+            [1, 0, 2, 1, 3, 2, 0, 3, 5, 4, 6, 5, 4, 6],
+        ]
+    )
+    return x, equiv, edge_index, batch
+
+
+def _copy_nonlocal_state(ours: HydraGPSConv, native: PyGGPSConv) -> None:
+    ours.attn.load_state_dict(copy.deepcopy(native.attn.state_dict()))
+    ours.mlp.load_state_dict(copy.deepcopy(native.mlp.state_dict()))
+    for ours_norm, native_norm in (
+        (ours.norm1, native.norm1),
+        (ours.norm2, native.norm2),
+        (ours.norm3, native.norm3),
+    ):
+        if ours_norm is not None:
+            ours_norm.load_state_dict(copy.deepcopy(native_norm.state_dict()))
+
+
+@pytest.mark.parametrize("attn_type", ["multihead", "performer"])
+def pytest_graphgps_global_branch_matches_pyg(attn_type):
+    torch.manual_seed(23)
+    native = PyGGPSConv(8, conv=None, heads=2, attn_type=attn_type).eval()
+    ours = HydraGPSConv(8, conv=None, heads=2, attn_type=attn_type).eval()
+    _copy_nonlocal_state(ours, native)
+    x, equiv, edge_index, batch = _inputs()
+
+    with torch.no_grad():
+        expected = native(x, edge_index, batch)
+        actual, actual_equiv = ours(x, equiv, batch, edge_index=edge_index)
+
+    assert torch.allclose(actual, expected, atol=1e-7, rtol=1e-6)
+    assert actual_equiv is equiv
+
+
+def pytest_graphgps_local_and_global_branches_match_pyg():
+    torch.manual_seed(29)
+    native_local = GCNConv(8, 8)
+    native = PyGGPSConv(8, conv=native_local, heads=2).eval()
+    ours = HydraGPSConv(
+        8,
+        conv=_HydraLocalAdapter(copy.deepcopy(native_local)),
+        heads=2,
+    ).eval()
+    _copy_nonlocal_state(ours, native)
+    x, equiv, edge_index, batch = _inputs()
+
+    with torch.no_grad():
+        expected = native(x, edge_index, batch)
+        actual, actual_equiv = ours(x, equiv, batch, edge_index=edge_index)
+
+    assert torch.allclose(actual, expected, atol=1e-7, rtol=1e-6)
+    assert torch.equal(actual_equiv, equiv)
+
+
+def pytest_graphgps_legacy_name_remains_compatible():
+    assert GPSConv is HydraGPSConv
+    assert HydraGPSConv.pyg_source_version == "2.8.0"

--- a/tests/test_graphgps_pyg_parity.py
+++ b/tests/test_graphgps_pyg_parity.py
@@ -22,7 +22,6 @@ from torch_geometric.nn import GPSConv as PyGGPSConv
 from torch_geometric.data import Data
 
 from hydragnn.globalAtt.gps import (
-    GPSConv,
     HydraGPSConv,
     redraw_performer_projections,
 )
@@ -111,8 +110,7 @@ def pytest_graphgps_local_and_global_branches_match_pyg():
     assert torch.equal(actual_equiv, equiv)
 
 
-def pytest_graphgps_legacy_name_remains_compatible():
-    assert GPSConv is HydraGPSConv
+def pytest_graphgps_records_pyg_source_version():
     assert HydraGPSConv.pyg_source_version == "2.8.0"
 
 

--- a/tests/test_graphgps_pyg_parity.py
+++ b/tests/test_graphgps_pyg_parity.py
@@ -19,13 +19,11 @@ import torch
 from torch import Tensor
 from torch_geometric.nn import GCNConv
 from torch_geometric.nn import GPSConv as PyGGPSConv
-from torch_geometric.data import Data
 
 from hydragnn.globalAtt.gps import (
     HydraGPSConv,
     redraw_performer_projections,
 )
-from hydragnn.models.create import create_model
 
 
 class _HydraLocalAdapter(torch.nn.Module):
@@ -110,10 +108,6 @@ def pytest_graphgps_local_and_global_branches_match_pyg():
     assert torch.equal(actual_equiv, equiv)
 
 
-def pytest_graphgps_records_pyg_source_version():
-    assert HydraGPSConv.pyg_source_version == "2.8.0"
-
-
 def pytest_graphgps_performer_projection_redraw_is_step_based(monkeypatch):
     layer = HydraGPSConv(8, conv=None, heads=2, attn_type="performer").train()
     redraw_count = 0
@@ -133,49 +127,3 @@ def pytest_graphgps_performer_projection_redraw_is_step_based(monkeypatch):
     layer.eval()
     assert redraw_performer_projections(layer, redraw_interval=1) == 0
     assert redraw_count == 1
-
-
-def pytest_graphgps_model_factory_forward_and_backward():
-    model = create_model(
-        mpnn_type="GIN",
-        input_dim=2,
-        hidden_dim=8,
-        output_dim=[1],
-        pe_dim=2,
-        global_attn_engine="GPS",
-        global_attn_type="multihead",
-        global_attn_heads=2,
-        output_type=["graph"],
-        output_heads={
-            "graph": [
-                {
-                    "type": "branch-0",
-                    "architecture": {
-                        "num_sharedlayers": 1,
-                        "dim_sharedlayers": 4,
-                        "num_headlayers": 1,
-                        "dim_headlayers": [4],
-                    },
-                }
-            ]
-        },
-        activation_function="relu",
-        loss_function_type="mse",
-        task_weights=[1.0],
-        num_conv_layers=1,
-        use_gpu=False,
-    )
-    data = Data(
-        x=torch.randn(5, 2),
-        pe=torch.randn(5, 2),
-        pos=torch.randn(5, 3),
-        edge_index=torch.tensor([[0, 1, 1, 2, 2, 0, 3, 4], [1, 0, 2, 1, 0, 2, 4, 3]]),
-        batch=torch.tensor([0, 0, 0, 1, 1]),
-    )
-
-    output = model(data)
-    assert len(output) == 1
-    assert output[0].shape == (2, 1)
-    output[0].sum().backward()
-    assert any(parameter.grad is not None for parameter in model.parameters())
-    assert isinstance(model.graph_convs[0], HydraGPSConv)

--- a/tests/test_graphgps_pyg_parity.py
+++ b/tests/test_graphgps_pyg_parity.py
@@ -19,8 +19,14 @@ import torch
 from torch import Tensor
 from torch_geometric.nn import GCNConv
 from torch_geometric.nn import GPSConv as PyGGPSConv
+from torch_geometric.data import Data
 
-from hydragnn.globalAtt.gps import GPSConv, HydraGPSConv
+from hydragnn.globalAtt.gps import (
+    GPSConv,
+    HydraGPSConv,
+    redraw_performer_projections,
+)
+from hydragnn.models.create import create_model
 
 
 class _HydraLocalAdapter(torch.nn.Module):
@@ -108,3 +114,70 @@ def pytest_graphgps_local_and_global_branches_match_pyg():
 def pytest_graphgps_legacy_name_remains_compatible():
     assert GPSConv is HydraGPSConv
     assert HydraGPSConv.pyg_source_version == "2.8.0"
+
+
+def pytest_graphgps_performer_projection_redraw_is_step_based(monkeypatch):
+    layer = HydraGPSConv(8, conv=None, heads=2, attn_type="performer").train()
+    redraw_count = 0
+
+    def count_redraw():
+        nonlocal redraw_count
+        redraw_count += 1
+
+    monkeypatch.setattr(layer.attn, "redraw_projection_matrix", count_redraw)
+
+    assert redraw_performer_projections(layer, redraw_interval=2) == 0
+    assert redraw_count == 0
+    assert redraw_performer_projections(layer, redraw_interval=2) == 1
+    assert redraw_count == 1
+    assert redraw_performer_projections(layer, redraw_interval=2) == 0
+
+    layer.eval()
+    assert redraw_performer_projections(layer, redraw_interval=1) == 0
+    assert redraw_count == 1
+
+
+def pytest_graphgps_model_factory_forward_and_backward():
+    model = create_model(
+        mpnn_type="GIN",
+        input_dim=2,
+        hidden_dim=8,
+        output_dim=[1],
+        pe_dim=2,
+        global_attn_engine="GPS",
+        global_attn_type="multihead",
+        global_attn_heads=2,
+        output_type=["graph"],
+        output_heads={
+            "graph": [
+                {
+                    "type": "branch-0",
+                    "architecture": {
+                        "num_sharedlayers": 1,
+                        "dim_sharedlayers": 4,
+                        "num_headlayers": 1,
+                        "dim_headlayers": [4],
+                    },
+                }
+            ]
+        },
+        activation_function="relu",
+        loss_function_type="mse",
+        task_weights=[1.0],
+        num_conv_layers=1,
+        use_gpu=False,
+    )
+    data = Data(
+        x=torch.randn(5, 2),
+        pe=torch.randn(5, 2),
+        pos=torch.randn(5, 3),
+        edge_index=torch.tensor([[0, 1, 1, 2, 2, 0, 3, 4], [1, 0, 2, 1, 0, 2, 4, 3]]),
+        batch=torch.tensor([0, 0, 0, 1, 1]),
+    )
+
+    output = model(data)
+    assert len(output) == 1
+    assert output[0].shape == (2, 1)
+    output[0].sum().backward()
+    assert any(parameter.grad is not None for parameter in model.parameters())
+    assert isinstance(model.graph_convs[0], HydraGPSConv)

--- a/tests/test_graphgps_pyg_parity.py
+++ b/tests/test_graphgps_pyg_parity.py
@@ -233,6 +233,25 @@ def pytest_graphgps_performer_projection_redraw_is_step_based(monkeypatch):
     assert redraw_count == 1
 
 
+def pytest_graphgps_reset_restarts_performer_redraw_schedule(monkeypatch):
+    layer = HydraGPSConv(8, conv=None, heads=2, attn_type="performer").train()
+    redraw_count = 0
+
+    def count_redraw():
+        nonlocal redraw_count
+        redraw_count += 1
+
+    monkeypatch.setattr(layer.attn, "redraw_projection_matrix", count_redraw)
+
+    assert redraw_performer_projections(layer, redraw_interval=2) == 0
+    layer.reset_parameters()
+    redraws_after_reset = redraw_count
+    assert redraw_performer_projections(layer, redraw_interval=2) == 0
+    assert redraw_count == redraws_after_reset
+    assert redraw_performer_projections(layer, redraw_interval=2) == 1
+    assert redraw_count == redraws_after_reset + 1
+
+
 def pytest_graphgps_performer_projection_redraw_handles_multiple_layers(monkeypatch):
     layers = torch.nn.ModuleList(
         [

--- a/tests/test_graphgps_pyg_parity.py
+++ b/tests/test_graphgps_pyg_parity.py
@@ -17,6 +17,7 @@ import copy
 import pytest
 import torch
 from torch import Tensor
+from torch_geometric.data import Data
 from torch_geometric.nn import GCNConv
 from torch_geometric.nn import GPSConv as PyGGPSConv
 
@@ -24,6 +25,7 @@ from hydragnn.globalAtt.gps import (
     HydraGPSConv,
     redraw_performer_projections,
 )
+from hydragnn.models.create import create_model
 
 
 class _HydraLocalAdapter(torch.nn.Module):
@@ -46,11 +48,12 @@ class _HydraLocalAdapter(torch.nn.Module):
         return self.conv(inv_node_feat, edge_index, **kwargs), equiv_node_feat
 
 
-def _inputs() -> tuple[Tensor, Tensor, Tensor, Tensor]:
+def _inputs(batch: Tensor | None = None) -> tuple[Tensor, Tensor, Tensor, Tensor]:
     torch.manual_seed(17)
     x = torch.randn(7, 8)
     equiv = torch.randn(7, 3, 4)
-    batch = torch.tensor([0, 0, 0, 0, 1, 1, 1])
+    if batch is None:
+        batch = torch.tensor([0, 0, 0, 0, 1, 1, 1])
     edge_index = torch.tensor(
         [
             [0, 1, 1, 2, 2, 3, 3, 0, 4, 5, 5, 6, 6, 4],
@@ -73,12 +76,21 @@ def _copy_nonlocal_state(ours: HydraGPSConv, native: PyGGPSConv) -> None:
 
 
 @pytest.mark.parametrize("attn_type", ["multihead", "performer"])
-def pytest_graphgps_global_branch_matches_pyg(attn_type):
+@pytest.mark.parametrize(
+    "batch",
+    [
+        torch.tensor([0, 0, 0, 0, 1, 1, 1]),
+        torch.tensor([0, 1, 1, 1, 1, 1, 1]),
+        torch.zeros(7, dtype=torch.long),
+    ],
+    ids=["balanced", "uneven", "single-graph"],
+)
+def pytest_graphgps_global_branch_matches_pyg(attn_type, batch):
     torch.manual_seed(23)
     native = PyGGPSConv(8, conv=None, heads=2, attn_type=attn_type).eval()
     ours = HydraGPSConv(8, conv=None, heads=2, attn_type=attn_type).eval()
     _copy_nonlocal_state(ours, native)
-    x, equiv, edge_index, batch = _inputs()
+    x, equiv, edge_index, batch = _inputs(batch)
 
     with torch.no_grad():
         expected = native(x, edge_index, batch)
@@ -88,14 +100,16 @@ def pytest_graphgps_global_branch_matches_pyg(attn_type):
     assert actual_equiv is equiv
 
 
-def pytest_graphgps_local_and_global_branches_match_pyg():
+@pytest.mark.parametrize("attn_type", ["multihead", "performer"])
+def pytest_graphgps_local_and_global_branches_match_pyg(attn_type):
     torch.manual_seed(29)
     native_local = GCNConv(8, 8)
-    native = PyGGPSConv(8, conv=native_local, heads=2).eval()
+    native = PyGGPSConv(8, conv=native_local, heads=2, attn_type=attn_type).eval()
     ours = HydraGPSConv(
         8,
         conv=_HydraLocalAdapter(copy.deepcopy(native_local)),
         heads=2,
+        attn_type=attn_type,
     ).eval()
     _copy_nonlocal_state(ours, native)
     x, equiv, edge_index, batch = _inputs()
@@ -106,6 +120,96 @@ def pytest_graphgps_local_and_global_branches_match_pyg():
 
     assert torch.allclose(actual, expected, atol=1e-7, rtol=1e-6)
     assert torch.equal(actual_equiv, equiv)
+
+
+@pytest.mark.parametrize("attn_type", ["multihead", "performer"])
+def pytest_graphgps_training_dropout_matches_pyg(attn_type):
+    torch.manual_seed(31)
+    native = PyGGPSConv(
+        8, conv=None, heads=2, dropout=0.25, attn_type=attn_type
+    ).train()
+    ours = HydraGPSConv(
+        8, conv=None, heads=2, dropout=0.25, attn_type=attn_type
+    ).train()
+    _copy_nonlocal_state(ours, native)
+    x, equiv, edge_index, batch = _inputs()
+
+    torch.manual_seed(37)
+    expected = native(x, edge_index, batch)
+    torch.manual_seed(37)
+    actual, actual_equiv = ours(x, equiv, batch, edge_index=edge_index)
+
+    assert torch.allclose(actual, expected, atol=1e-7, rtol=1e-6)
+    assert actual_equiv is equiv
+
+
+@pytest.mark.parametrize("attn_type", ["multihead", "performer"])
+def pytest_graphgps_input_gradients_match_pyg(attn_type):
+    torch.manual_seed(41)
+    native = PyGGPSConv(8, conv=None, heads=2, attn_type=attn_type).eval()
+    ours = HydraGPSConv(8, conv=None, heads=2, attn_type=attn_type).eval()
+    _copy_nonlocal_state(ours, native)
+    x, equiv, edge_index, batch = _inputs()
+    native_x = x.detach().clone().requires_grad_()
+    ours_x = x.detach().clone().requires_grad_()
+
+    native(native_x, edge_index, batch).square().sum().backward()
+    ours(ours_x, equiv, batch, edge_index=edge_index)[0].square().sum().backward()
+
+    assert torch.allclose(ours_x.grad, native_x.grad, atol=1e-6, rtol=1e-5)
+    native_gradients = dict(native.named_parameters())
+    for name, parameter in ours.named_parameters():
+        native_gradient = native_gradients[name].grad
+        if native_gradient is None:
+            assert parameter.grad is None
+        else:
+            assert torch.allclose(parameter.grad, native_gradient, atol=1e-6, rtol=1e-5)
+
+
+def pytest_graphgps_performer_model_factory_forward_and_backward():
+    model = create_model(
+        mpnn_type="GIN",
+        input_dim=2,
+        hidden_dim=8,
+        output_dim=[1],
+        pe_dim=2,
+        global_attn_engine="GPS",
+        global_attn_type="performer",
+        global_attn_heads=2,
+        output_type=["graph"],
+        output_heads={
+            "graph": [
+                {
+                    "type": "branch-0",
+                    "architecture": {
+                        "num_sharedlayers": 1,
+                        "dim_sharedlayers": 4,
+                        "num_headlayers": 1,
+                        "dim_headlayers": [4],
+                    },
+                }
+            ]
+        },
+        activation_function="relu",
+        loss_function_type="mse",
+        task_weights=[1.0],
+        num_conv_layers=1,
+        use_gpu=False,
+    )
+    data = Data(
+        x=torch.randn(5, 2),
+        pe=torch.randn(5, 2),
+        pos=torch.randn(5, 3),
+        edge_index=torch.tensor([[0, 1, 1, 2, 2, 0, 3, 4], [1, 0, 2, 1, 0, 2, 4, 3]]),
+        batch=torch.tensor([0, 0, 0, 1, 1]),
+    )
+
+    output = model(data)
+    assert len(output) == 1
+    assert output[0].shape == (2, 1)
+    output[0].sum().backward()
+    assert any(parameter.grad is not None for parameter in model.parameters())
+    assert isinstance(model.graph_convs[0], HydraGPSConv)
 
 
 def pytest_graphgps_performer_projection_redraw_is_step_based(monkeypatch):
@@ -127,3 +231,32 @@ def pytest_graphgps_performer_projection_redraw_is_step_based(monkeypatch):
     layer.eval()
     assert redraw_performer_projections(layer, redraw_interval=1) == 0
     assert redraw_count == 1
+
+
+def pytest_graphgps_performer_projection_redraw_handles_multiple_layers(monkeypatch):
+    layers = torch.nn.ModuleList(
+        [
+            HydraGPSConv(8, conv=None, heads=2, attn_type="performer"),
+            HydraGPSConv(8, conv=None, heads=2, attn_type="multihead"),
+            HydraGPSConv(8, conv=None, heads=2, attn_type="performer"),
+        ]
+    ).train()
+    redraw_counts = [0, 0]
+
+    for index, layer in enumerate((layers[0], layers[2])):
+
+        def count_redraw(index=index):
+            redraw_counts[index] += 1
+
+        monkeypatch.setattr(layer.attn, "redraw_projection_matrix", count_redraw)
+
+    assert redraw_performer_projections(layers, redraw_interval=None) == 0
+    assert redraw_performer_projections(layers, redraw_interval=1) == 2
+    assert redraw_counts == [1, 1]
+
+
+def pytest_graphgps_performer_projection_redraw_rejects_invalid_interval():
+    layer = HydraGPSConv(8, conv=None, heads=2, attn_type="performer").train()
+
+    with pytest.raises(ValueError, match="positive or None"):
+        redraw_performer_projections(layer, redraw_interval=0)


### PR DESCRIPTION
## Summary

- rename HydraGNN's PyG-derived layer to `HydraGPSConv` and remove the old `GPSConv` name
- document the PyG 2.8.0 origin and package the upstream MIT license
- use an `MIT AND BSD-3-Clause` SPDX expression for the adapted implementation
- add numerical parity tests against native `torch_geometric.nn.GPSConv`
- add step-based Performer projection redraw support outside `forward`
- document GraphGPS configuration and invariant/equivariant behavior

## Motivation

HydraGNN's GraphGPS implementation closely tracks PyG's `GPSConv`, with a focused adaptation for HydraGNN's invariant/equivariant two-stream interface. The previous implementation did not clearly record that relationship, did not test numerical parity, and accepted Performer attention without periodically redrawing its random-feature projections as recommended by PyG's example.

## User impact

Code importing HydraGNN's former `GPSConv` name must migrate to `HydraGPSConv`. Multi-head behavior is unchanged. Performer users now receive projection redraw every 1,000 training batches by default and can configure `NeuralNetwork.Training.global_attn_redraw_interval` or set it to `null` to disable redraw.

## Validation

- `tests/test_graphgps_pyg_parity.py`: 16 passed with PyTorch 2.13.0 and PyG 2.8.0
- both attention engines are covered across balanced, uneven, and single-graph batches; local+global execution; training-mode dropout; forward and gradient parity; and equivariant passthrough
- Performer-specific coverage includes a complete HydraGNN factory forward/backward pass plus redraw cadence, multiple layers, disabled redraw, evaluation behavior, and invalid configuration
- Black check passed for modified Python files
- `git diff --check` passed

The pre-existing `tests/test_graphs.py -k global_attention` subset was also attempted locally. All nine cases stop during dataset preprocessing because this environment lacks the compiled `pyg-lib` radius-graph backend; none reaches GraphGPS model construction. CI installs the pinned `pyg_lib` dependency and will provide the complete integration result.
