### PR TITLE
Add an equivariant all-to-all graph Transformer

### DIFF
--- a/docs/equivariant_graph_transformer.md
+++ b/docs/equivariant_graph_transformer.md
@@ -93,6 +93,7 @@ The engine is selected with:
       "equivariant_attn_lmax": 1,
       "equivariant_attn_num_radial": 32,
       "equivariant_attn_chunk_size": 512,
+      "equivariant_attn_coupling_mode": "parallel",
       "equivariant_attn_allow_scalar_only": false,
       "equivariant_attn_require_tensor_coupling": true
     }
@@ -105,6 +106,13 @@ the value tensor product. In scalar-only mode, non-scalar harmonics cannot
 couple a scalar input back to a scalar output, so increasing `lmax` does not
 create tensor-valued latent channels. Chunking changes execution and memory
 use, not numerical semantics.
+
+`equivariant_attn_coupling_mode` controls how the local MPNN and global
+Transformer are combined. The default, `"parallel"`, applies both branches to
+the same input and adds their outputs in the shared irrep representation. This
+matches GraphGPS's local/global organization while preserving equivariance.
+`"sequential"` retains the earlier local-MPNN-then-global-Transformer flow for
+experiments and compatibility with models trained using that architecture.
 
 `equivariant_attn_allow_scalar_only` must be set to `true` for SchNet or
 DimeNet, and `equivariant_attn_require_tensor_coupling` must be set to `false`.

--- a/docs/equivariant_graph_transformer.md
+++ b/docs/equivariant_graph_transformer.md
@@ -84,7 +84,8 @@ The engine is selected with:
       "equivariant_attn_lmax": 1,
       "equivariant_attn_num_radial": 32,
       "equivariant_attn_chunk_size": 512,
-      "equivariant_attn_allow_scalar_only": false
+      "equivariant_attn_allow_scalar_only": false,
+      "equivariant_attn_require_tensor_coupling": true
     }
   }
 }
@@ -97,8 +98,12 @@ create tensor-valued latent channels. Chunking changes execution and memory
 use, not numerical semantics.
 
 `equivariant_attn_allow_scalar_only` must be set to `true` for SchNet or
-DimeNet. HydraGNN emits a warning when this limited mode is selected. For
-SchNet it also rejects coordinate-update mode
+DimeNet, and `equivariant_attn_require_tensor_coupling` must be set to `false`.
+If tensor coupling remains requested, model construction fails because these
+MPNNs expose no non-scalar latent irreps. The Transformer layer independently
+performs the same irrep-level validation so the restriction cannot be bypassed
+by constructing it directly. HydraGNN emits a warning when the limited mode is
+selected. For SchNet it also rejects coordinate-update mode
 (`Architecture.equivariance=true`) because raw coordinates are not
 translation-invariant latent tensor features.
 

--- a/docs/equivariant_graph_transformer.md
+++ b/docs/equivariant_graph_transformer.md
@@ -71,9 +71,12 @@ all-to-all attention requires an explicit image convention or a lattice-aware
 long-range formulation; silently applying a minimum-image displacement is not
 equivalent to an infinite periodic interaction.
 
-The reference implementation may materialize the complete edge set for
-correctness tests. The production path must support query chunking so memory
-does not require storing every pairwise message simultaneously.
+The dense reference path materializes the complete edge set for correctness
+tests. Production execution chunks target nodes and constructs only the pairs
+needed by the current target chunk. Every target still attends to every source
+in its graph in one softmax; chunks never split a target's source set. Thus
+chunking bounds pair-message memory without approximating or truncating
+attention. Dense/chunked output and gradient parity are regression-tested.
 
 ## Configuration
 

--- a/docs/equivariant_graph_transformer.md
+++ b/docs/equivariant_graph_transformer.md
@@ -11,11 +11,9 @@ This is a new HydraGNN architecture. It is not EquiformerV2, whose attention is
 restricted to a local neighbor graph, and it is not AllScAIP, whose rotational
 equivariance is learned rather than encoded with irreducible tensors.
 
-The current end-to-end model integration is enabled for PaiNN and PNAEq.
-SchNet and DimeNet have representation adapters, but model construction keeps
-them disabled until each path has its own full-model invariance and gradient
-tests. This distinction prevents an adapter-level test from being mistaken for
-a supported training configuration.
+The end-to-end model integration supports PaiNN and PNAEq with tensor-valued
+coupling. SchNet and DimeNet are supported only in the explicitly acknowledged
+scalar-only mode described below.
 
 ## Equivariance contract
 

--- a/docs/equivariant_graph_transformer.md
+++ b/docs/equivariant_graph_transformer.md
@@ -11,6 +11,12 @@ This is a new HydraGNN architecture. It is not EquiformerV2, whose attention is
 restricted to a local neighbor graph, and it is not AllScAIP, whose rotational
 equivariance is learned rather than encoded with irreducible tensors.
 
+The current end-to-end model integration is enabled only for PaiNN. PNAEq,
+SchNet, and DimeNet have representation adapters, but model construction keeps
+them disabled until each path has its own full-model symmetry and gradient
+tests. This distinction prevents an adapter-level test from being mistaken for
+a supported training configuration.
+
 ## Equivariance contract
 
 Node features are represented as e3nn irreducible representations (irreps).

--- a/docs/equivariant_graph_transformer.md
+++ b/docs/equivariant_graph_transformer.md
@@ -11,9 +11,9 @@ This is a new HydraGNN architecture. It is not EquiformerV2, whose attention is
 restricted to a local neighbor graph, and it is not AllScAIP, whose rotational
 equivariance is learned rather than encoded with irreducible tensors.
 
-The current end-to-end model integration is enabled only for PaiNN. PNAEq,
-SchNet, and DimeNet have representation adapters, but model construction keeps
-them disabled until each path has its own full-model symmetry and gradient
+The current end-to-end model integration is enabled for PaiNN and PNAEq.
+SchNet and DimeNet have representation adapters, but model construction keeps
+them disabled until each path has its own full-model invariance and gradient
 tests. This distinction prevents an adapter-level test from being mistaken for
 a supported training configuration.
 

--- a/docs/equivariant_graph_transformer.md
+++ b/docs/equivariant_graph_transformer.md
@@ -1,0 +1,107 @@
+# Equivariant all-to-all graph Transformer
+
+## Scope
+
+HydraGNN's `GPS` global-attention engine applies scalar attention to invariant
+node channels. The proposed `EquivariantTransformer` engine is an alternative
+GraphGPS-style hybrid: every layer combines a local equivariant MPNN update
+with an explicitly SE(3)-equivariant, all-to-all attention update.
+
+This is a new HydraGNN architecture. It is not EquiformerV2, whose attention is
+restricted to a local neighbor graph, and it is not AllScAIP, whose rotational
+equivariance is learned rather than encoded with irreducible tensors.
+
+## Equivariance contract
+
+Node features are represented as e3nn irreducible representations (irreps).
+For every ordered atom pair `(i, j)` within the same graph, the global branch
+uses the relative displacement `r_ij = r_j - r_i`, its radial expansion, and
+spherical harmonics of its direction. It must never use absolute positions.
+
+Queries and keys are equivariant linear projections of the node irreps. Their
+contraction to degree zero produces invariant attention logits. Softmax is
+applied over all source atoms `j` belonging to the target atom's graph.
+
+Values are equivariant tensor-product messages coupling source-node irreps to
+spherical harmonics of `r_ij`. Multiplication by invariant attention weights
+and summation over source atoms preserve equivariance. The output projection,
+normalization, residual path, and feed-forward network must also preserve the
+declared irreps.
+
+Consequently, under a rotation `R`, scalar outputs remain unchanged and every
+degree-`l` output transforms with the corresponding representation `D_l(R)`.
+Translation invariance follows from using only relative displacements.
+
+## Local-model adapters
+
+HydraGNN's current equivariant models do not share one tensor layout, so the
+global engine must use explicit adapters instead of guessing from tensor
+shapes.
+
+- `PAINN` and `PNAEq` expose scalar channels plus vector channels shaped
+  `[num_nodes, 3, channels]`. Their adapter maps these to
+  `channels x 0e + channels x 1o` and restores the original layout afterward.
+- `MACE` exposes flattened e3nn irreps. Its adapter obtains the exact irreps
+  from the stack configuration and preserves all configured degrees.
+- `EGNN` uses atomic coordinates as its equivariant state rather than latent
+  irreducible tensor features. It is initially unsupported; treating positions
+  as ordinary vector channels would break translation invariance.
+- Scalar-only MPNNs are rejected because this engine is specifically intended
+  to combine equivariant local and global branches. They can continue to use
+  `GPS`.
+
+Adapters must validate dimensions and parity and fail with actionable errors.
+
+## Complete-graph construction
+
+All ordered non-self pairs are constructed independently for each graph in a
+batch. Cross-graph attention is forbidden. Self-attention is handled by the
+residual path rather than by zero-length geometric edges.
+
+The first implementation targets finite, non-periodic systems. Periodic
+all-to-all attention requires an explicit image convention or a lattice-aware
+long-range formulation; silently applying a minimum-image displacement is not
+equivalent to an infinite periodic interaction.
+
+The reference implementation may materialize the complete edge set for
+correctness tests. The production path must support query chunking so memory
+does not require storing every pairwise message simultaneously.
+
+## Configuration
+
+The engine is selected with:
+
+```json
+{
+  "NeuralNetwork": {
+    "Architecture": {
+      "global_attn_engine": "EquivariantTransformer",
+      "global_attn_heads": 4,
+      "equivariant_attn_lmax": 1,
+      "equivariant_attn_num_radial": 32,
+      "equivariant_attn_chunk_size": 512
+    }
+  }
+}
+```
+
+`equivariant_attn_lmax` cannot exceed the degrees supplied by the selected
+local-model adapter. Chunking changes execution and memory use, not numerical
+semantics.
+
+## Required tests
+
+The engine is not complete until tests cover:
+
+1. rotation equivariance for every output irrep;
+2. translation invariance;
+3. permutation equivariance;
+4. absence of cross-graph attention in mixed-size batches;
+5. dense-versus-chunked numerical and gradient parity;
+6. PaiNN/PNAEq and MACE adapter round trips;
+7. forward and backward integration with each supported local MPNN;
+8. invariant energy and equivariant energy-gradient forces; and
+9. clear rejection of scalar-only, EGNN, and unsupported periodic inputs.
+
+All symmetry tests must use multiple random transformations and nontrivial
+features; shape-only smoke tests are insufficient.

--- a/docs/equivariant_graph_transformer.md
+++ b/docs/equivariant_graph_transformer.md
@@ -11,9 +11,11 @@ This is a new HydraGNN architecture. It is not EquiformerV2, whose attention is
 restricted to a local neighbor graph, and it is not AllScAIP, whose rotational
 equivariance is learned rather than encoded with irreducible tensors.
 
-The end-to-end model integration supports PaiNN and PNAEq with tensor-valued
-coupling. SchNet and DimeNet are supported only in the explicitly acknowledged
-scalar-only mode described below.
+The end-to-end model integration supports PaiNN, PNAEq, and MACE with
+tensor-valued coupling. SchNet and DimeNet are supported only in the explicitly
+acknowledged scalar-only mode described below. MACE applies global attention
+after its tensor-valued hidden layers but not after its final scalar-only
+readout layer, and consequently requires at least two convolution layers.
 
 ## Equivariance contract
 
@@ -45,8 +47,8 @@ shapes.
 - `PAINN` and `PNAEq` expose scalar channels plus vector channels shaped
   `[num_nodes, 3, channels]`. Their adapter maps these to
   `channels x 0e + channels x 1o` and restores the original layout afterward.
-- `MACE` exposes flattened e3nn irreps. Its adapter obtains the exact irreps
-  from the stack configuration and preserves all configured degrees.
+- `MACE` exposes flattened e3nn irreps. Its adapter receives the exact output
+  irreps from each wrapped MACE layer and preserves all configured degrees.
 - `SchNet` and `DimeNet` may be used in an explicitly acknowledged scalar-only
   mode. Their hidden node features map to `channels x 0e`; consequently, their
   local and global branches exchange invariant features only. This mode does

--- a/docs/equivariant_graph_transformer.md
+++ b/docs/equivariant_graph_transformer.md
@@ -43,12 +43,16 @@ shapes.
   `channels x 0e + channels x 1o` and restores the original layout afterward.
 - `MACE` exposes flattened e3nn irreps. Its adapter obtains the exact irreps
   from the stack configuration and preserves all configured degrees.
+- `SchNet` and `DimeNet` may be used in an explicitly acknowledged scalar-only
+  mode. Their hidden node features map to `channels x 0e`; consequently, their
+  local and global branches exchange invariant features only. This mode does
+  not provide tensor-valued local/global feature exchange and must not be
+  described as equivalent to the PaiNN/PNAEq or MACE integrations.
 - `EGNN` uses atomic coordinates as its equivariant state rather than latent
   irreducible tensor features. It is initially unsupported; treating positions
   as ordinary vector channels would break translation invariance.
-- Scalar-only MPNNs are rejected because this engine is specifically intended
-  to combine equivariant local and global branches. They can continue to use
-  `GPS`.
+- Other scalar-only MPNNs remain unsupported until their feature and geometry
+  contracts have been reviewed explicitly.
 
 Adapters must validate dimensions and parity and fail with actionable errors.
 
@@ -79,15 +83,24 @@ The engine is selected with:
       "global_attn_heads": 4,
       "equivariant_attn_lmax": 1,
       "equivariant_attn_num_radial": 32,
-      "equivariant_attn_chunk_size": 512
+      "equivariant_attn_chunk_size": 512,
+      "equivariant_attn_allow_scalar_only": false
     }
   }
 }
 ```
 
-`equivariant_attn_lmax` cannot exceed the degrees supplied by the selected
-local-model adapter. Chunking changes execution and memory use, not numerical
-semantics.
+`equivariant_attn_lmax` controls the spherical-harmonic degrees available to
+the value tensor product. In scalar-only mode, non-scalar harmonics cannot
+couple a scalar input back to a scalar output, so increasing `lmax` does not
+create tensor-valued latent channels. Chunking changes execution and memory
+use, not numerical semantics.
+
+`equivariant_attn_allow_scalar_only` must be set to `true` for SchNet or
+DimeNet. HydraGNN emits a warning when this limited mode is selected. For
+SchNet it also rejects coordinate-update mode
+(`Architecture.equivariance=true`) because raw coordinates are not
+translation-invariant latent tensor features.
 
 ## Required tests
 

--- a/hydragnn/globalAtt/complete_graph.py
+++ b/hydragnn/globalAtt/complete_graph.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import torch
+
+
+def complete_graph_edge_index(batch: torch.Tensor) -> torch.Tensor:
+    """Build all ordered non-self node pairs independently in each graph.
+
+    Args:
+        batch: One-dimensional integer tensor assigning every node to a graph.
+            Graph identifiers need not be contiguous.
+
+    Returns:
+        A standard PyTorch Geometric ``edge_index`` tensor with shape
+        ``[2, E]``.  Row zero contains source nodes and row one contains target
+        nodes.  Pairs are ordered by graph identifier, target node, then source
+        node.  Singleton graphs contribute no pairs.
+
+    This function deliberately excludes self-pairs: the equivariant
+    Transformer handles a node's own state through its residual connection.
+    """
+    if not isinstance(batch, torch.Tensor):
+        raise TypeError("batch must be a torch.Tensor")
+    if batch.ndim != 1:
+        raise ValueError(
+            f"batch must be one-dimensional, but has shape {tuple(batch.shape)}"
+        )
+    if batch.dtype != torch.long:
+        raise TypeError(f"batch must have dtype torch.long, but has {batch.dtype}")
+    if torch.any(batch < 0):
+        raise ValueError("batch graph identifiers must be nonnegative")
+
+    pairs = []
+    for graph_id in torch.unique(batch, sorted=True):
+        nodes = torch.nonzero(batch == graph_id, as_tuple=False).flatten()
+        target = nodes.repeat_interleave(nodes.numel())
+        source = nodes.repeat(nodes.numel())
+        non_self = source != target
+        pairs.append(torch.stack((source[non_self], target[non_self])))
+
+    if not pairs:
+        return torch.empty((2, 0), dtype=torch.long, device=batch.device)
+    return torch.cat(pairs, dim=1)

--- a/hydragnn/globalAtt/equivariant_attention.py
+++ b/hydragnn/globalAtt/equivariant_attention.py
@@ -98,6 +98,89 @@ class EquivariantAllToAllAttention(torch.nn.Module):
         logits = logits / math.sqrt(self.irreps.dim)
         attention = softmax(logits, index=target, num_nodes=num_nodes)
 
+        values = self._values(node_features, positions, edge_index)
+        messages = attention.unsqueeze(-1) * values
+        aggregated = node_features.new_zeros((num_nodes, self.heads, self.irreps.dim))
+        aggregated.index_add_(0, target, messages)
+        result = self.output(aggregated.reshape(num_nodes, self.head_irreps.dim))
+
+        if return_attention_weights:
+            return result, attention
+        return result
+
+    def forward_chunked(
+        self,
+        node_features: torch.Tensor,
+        positions: torch.Tensor,
+        batch: torch.Tensor,
+        chunk_size: int,
+    ) -> torch.Tensor:
+        """Apply exact attention while materializing only a target-node chunk.
+
+        Chunking is over target nodes, not edges. Every target retains all
+        sources from its graph in the same softmax, so this changes memory and
+        execution order without changing attention semantics.
+        """
+        if not isinstance(chunk_size, int) or isinstance(chunk_size, bool):
+            raise TypeError("chunk_size must be an integer")
+        if chunk_size <= 0:
+            raise ValueError("chunk_size must be positive")
+        self._validate_inputs(
+            node_features,
+            positions,
+            torch.empty((2, 0), dtype=torch.long, device=node_features.device),
+        )
+        if batch.ndim != 1 or batch.shape[0] != node_features.shape[0]:
+            raise ValueError("batch must contain one graph identifier per node")
+        if batch.dtype != torch.long:
+            raise TypeError("batch must have dtype torch.long")
+        if batch.device != node_features.device:
+            raise ValueError("batch and node features must share a device")
+
+        num_nodes = node_features.shape[0]
+        queries = self.query(node_features).reshape(
+            num_nodes, self.heads, self.irreps.dim
+        )
+        keys = self.key(node_features).reshape(num_nodes, self.heads, self.irreps.dim)
+        node_indices = torch.arange(num_nodes, device=batch.device)
+        outputs = []
+
+        for start in range(0, num_nodes, chunk_size):
+            stop = min(start + chunk_size, num_nodes)
+            targets = node_indices[start:stop]
+            edge_index = self._edges_for_targets(batch, targets, node_indices)
+            if edge_index.shape[1] == 0:
+                outputs.append(
+                    node_features.new_zeros((targets.numel(), self.irreps.dim))
+                )
+                continue
+
+            source, target = edge_index
+            logits = (queries[target] * keys[source]).sum(dim=-1)
+            logits = logits / math.sqrt(self.irreps.dim)
+            attention = softmax(logits, index=target, num_nodes=num_nodes)
+            values = self._values(node_features, positions, edge_index)
+            messages = attention.unsqueeze(-1) * values
+
+            aggregated = node_features.new_zeros(
+                (targets.numel(), self.heads, self.irreps.dim)
+            )
+            aggregated.index_add_(0, target - start, messages)
+            outputs.append(
+                self.output(aggregated.reshape(targets.numel(), self.head_irreps.dim))
+            )
+
+        if not outputs:
+            return node_features.new_zeros((0, self.irreps.dim))
+        return torch.cat(outputs, dim=0)
+
+    def _values(
+        self,
+        node_features: torch.Tensor,
+        positions: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> torch.Tensor:
+        source, target = edge_index
         relative = positions[source] - positions[target]
         distances = torch.linalg.vector_norm(relative, dim=-1)
         spherical_harmonics = o3.spherical_harmonics(
@@ -110,9 +193,8 @@ class EquivariantAllToAllAttention(torch.nn.Module):
         weights = self.radial_mlp(radial).reshape(
             edge_index.shape[1], self.heads, self.value_tensor_product.weight_numel
         )
-
         source_features = node_features[source]
-        values = torch.stack(
+        return torch.stack(
             [
                 self.value_tensor_product(
                     source_features, spherical_harmonics, weights[:, head]
@@ -121,14 +203,20 @@ class EquivariantAllToAllAttention(torch.nn.Module):
             ],
             dim=1,
         )
-        messages = attention.unsqueeze(-1) * values
-        aggregated = node_features.new_zeros((num_nodes, self.heads, self.irreps.dim))
-        aggregated.index_add_(0, target, messages)
-        result = self.output(aggregated.reshape(num_nodes, self.head_irreps.dim))
 
-        if return_attention_weights:
-            return result, attention
-        return result
+    @staticmethod
+    def _edges_for_targets(
+        batch: torch.Tensor,
+        targets: torch.Tensor,
+        node_indices: torch.Tensor,
+    ) -> torch.Tensor:
+        pair_blocks = []
+        for target in targets:
+            sources = node_indices[(batch == batch[target]) & (node_indices != target)]
+            pair_blocks.append(torch.stack((sources, target.expand(sources.shape[0]))))
+        if not pair_blocks:
+            return torch.empty((2, 0), dtype=torch.long, device=batch.device)
+        return torch.cat(pair_blocks, dim=1)
 
     def _radial_basis(self, distances: torch.Tensor) -> torch.Tensor:
         normalized = distances / (1.0 + distances)

--- a/hydragnn/globalAtt/equivariant_attention.py
+++ b/hydragnn/globalAtt/equivariant_attention.py
@@ -1,0 +1,165 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import math
+
+import torch
+from e3nn import o3
+from torch_geometric.utils import softmax
+
+
+class EquivariantAllToAllAttention(torch.nn.Module):
+    """SE(3)-equivariant attention over an explicitly supplied edge set.
+
+    Queries and keys retain the input irreps. Their inner product is invariant
+    and therefore suitable as an attention logit. Values couple source-node
+    features to spherical harmonics of ``position[source] - position[target]``
+    through a fully connected tensor product. Invariant attention weights are
+    normalized over the sources of each target node.
+
+    Pair construction is intentionally separate so this kernel can later be
+    used by both dense and chunked execution paths.
+    """
+
+    def __init__(
+        self,
+        irreps: o3.Irreps | str,
+        heads: int = 1,
+        lmax: int = 1,
+        num_radial: int = 16,
+    ):
+        super().__init__()
+        self.irreps = o3.Irreps(irreps)
+        if self.irreps.dim == 0:
+            raise ValueError("irreps must not be empty")
+        if not isinstance(heads, int) or isinstance(heads, bool) or heads <= 0:
+            raise ValueError("heads must be a positive integer")
+        if not isinstance(lmax, int) or isinstance(lmax, bool) or lmax < 0:
+            raise ValueError("lmax must be a nonnegative integer")
+        if (
+            not isinstance(num_radial, int)
+            or isinstance(num_radial, bool)
+            or num_radial <= 0
+        ):
+            raise ValueError("num_radial must be a positive integer")
+
+        self.heads = heads
+        self.num_radial = num_radial
+        self.head_irreps = o3.Irreps(" + ".join([str(self.irreps)] * heads))
+        self.sh_irreps = o3.Irreps.spherical_harmonics(lmax)
+
+        self.query = o3.Linear(self.irreps, self.head_irreps, biases=False)
+        self.key = o3.Linear(self.irreps, self.head_irreps, biases=False)
+        self.value_tensor_product = o3.FullyConnectedTensorProduct(
+            self.irreps,
+            self.sh_irreps,
+            self.irreps,
+            shared_weights=False,
+        )
+        self.radial_mlp = torch.nn.Sequential(
+            torch.nn.Linear(num_radial, num_radial),
+            torch.nn.SiLU(),
+            torch.nn.Linear(num_radial, heads * self.value_tensor_product.weight_numel),
+        )
+        self.output = o3.Linear(self.head_irreps, self.irreps, biases=False)
+        self.register_buffer("radial_centers", torch.linspace(0.0, 1.0, num_radial))
+
+    def forward(
+        self,
+        node_features: torch.Tensor,
+        positions: torch.Tensor,
+        edge_index: torch.Tensor,
+        return_attention_weights: bool = False,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        """Apply attention, returning one feature tensor per input node."""
+        self._validate_inputs(node_features, positions, edge_index)
+        num_nodes = node_features.shape[0]
+        source, target = edge_index
+
+        if edge_index.shape[1] == 0:
+            result = node_features.new_zeros((num_nodes, self.irreps.dim))
+            if return_attention_weights:
+                return result, node_features.new_zeros((0, self.heads))
+            return result
+
+        queries = self.query(node_features).reshape(
+            num_nodes, self.heads, self.irreps.dim
+        )
+        keys = self.key(node_features).reshape(num_nodes, self.heads, self.irreps.dim)
+        logits = (queries[target] * keys[source]).sum(dim=-1)
+        logits = logits / math.sqrt(self.irreps.dim)
+        attention = softmax(logits, index=target, num_nodes=num_nodes)
+
+        relative = positions[source] - positions[target]
+        distances = torch.linalg.vector_norm(relative, dim=-1)
+        spherical_harmonics = o3.spherical_harmonics(
+            self.sh_irreps,
+            relative,
+            normalize=True,
+            normalization="component",
+        )
+        radial = self._radial_basis(distances)
+        weights = self.radial_mlp(radial).reshape(
+            edge_index.shape[1], self.heads, self.value_tensor_product.weight_numel
+        )
+
+        source_features = node_features[source]
+        values = torch.stack(
+            [
+                self.value_tensor_product(
+                    source_features, spherical_harmonics, weights[:, head]
+                )
+                for head in range(self.heads)
+            ],
+            dim=1,
+        )
+        messages = attention.unsqueeze(-1) * values
+        aggregated = node_features.new_zeros((num_nodes, self.heads, self.irreps.dim))
+        aggregated.index_add_(0, target, messages)
+        result = self.output(aggregated.reshape(num_nodes, self.head_irreps.dim))
+
+        if return_attention_weights:
+            return result, attention
+        return result
+
+    def _radial_basis(self, distances: torch.Tensor) -> torch.Tensor:
+        normalized = distances / (1.0 + distances)
+        width = max(self.num_radial - 1, 1)
+        return torch.exp(
+            -(width**2) * (normalized.unsqueeze(-1) - self.radial_centers) ** 2
+        )
+
+    def _validate_inputs(
+        self,
+        node_features: torch.Tensor,
+        positions: torch.Tensor,
+        edge_index: torch.Tensor,
+    ) -> None:
+        num_nodes = node_features.shape[0] if node_features.ndim > 0 else 0
+        if node_features.ndim != 2 or node_features.shape[1] != self.irreps.dim:
+            raise ValueError(f"node_features must have shape [N, {self.irreps.dim}]")
+        if positions.shape != (num_nodes, 3):
+            raise ValueError(f"positions must have shape ({num_nodes}, 3)")
+        if edge_index.ndim != 2 or edge_index.shape[0] != 2:
+            raise ValueError("edge_index must have shape [2, E]")
+        if edge_index.dtype != torch.long:
+            raise TypeError("edge_index must have dtype torch.long")
+        if (
+            node_features.device != positions.device
+            or positions.device != edge_index.device
+        ):
+            raise ValueError("features, positions, and edge_index must share a device")
+        if node_features.dtype != positions.dtype:
+            raise ValueError("features and positions must have the same dtype")
+        if edge_index.numel() and (
+            torch.any(edge_index < 0) or torch.any(edge_index >= num_nodes)
+        ):
+            raise ValueError("edge_index contains an out-of-range node index")

--- a/hydragnn/globalAtt/equivariant_features.py
+++ b/hydragnn/globalAtt/equivariant_features.py
@@ -123,6 +123,7 @@ def create_local_feature_adapter(
     channels: int,
     *,
     allow_scalar_only: bool = False,
+    require_tensor_coupling: bool = True,
     local_equivariance: bool = False,
 ) -> ScalarVectorIrrepsAdapter | ScalarIrrepsAdapter:
     """Create an adapter while enforcing each local model's feature contract.
@@ -138,6 +139,11 @@ def create_local_feature_adapter(
     if mpnn_type not in {"SchNet", "DimeNet"}:
         raise ValueError(
             f"{mpnn_type} does not yet have an equivariant Transformer adapter"
+        )
+    if require_tensor_coupling:
+        raise ValueError(
+            f"{mpnn_type} cannot provide tensor-valued local/global coupling: "
+            "its latent node features are invariant scalars only"
         )
     if not allow_scalar_only:
         raise ValueError(

--- a/hydragnn/globalAtt/equivariant_features.py
+++ b/hydragnn/globalAtt/equivariant_features.py
@@ -9,8 +9,38 @@
 # SPDX-License-Identifier: BSD-3-Clause                                      #
 ##############################################################################
 
+import warnings
+
 import torch
 from e3nn import o3
+
+
+class ScalarIrrepsAdapter(torch.nn.Module):
+    """Expose invariant local-model features as an e3nn ``0e`` tensor.
+
+    This adapter is intended for SchNet and DimeNet.  It does not manufacture
+    vector or higher-order latent features: the associated Transformer is
+    therefore equivariant only in the scalar (rotation-invariant) sense.
+    """
+
+    def __init__(self, channels: int):
+        super().__init__()
+        _validate_channels(channels)
+        self.channels = channels
+        self.irreps = o3.Irreps(f"{channels}x0e")
+
+    def forward(self, inv_node_feat: torch.Tensor) -> torch.Tensor:
+        """Validate and expose HydraGNN invariant node features."""
+        if inv_node_feat.ndim != 2 or inv_node_feat.shape[1] != self.channels:
+            raise ValueError(
+                f"inv_node_feat must have shape [N, {self.channels}], "
+                f"but has shape {tuple(inv_node_feat.shape)}"
+            )
+        return inv_node_feat
+
+    def decode(self, features: torch.Tensor) -> torch.Tensor:
+        """Restore the scalar-only HydraGNN feature layout."""
+        return self(features)
 
 
 class ScalarVectorIrrepsAdapter(torch.nn.Module):
@@ -29,8 +59,7 @@ class ScalarVectorIrrepsAdapter(torch.nn.Module):
 
     def __init__(self, channels: int):
         super().__init__()
-        if not isinstance(channels, int) or isinstance(channels, bool) or channels <= 0:
-            raise ValueError("channels must be a positive integer")
+        _validate_channels(channels)
 
         self.channels = channels
         self.irreps = o3.Irreps(f"{channels}x0e + {channels}x1o")
@@ -87,3 +116,51 @@ class ScalarVectorIrrepsAdapter(torch.nn.Module):
             raise ValueError("scalar and vector features must be on the same device")
         if inv_node_feat.dtype != equiv_node_feat.dtype:
             raise ValueError("scalar and vector features must have the same dtype")
+
+
+def create_local_feature_adapter(
+    mpnn_type: str,
+    channels: int,
+    *,
+    allow_scalar_only: bool = False,
+    local_equivariance: bool = False,
+) -> ScalarVectorIrrepsAdapter | ScalarIrrepsAdapter:
+    """Create an adapter while enforcing each local model's feature contract.
+
+    SchNet and DimeNet require an explicit scalar-only opt-in because their
+    latent node features contain no vectors or higher-order tensors.  SchNet's
+    coordinate-update mode is rejected: coordinates are not translation-
+    invariant latent vector features and must never be passed through this
+    adapter.
+    """
+    if mpnn_type in {"PAINN", "PNAEq"}:
+        return ScalarVectorIrrepsAdapter(channels)
+    if mpnn_type not in {"SchNet", "DimeNet"}:
+        raise ValueError(
+            f"{mpnn_type} does not yet have an equivariant Transformer adapter"
+        )
+    if not allow_scalar_only:
+        raise ValueError(
+            f"{mpnn_type} has scalar-only latent features; set "
+            "equivariant_attn_allow_scalar_only=true to acknowledge that the "
+            "local and global branches will exchange invariant features only"
+        )
+    if mpnn_type == "SchNet" and local_equivariance:
+        raise ValueError(
+            "SchNet scalar-only integration cannot use coordinate updates; "
+            "set Architecture.equivariance=false"
+        )
+
+    warnings.warn(
+        f"{mpnn_type} uses scalar-only equivariant Transformer integration: "
+        "attention is rotation invariant and does not exchange tensor-valued "
+        "latent features with the local MPNN.",
+        UserWarning,
+        stacklevel=2,
+    )
+    return ScalarIrrepsAdapter(channels)
+
+
+def _validate_channels(channels: int) -> None:
+    if not isinstance(channels, int) or isinstance(channels, bool) or channels <= 0:
+        raise ValueError("channels must be a positive integer")

--- a/hydragnn/globalAtt/equivariant_features.py
+++ b/hydragnn/globalAtt/equivariant_features.py
@@ -1,0 +1,89 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import torch
+from e3nn import o3
+
+
+class ScalarVectorIrrepsAdapter(torch.nn.Module):
+    """Convert HydraGNN scalar/vector features to an e3nn representation.
+
+    PaiNN and PNAEq store ``channels`` invariant features as ``[N, C]`` and
+    the same number of Cartesian vector features as ``[N, 3, C]``.  e3nn
+    represents these features as a single ``C x 0e + C x 1o`` tensor with
+    shape ``[N, 4 * C]``.  This adapter defines the conversion at the boundary
+    of the equivariant global-attention implementation.
+
+    The vector features use odd parity (``1o``), as appropriate for polar
+    vectors.  Encoding and decoding only rearrange tensor entries; they do not
+    contain trainable parameters.
+    """
+
+    def __init__(self, channels: int):
+        super().__init__()
+        if not isinstance(channels, int) or isinstance(channels, bool) or channels <= 0:
+            raise ValueError("channels must be a positive integer")
+
+        self.channels = channels
+        self.irreps = o3.Irreps(f"{channels}x0e + {channels}x1o")
+
+    def forward(
+        self, inv_node_feat: torch.Tensor, equiv_node_feat: torch.Tensor
+    ) -> torch.Tensor:
+        """Encode scalar and vector features as one e3nn irrep tensor."""
+        self._validate_hydragnn_features(inv_node_feat, equiv_node_feat)
+        vectors = equiv_node_feat.transpose(1, 2).reshape(
+            inv_node_feat.shape[0], 3 * self.channels
+        )
+        return torch.cat((inv_node_feat, vectors), dim=-1)
+
+    def decode(self, features: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Decode an e3nn irrep tensor into HydraGNN scalar/vector layouts."""
+        if features.ndim != 2:
+            raise ValueError(
+                f"features must have shape [N, {self.irreps.dim}], "
+                f"but has shape {tuple(features.shape)}"
+            )
+        if features.shape[1] != self.irreps.dim:
+            raise ValueError(
+                f"features must have {self.irreps.dim} entries per node, "
+                f"but has {features.shape[1]}"
+            )
+
+        scalars = features[:, : self.channels]
+        vectors = features[:, self.channels :].reshape(
+            features.shape[0], self.channels, 3
+        )
+        return scalars, vectors.transpose(1, 2).contiguous()
+
+    def _validate_hydragnn_features(
+        self, inv_node_feat: torch.Tensor, equiv_node_feat: torch.Tensor
+    ) -> None:
+        if inv_node_feat.ndim != 2 or inv_node_feat.shape[1] != self.channels:
+            raise ValueError(
+                f"inv_node_feat must have shape [N, {self.channels}], "
+                f"but has shape {tuple(inv_node_feat.shape)}"
+            )
+        expected_vector_shape = (
+            inv_node_feat.shape[0],
+            3,
+            self.channels,
+        )
+        if tuple(equiv_node_feat.shape) != expected_vector_shape:
+            raise ValueError(
+                "equiv_node_feat must have shape "
+                f"{expected_vector_shape}, but has shape "
+                f"{tuple(equiv_node_feat.shape)}"
+            )
+        if inv_node_feat.device != equiv_node_feat.device:
+            raise ValueError("scalar and vector features must be on the same device")
+        if inv_node_feat.dtype != equiv_node_feat.dtype:
+            raise ValueError("scalar and vector features must have the same dtype")

--- a/hydragnn/globalAtt/equivariant_features.py
+++ b/hydragnn/globalAtt/equivariant_features.py
@@ -81,6 +81,31 @@ class IrrepsFeatureAdapter(torch.nn.Module):
             raise ValueError(f"features must have shape [N, {self.irreps.dim}]")
         return features[:, : self.scalar_dim], features[:, self.scalar_dim :]
 
+    def encode_parallel_input(
+        self, inv_node_feat: torch.Tensor, equiv_node_feat: torch.Tensor
+    ) -> torch.Tensor:
+        """Embed a MACE layer input in the layer's output representation.
+
+        MACE's first hidden layer promotes scalar input features to a
+        scalar-plus-tensor representation. Zero is the unique canonical value
+        for tensor channels that are absent at that boundary and remains zero
+        under every rotation. Other representation mismatches remain errors.
+        """
+        tensor_dim = self.irreps.dim - self.scalar_dim
+        if equiv_node_feat.shape == (inv_node_feat.shape[0], tensor_dim):
+            return self(inv_node_feat, equiv_node_feat)
+        if equiv_node_feat.shape == (inv_node_feat.shape[0], 0):
+            if inv_node_feat.ndim != 2 or inv_node_feat.shape[1] != self.scalar_dim:
+                raise ValueError(
+                    f"inv_node_feat must have shape [N, {self.scalar_dim}]"
+                )
+            zeros = inv_node_feat.new_zeros(inv_node_feat.shape[0], tensor_dim)
+            return torch.cat((inv_node_feat, zeros), dim=-1)
+        raise ValueError(
+            "MACE parallel coupling requires input tensor features to either "
+            f"match [N, {tensor_dim}] or be absent with shape [N, 0]"
+        )
+
 
 class ScalarVectorIrrepsAdapter(torch.nn.Module):
     """Convert HydraGNN scalar/vector features to an e3nn representation.

--- a/hydragnn/globalAtt/equivariant_features.py
+++ b/hydragnn/globalAtt/equivariant_features.py
@@ -43,6 +43,45 @@ class ScalarIrrepsAdapter(torch.nn.Module):
         return self(features)
 
 
+class IrrepsFeatureAdapter(torch.nn.Module):
+    """Join HydraGNN's split MACE layout using its declared e3nn irreps."""
+
+    def __init__(self, irreps: o3.Irreps | str):
+        super().__init__()
+        self.irreps = o3.Irreps(irreps)
+        if self.irreps.dim == 0:
+            raise ValueError("irreps must not be empty")
+        self.scalar_dim = self.irreps.count(o3.Irrep("0e"))
+        scalar_prefix_dim = 0
+        for multiplicity, irrep in self.irreps:
+            if irrep != o3.Irrep("0e"):
+                break
+            scalar_prefix_dim += multiplicity * irrep.dim
+        if scalar_prefix_dim != self.scalar_dim:
+            raise ValueError(
+                "MACE adapter requires all 0e scalar irreps to precede tensor irreps"
+            )
+
+    def forward(
+        self, inv_node_feat: torch.Tensor, equiv_node_feat: torch.Tensor
+    ) -> torch.Tensor:
+        if inv_node_feat.ndim != 2 or inv_node_feat.shape[1] != self.scalar_dim:
+            raise ValueError(f"inv_node_feat must have shape [N, {self.scalar_dim}]")
+        tensor_dim = self.irreps.dim - self.scalar_dim
+        if equiv_node_feat.shape != (inv_node_feat.shape[0], tensor_dim):
+            raise ValueError(f"equiv_node_feat must have shape [N, {tensor_dim}]")
+        if inv_node_feat.device != equiv_node_feat.device:
+            raise ValueError("scalar and tensor features must be on the same device")
+        if inv_node_feat.dtype != equiv_node_feat.dtype:
+            raise ValueError("scalar and tensor features must have the same dtype")
+        return torch.cat((inv_node_feat, equiv_node_feat), dim=-1)
+
+    def decode(self, features: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        if features.ndim != 2 or features.shape[1] != self.irreps.dim:
+            raise ValueError(f"features must have shape [N, {self.irreps.dim}]")
+        return features[:, : self.scalar_dim], features[:, self.scalar_dim :]
+
+
 class ScalarVectorIrrepsAdapter(torch.nn.Module):
     """Convert HydraGNN scalar/vector features to an e3nn representation.
 

--- a/hydragnn/globalAtt/equivariant_local_global.py
+++ b/hydragnn/globalAtt/equivariant_local_global.py
@@ -14,6 +14,7 @@ from typing import Any
 import torch
 
 from hydragnn.globalAtt.equivariant_features import (
+    IrrepsFeatureAdapter,
     ScalarVectorIrrepsAdapter,
     create_local_feature_adapter,
 )
@@ -36,16 +37,22 @@ class EquivariantLocalGlobalConv(torch.nn.Module):
         require_tensor_coupling: bool,
         local_equivariance: bool,
         chunk_size: int | None,
+        irreps: str | None = None,
     ):
         super().__init__()
         self.conv = conv
-        self.adapter = create_local_feature_adapter(
-            mpnn_type,
-            channels,
-            allow_scalar_only=allow_scalar_only,
-            require_tensor_coupling=require_tensor_coupling,
-            local_equivariance=local_equivariance,
-        )
+        if mpnn_type == "MACE":
+            if irreps is None:
+                raise ValueError("MACE integration requires explicit output irreps")
+            self.adapter = IrrepsFeatureAdapter(irreps)
+        else:
+            self.adapter = create_local_feature_adapter(
+                mpnn_type,
+                channels,
+                allow_scalar_only=allow_scalar_only,
+                require_tensor_coupling=require_tensor_coupling,
+                local_equivariance=local_equivariance,
+            )
         self.global_layer = EquivariantTransformerLayer(
             self.adapter.irreps,
             heads=heads,
@@ -75,7 +82,7 @@ class EquivariantLocalGlobalConv(torch.nn.Module):
             equiv_node_feat=equiv_node_feat,
             **kwargs,
         )
-        if isinstance(self.adapter, ScalarVectorIrrepsAdapter):
+        if isinstance(self.adapter, (ScalarVectorIrrepsAdapter, IrrepsFeatureAdapter)):
             features = self.adapter(inv_node_feat, equiv_node_feat)
             features = self.global_layer(features, positions, graph_batch)
             return self.adapter.decode(features)

--- a/hydragnn/globalAtt/equivariant_local_global.py
+++ b/hydragnn/globalAtt/equivariant_local_global.py
@@ -1,0 +1,83 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+from typing import Any
+
+import torch
+
+from hydragnn.globalAtt.equivariant_features import (
+    ScalarVectorIrrepsAdapter,
+    create_local_feature_adapter,
+)
+from hydragnn.globalAtt.equivariant_transformer import EquivariantTransformerLayer
+
+
+class EquivariantLocalGlobalConv(torch.nn.Module):
+    """Apply a local MPNN update followed by equivariant global attention."""
+
+    def __init__(
+        self,
+        channels: int,
+        conv: torch.nn.Module,
+        mpnn_type: str,
+        heads: int,
+        lmax: int,
+        num_radial: int,
+        feedforward_multiplier: int,
+        allow_scalar_only: bool,
+        require_tensor_coupling: bool,
+        local_equivariance: bool,
+    ):
+        super().__init__()
+        self.conv = conv
+        self.adapter = create_local_feature_adapter(
+            mpnn_type,
+            channels,
+            allow_scalar_only=allow_scalar_only,
+            require_tensor_coupling=require_tensor_coupling,
+            local_equivariance=local_equivariance,
+        )
+        self.global_layer = EquivariantTransformerLayer(
+            self.adapter.irreps,
+            heads=heads,
+            lmax=lmax,
+            num_radial=num_radial,
+            feedforward_multiplier=feedforward_multiplier,
+            require_tensor_coupling=require_tensor_coupling,
+        )
+
+    def forward(
+        self,
+        inv_node_feat: torch.Tensor,
+        equiv_node_feat: torch.Tensor,
+        positions: torch.Tensor | None = None,
+        graph_batch: torch.Tensor | None = None,
+        **kwargs: Any,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Run local and global updates without passing global data locally."""
+        if positions is None:
+            raise ValueError("EquivariantTransformer requires node positions")
+        if graph_batch is None:
+            raise ValueError("EquivariantTransformer requires a graph batch tensor")
+
+        inv_node_feat, equiv_node_feat = self.conv(
+            inv_node_feat=inv_node_feat,
+            equiv_node_feat=equiv_node_feat,
+            **kwargs,
+        )
+        if isinstance(self.adapter, ScalarVectorIrrepsAdapter):
+            features = self.adapter(inv_node_feat, equiv_node_feat)
+            features = self.global_layer(features, positions, graph_batch)
+            return self.adapter.decode(features)
+
+        features = self.adapter(inv_node_feat)
+        features = self.global_layer(features, positions, graph_batch)
+        return self.adapter.decode(features), equiv_node_feat

--- a/hydragnn/globalAtt/equivariant_local_global.py
+++ b/hydragnn/globalAtt/equivariant_local_global.py
@@ -22,7 +22,13 @@ from hydragnn.globalAtt.equivariant_transformer import EquivariantTransformerLay
 
 
 class EquivariantLocalGlobalConv(torch.nn.Module):
-    """Apply a local MPNN update followed by equivariant global attention."""
+    """Combine local message passing with equivariant global attention.
+
+    ``parallel`` (the default) applies the local and global branches to the
+    same input and adds their outputs in the shared irrep representation,
+    matching the local/global organization of GraphGPS. ``sequential`` keeps
+    the original local-then-global composition for controlled experiments.
+    """
 
     def __init__(
         self,
@@ -37,9 +43,13 @@ class EquivariantLocalGlobalConv(torch.nn.Module):
         require_tensor_coupling: bool,
         local_equivariance: bool,
         chunk_size: int | None,
+        coupling_mode: str = "parallel",
         irreps: str | None = None,
     ):
         super().__init__()
+        if coupling_mode not in {"parallel", "sequential"}:
+            raise ValueError("coupling_mode must be 'parallel' or 'sequential'")
+        self.coupling_mode = coupling_mode
         self.conv = conv
         if mpnn_type == "MACE":
             if irreps is None:
@@ -77,16 +87,42 @@ class EquivariantLocalGlobalConv(torch.nn.Module):
         if graph_batch is None:
             raise ValueError("EquivariantTransformer requires a graph batch tensor")
 
-        inv_node_feat, equiv_node_feat = self.conv(
+        input_inv_node_feat = inv_node_feat
+        input_equiv_node_feat = equiv_node_feat
+        local_inv_node_feat, local_equiv_node_feat = self.conv(
             inv_node_feat=inv_node_feat,
             equiv_node_feat=equiv_node_feat,
             **kwargs,
         )
         if isinstance(self.adapter, (ScalarVectorIrrepsAdapter, IrrepsFeatureAdapter)):
-            features = self.adapter(inv_node_feat, equiv_node_feat)
-            features = self.global_layer(features, positions, graph_batch)
+            local_features = self.adapter(local_inv_node_feat, local_equiv_node_feat)
+            if self.coupling_mode == "parallel":
+                if isinstance(self.adapter, IrrepsFeatureAdapter):
+                    global_input = self.adapter.encode_parallel_input(
+                        input_inv_node_feat, input_equiv_node_feat
+                    )
+                else:
+                    global_input = self.adapter(
+                        input_inv_node_feat, input_equiv_node_feat
+                    )
+                global_features = self.global_layer.forward_attention(
+                    global_input, positions, graph_batch
+                )
+                features = self.global_layer.forward_feedforward(
+                    local_features + global_features
+                )
+            else:
+                features = self.global_layer(local_features, positions, graph_batch)
             return self.adapter.decode(features)
 
-        features = self.adapter(inv_node_feat)
-        features = self.global_layer(features, positions, graph_batch)
-        return self.adapter.decode(features), equiv_node_feat
+        local_features = self.adapter(local_inv_node_feat)
+        if self.coupling_mode == "parallel":
+            global_features = self.global_layer.forward_attention(
+                self.adapter(input_inv_node_feat), positions, graph_batch
+            )
+            features = self.global_layer.forward_feedforward(
+                local_features + global_features
+            )
+        else:
+            features = self.global_layer(local_features, positions, graph_batch)
+        return self.adapter.decode(features), local_equiv_node_feat

--- a/hydragnn/globalAtt/equivariant_local_global.py
+++ b/hydragnn/globalAtt/equivariant_local_global.py
@@ -35,6 +35,7 @@ class EquivariantLocalGlobalConv(torch.nn.Module):
         allow_scalar_only: bool,
         require_tensor_coupling: bool,
         local_equivariance: bool,
+        chunk_size: int | None,
     ):
         super().__init__()
         self.conv = conv
@@ -52,6 +53,7 @@ class EquivariantLocalGlobalConv(torch.nn.Module):
             num_radial=num_radial,
             feedforward_multiplier=feedforward_multiplier,
             require_tensor_coupling=require_tensor_coupling,
+            chunk_size=chunk_size,
         )
 
     def forward(

--- a/hydragnn/globalAtt/equivariant_transformer.py
+++ b/hydragnn/globalAtt/equivariant_transformer.py
@@ -1,0 +1,135 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import torch
+from e3nn import nn, o3
+
+from hydragnn.globalAtt.complete_graph import complete_graph_edge_index
+from hydragnn.globalAtt.equivariant_attention import EquivariantAllToAllAttention
+
+
+class EquivariantRMSNorm(torch.nn.Module):
+    """Normalize each node by an invariant RMS with a shared scalar gain.
+
+    A conventional LayerNorm would independently normalize Cartesian tensor
+    components and would therefore break rotation equivariance.  The squared
+    norm of a complete irrep representation is invariant, so using it as one
+    scale per node preserves every declared irrep.
+    """
+
+    def __init__(self, irreps: o3.Irreps | str, epsilon: float = 1.0e-8):
+        super().__init__()
+        self.irreps = o3.Irreps(irreps)
+        if self.irreps.dim == 0:
+            raise ValueError("irreps must not be empty")
+        if epsilon <= 0.0:
+            raise ValueError("epsilon must be positive")
+        self.epsilon = epsilon
+        self.gain = torch.nn.Parameter(torch.ones(()))
+
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        if features.ndim != 2 or features.shape[1] != self.irreps.dim:
+            raise ValueError(f"features must have shape [N, {self.irreps.dim}]")
+        inverse_rms = torch.rsqrt(
+            features.square().mean(dim=-1, keepdim=True) + self.epsilon
+        )
+        return self.gain * features * inverse_rms
+
+
+class EquivariantTransformerLayer(torch.nn.Module):
+    """Equivariant all-to-all attention and feed-forward residual block.
+
+    The layer uses pre-normalization around both sublayers.  Its feed-forward
+    nonlinearity acts on invariant irrep norms and rescales complete irrep
+    blocks, rather than applying an elementwise activation to tensor
+    components.  Consequently, attention, normalization, feed-forward paths,
+    and residual additions all preserve the configured representation.
+    """
+
+    def __init__(
+        self,
+        irreps: o3.Irreps | str,
+        heads: int = 1,
+        lmax: int = 1,
+        num_radial: int = 16,
+        feedforward_multiplier: int = 2,
+    ):
+        super().__init__()
+        self.irreps = o3.Irreps(irreps)
+        if (
+            not isinstance(feedforward_multiplier, int)
+            or isinstance(feedforward_multiplier, bool)
+            or feedforward_multiplier <= 0
+        ):
+            raise ValueError("feedforward_multiplier must be a positive integer")
+
+        hidden_irreps = o3.Irreps(
+            [
+                (multiplicity * feedforward_multiplier, irrep)
+                for multiplicity, irrep in self.irreps
+            ]
+        )
+        self.attention_norm = EquivariantRMSNorm(self.irreps)
+        self.attention = EquivariantAllToAllAttention(
+            self.irreps,
+            heads=heads,
+            lmax=lmax,
+            num_radial=num_radial,
+        )
+        self.feedforward_norm = EquivariantRMSNorm(self.irreps)
+        self.feedforward = torch.nn.Sequential(
+            o3.Linear(self.irreps, hidden_irreps, biases=False),
+            nn.NormActivation(
+                hidden_irreps,
+                scalar_nonlinearity=torch.nn.functional.silu,
+                normalize=True,
+                epsilon=1.0e-8,
+                bias=False,
+            ),
+            o3.Linear(hidden_irreps, self.irreps, biases=False),
+        )
+
+    def forward(
+        self,
+        node_features: torch.Tensor,
+        positions: torch.Tensor,
+        batch: torch.Tensor,
+        edge_index: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Update node features using pairs within each graph in ``batch``."""
+        if batch.ndim != 1 or batch.shape[0] != node_features.shape[0]:
+            raise ValueError("batch must contain one graph identifier per node")
+        if batch.dtype != torch.long:
+            raise TypeError("batch must have dtype torch.long")
+        if batch.device != node_features.device:
+            raise ValueError("batch and node features must share a device")
+        if edge_index is None:
+            edge_index = complete_graph_edge_index(batch)
+        elif edge_index.ndim == 2 and edge_index.shape[0] == 2:
+            if edge_index.dtype != torch.long:
+                raise TypeError("edge_index must have dtype torch.long")
+            if edge_index.device != batch.device:
+                raise ValueError("edge_index and batch must share a device")
+            if edge_index.numel() and (
+                torch.any(edge_index < 0)
+                or torch.any(edge_index >= node_features.shape[0])
+            ):
+                raise ValueError("edge_index contains an out-of-range node index")
+            source, target = edge_index
+            if edge_index.numel() and torch.any(source == target):
+                raise ValueError("edge_index must not contain self-pairs")
+            if edge_index.numel() and torch.any(batch[source] != batch[target]):
+                raise ValueError("edge_index must not contain cross-graph pairs")
+
+        node_features = node_features + self.attention(
+            self.attention_norm(node_features), positions, edge_index
+        )
+        return node_features + self.feedforward(self.feedforward_norm(node_features))

--- a/hydragnn/globalAtt/equivariant_transformer.py
+++ b/hydragnn/globalAtt/equivariant_transformer.py
@@ -121,6 +121,19 @@ class EquivariantTransformerLayer(torch.nn.Module):
         edge_index: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Update node features using pairs within each graph in ``batch``."""
+        node_features = self.forward_attention(
+            node_features, positions, batch, edge_index=edge_index
+        )
+        return self.forward_feedforward(node_features)
+
+    def forward_attention(
+        self,
+        node_features: torch.Tensor,
+        positions: torch.Tensor,
+        batch: torch.Tensor,
+        edge_index: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Apply the normalized attention residual sublayer."""
         if batch.ndim != 1 or batch.shape[0] != node_features.shape[0]:
             raise ValueError("batch must contain one graph identifier per node")
         if batch.dtype != torch.long:
@@ -153,5 +166,8 @@ class EquivariantTransformerLayer(torch.nn.Module):
             )
         else:
             attention_output = self.attention(normalized, positions, edge_index)
-        node_features = node_features + attention_output
+        return node_features + attention_output
+
+    def forward_feedforward(self, node_features: torch.Tensor) -> torch.Tensor:
+        """Apply the normalized equivariant feed-forward residual sublayer."""
         return node_features + self.feedforward(self.feedforward_norm(node_features))

--- a/hydragnn/globalAtt/equivariant_transformer.py
+++ b/hydragnn/globalAtt/equivariant_transformer.py
@@ -62,6 +62,7 @@ class EquivariantTransformerLayer(torch.nn.Module):
         num_radial: int = 16,
         feedforward_multiplier: int = 2,
         require_tensor_coupling: bool = True,
+        chunk_size: int | None = None,
     ):
         super().__init__()
         self.irreps = o3.Irreps(irreps)
@@ -78,6 +79,13 @@ class EquivariantTransformerLayer(torch.nn.Module):
             or feedforward_multiplier <= 0
         ):
             raise ValueError("feedforward_multiplier must be a positive integer")
+        if chunk_size is not None and (
+            not isinstance(chunk_size, int)
+            or isinstance(chunk_size, bool)
+            or chunk_size <= 0
+        ):
+            raise ValueError("chunk_size must be a positive integer or None")
+        self.chunk_size = chunk_size
 
         hidden_irreps = o3.Irreps(
             [
@@ -120,7 +128,8 @@ class EquivariantTransformerLayer(torch.nn.Module):
         if batch.device != node_features.device:
             raise ValueError("batch and node features must share a device")
         if edge_index is None:
-            edge_index = complete_graph_edge_index(batch)
+            if self.chunk_size is None:
+                edge_index = complete_graph_edge_index(batch)
         elif edge_index.ndim == 2 and edge_index.shape[0] == 2:
             if edge_index.dtype != torch.long:
                 raise TypeError("edge_index must have dtype torch.long")
@@ -137,7 +146,12 @@ class EquivariantTransformerLayer(torch.nn.Module):
             if edge_index.numel() and torch.any(batch[source] != batch[target]):
                 raise ValueError("edge_index must not contain cross-graph pairs")
 
-        node_features = node_features + self.attention(
-            self.attention_norm(node_features), positions, edge_index
-        )
+        normalized = self.attention_norm(node_features)
+        if edge_index is None:
+            attention_output = self.attention.forward_chunked(
+                normalized, positions, batch, self.chunk_size
+            )
+        else:
+            attention_output = self.attention(normalized, positions, edge_index)
+        node_features = node_features + attention_output
         return node_features + self.feedforward(self.feedforward_norm(node_features))

--- a/hydragnn/globalAtt/equivariant_transformer.py
+++ b/hydragnn/globalAtt/equivariant_transformer.py
@@ -61,9 +61,17 @@ class EquivariantTransformerLayer(torch.nn.Module):
         lmax: int = 1,
         num_radial: int = 16,
         feedforward_multiplier: int = 2,
+        require_tensor_coupling: bool = True,
     ):
         super().__init__()
         self.irreps = o3.Irreps(irreps)
+        has_tensor_features = any(irrep.l > 0 for _, irrep in self.irreps)
+        if require_tensor_coupling and not has_tensor_features:
+            raise ValueError(
+                "tensor-valued local/global coupling requires at least one "
+                "non-scalar input irrep; use require_tensor_coupling=False "
+                "only for the acknowledged SchNet/DimeNet scalar-only mode"
+            )
         if (
             not isinstance(feedforward_multiplier, int)
             or isinstance(feedforward_multiplier, bool)

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -68,6 +68,7 @@ class Base(Module):
         equivariant_attn_allow_scalar_only: bool = False,
         equivariant_attn_require_tensor_coupling: bool = True,
         equivariant_attn_chunk_size: int | None = 512,
+        equivariant_attn_coupling_mode: str = "parallel",
     ):
         super().__init__()
         self.device = get_device()
@@ -91,6 +92,7 @@ class Base(Module):
             equivariant_attn_require_tensor_coupling
         )
         self.equivariant_attn_chunk_size = equivariant_attn_chunk_size
+        self.equivariant_attn_coupling_mode = equivariant_attn_coupling_mode
         self.num_conv_layers = num_conv_layers
         self.graph_convs = ModuleList()
         self.feature_layers = ModuleList()
@@ -293,6 +295,7 @@ class Base(Module):
                     ),
                     local_equivariance=self.equivariance,
                     chunk_size=self.equivariant_attn_chunk_size,
+                    coupling_mode=self.equivariant_attn_coupling_mode,
                     irreps=irreps,
                 )
             raise ValueError(

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -67,6 +67,7 @@ class Base(Module):
         equivariant_attn_feedforward_multiplier: int = 2,
         equivariant_attn_allow_scalar_only: bool = False,
         equivariant_attn_require_tensor_coupling: bool = True,
+        equivariant_attn_chunk_size: int | None = 512,
     ):
         super().__init__()
         self.device = get_device()
@@ -89,6 +90,7 @@ class Base(Module):
         self.equivariant_attn_require_tensor_coupling = (
             equivariant_attn_require_tensor_coupling
         )
+        self.equivariant_attn_chunk_size = equivariant_attn_chunk_size
         self.num_conv_layers = num_conv_layers
         self.graph_convs = ModuleList()
         self.feature_layers = ModuleList()
@@ -290,6 +292,7 @@ class Base(Module):
                         self.equivariant_attn_require_tensor_coupling
                     ),
                     local_equivariance=self.equivariance,
+                    chunk_size=self.equivariant_attn_chunk_size,
                 )
             raise ValueError(
                 f"Unknown global attention engine: {self.global_attn_engine}"

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -259,7 +259,7 @@ class Base(Module):
 
         self.conv_checkpointing = False
 
-    def _apply_global_attn(self, mpnn):
+    def _apply_global_attn(self, mpnn, irreps=None):
         # choose to use global attention or mpnn
         if self.use_global_attn:
             # specify global attention engine; use this to support more engines in future
@@ -293,6 +293,7 @@ class Base(Module):
                     ),
                     local_equivariance=self.equivariance,
                     chunk_size=self.equivariant_attn_chunk_size,
+                    irreps=irreps,
                 )
             raise ValueError(
                 f"Unknown global attention engine: {self.global_attn_engine}"

--- a/hydragnn/models/Base.py
+++ b/hydragnn/models/Base.py
@@ -28,6 +28,7 @@ from hydragnn.utils.distributed import get_device
 from hydragnn.utils.print.print_utils import print_master
 from hydragnn.utils.model.operations import get_edge_vectors_and_lengths
 from hydragnn.globalAtt.gps import HydraGPSConv
+from hydragnn.globalAtt.equivariant_local_global import EquivariantLocalGlobalConv
 import hydragnn.utils.profiling_and_tracing.tracer as tr
 
 import inspect
@@ -61,6 +62,11 @@ class Base(Module):
         graph_pooling: str = "mean",
         use_graph_attr_conditioning: bool = False,
         graph_attr_conditioning_mode: str = "concat_node",
+        equivariant_attn_lmax: int = 1,
+        equivariant_attn_num_radial: int = 16,
+        equivariant_attn_feedforward_multiplier: int = 2,
+        equivariant_attn_allow_scalar_only: bool = False,
+        equivariant_attn_require_tensor_coupling: bool = True,
     ):
         super().__init__()
         self.device = get_device()
@@ -74,6 +80,15 @@ class Base(Module):
         self.hidden_dim = hidden_dim
         self.dropout = dropout
         self.global_attn_dropout = dropout
+        self.equivariant_attn_lmax = equivariant_attn_lmax
+        self.equivariant_attn_num_radial = equivariant_attn_num_radial
+        self.equivariant_attn_feedforward_multiplier = (
+            equivariant_attn_feedforward_multiplier
+        )
+        self.equivariant_attn_allow_scalar_only = equivariant_attn_allow_scalar_only
+        self.equivariant_attn_require_tensor_coupling = (
+            equivariant_attn_require_tensor_coupling
+        )
         self.num_conv_layers = num_conv_layers
         self.graph_convs = ModuleList()
         self.feature_layers = ModuleList()
@@ -178,10 +193,17 @@ class Base(Module):
         # if model can handle edge features, enforce use of relative edge encodings
         if self.global_attn_engine:
             self.use_global_attn = True
-            self.embed_dim = self.edge_embed_dim = (
-                hidden_dim  # ensure that all input to gps have the same dimensionality
+            self.embed_dim = hidden_dim
+            self.edge_embed_dim = (
+                hidden_dim
+                if self.global_attn_engine == "GPS"
+                else (
+                    self.edge_dim
+                    if hasattr(self, "edge_dim") and self.edge_dim is not None
+                    else None
+                )
             )
-            if self.is_edge_model:
+            if self.is_edge_model and self.global_attn_engine == "GPS":
                 if "edge_attr" not in self.input_args:
                     self.input_args += ", edge_attr"
                 if "edge_attr" not in self.conv_args:
@@ -202,11 +224,15 @@ class Base(Module):
 
         # Specify learnable embeddings
         if self.use_global_attn or self.use_encodings:
-            self.pos_emb = Linear(self.pe_dim, self.hidden_dim, bias=False)
+            if self.global_attn_engine == "GPS":
+                self.pos_emb = Linear(self.pe_dim, self.hidden_dim, bias=False)
             if self.input_dim:
                 self.node_emb = Linear(self.input_dim, self.hidden_dim, bias=False)
-                self.node_lin = Linear(2 * self.hidden_dim, self.hidden_dim, bias=False)
-            if self.is_edge_model:
+                if self.global_attn_engine == "GPS":
+                    self.node_lin = Linear(
+                        2 * self.hidden_dim, self.hidden_dim, bias=False
+                    )
+            if self.is_edge_model and self.global_attn_engine == "GPS":
                 self.rel_pos_emb = Linear(self.pe_dim, self.hidden_dim, bias=False)
                 if self.use_edge_attr:
                     self.edge_emb = Linear(self.edge_dim, self.hidden_dim, bias=False)
@@ -243,6 +269,31 @@ class Base(Module):
                     dropout=self.global_attn_dropout,
                     attn_type=self.global_attn_type,
                 )
+            if self.global_attn_engine == "EquivariantTransformer":
+                if not hasattr(self, "equivariant_attn_adapter_type"):
+                    raise ValueError(
+                        f"{self.__class__.__name__} does not yet support "
+                        "EquivariantTransformer"
+                    )
+                return EquivariantLocalGlobalConv(
+                    channels=self.hidden_dim,
+                    conv=mpnn,
+                    mpnn_type=self.equivariant_attn_adapter_type,
+                    heads=self.global_attn_heads,
+                    lmax=self.equivariant_attn_lmax,
+                    num_radial=self.equivariant_attn_num_radial,
+                    feedforward_multiplier=(
+                        self.equivariant_attn_feedforward_multiplier
+                    ),
+                    allow_scalar_only=self.equivariant_attn_allow_scalar_only,
+                    require_tensor_coupling=(
+                        self.equivariant_attn_require_tensor_coupling
+                    ),
+                    local_equivariance=self.equivariance,
+                )
+            raise ValueError(
+                f"Unknown global attention engine: {self.global_attn_engine}"
+            )
         else:
             return mpnn
 
@@ -475,6 +526,12 @@ class Base(Module):
             conv_args.update({"edge_attr": data.edge_attr})
 
         if self.use_global_attn:
+            if self.global_attn_engine == "EquivariantTransformer":
+                if not self.input_dim:
+                    raise ValueError(
+                        "EquivariantTransformer requires invariant node features"
+                    )
+                return self.node_emb(data.x.float()), data.pos, conv_args
             # encode node positional embeddings
             x = self.pos_emb(data.pe)
             # if node features are available, generate mebeddings, concatenate with positional embeddings and map to hidden dim

--- a/hydragnn/models/DIMEStack.py
+++ b/hydragnn/models/DIMEStack.py
@@ -55,6 +55,7 @@ class DIMEStack(Base):
         max_neighbours: Optional[int] = None,
         **kwargs
     ):
+        self.equivariant_attn_adapter_type = "DimeNet"
         self.basis_emb_size = basis_emb_size
         self.int_emb_size = int_emb_size
         self.out_emb_size = out_emb_size
@@ -126,7 +127,7 @@ class DIMEStack(Base):
         )
 
         if self.use_edge_attr or (
-            self.use_global_attn and self.is_edge_model
+            self.global_attn_engine == "GPS" and self.is_edge_model
         ):  # check if gps is being used and mpnn can handle edge feats
             return Sequential(
                 self.input_args,
@@ -199,6 +200,24 @@ class DIMEStack(Base):
             "num_nodes": data.x.size(0),
         }
 
+        if self.global_attn_engine == "EquivariantTransformer":
+            if torch.any(data.edge_shifts != 0):
+                raise ValueError(
+                    "EquivariantTransformer does not yet support periodic images"
+                )
+            conv_args.update(
+                {
+                    "positions": data.pos,
+                    "graph_batch": (
+                        data.batch
+                        if data.batch is not None
+                        else torch.zeros(
+                            data.pos.shape[0], dtype=torch.long, device=data.pos.device
+                        )
+                    ),
+                }
+            )
+
         if self.use_edge_attr:
             assert (
                 data.edge_attr is not None
@@ -206,11 +225,19 @@ class DIMEStack(Base):
             conv_args.update({"edge_attr": data.edge_attr})
 
         if self.use_global_attn:
-            x = self.pos_emb(data.pe)
-            if self.input_dim:
-                x = torch.cat((self.node_emb(data.x.float()), x), 1)
-                x = self.node_lin(x)
-            if self.is_edge_model:
+            if self.global_attn_engine == "EquivariantTransformer":
+                if not self.input_dim:
+                    raise ValueError(
+                        "EquivariantTransformer requires invariant node features"
+                    )
+                x = self.node_emb(data.x.float())
+            else:
+                x = self.pos_emb(data.pe)
+                if self.input_dim:
+                    x = torch.cat((self.node_emb(data.x.float()), x), 1)
+                    x = self.node_lin(x)
+
+            if self.is_edge_model and self.global_attn_engine == "GPS":
                 e = self.rel_pos_emb(data.rel_pe)
                 if self.use_edge_attr:
                     e = torch.cat((self.edge_emb(conv_args["edge_attr"]), e), 1)

--- a/hydragnn/models/MACEStack.py
+++ b/hydragnn/models/MACEStack.py
@@ -113,6 +113,7 @@ class MACEStack(Base):
         ## Passed
         self.max_ell = max_ell
         self.node_max_ell = node_max_ell
+        self.equivariant_attn_adapter_type = "MACE"
         num_interactions = kwargs["num_conv_layers"]
         self.edge_dim = edge_dim
         self.avg_num_neighbors = avg_num_neighbors
@@ -227,15 +228,16 @@ class MACEStack(Base):
         )
 
         # First Conv and Decoder
+        first_conv = self.get_conv(
+            self.hidden_dim,
+            self.hidden_dim,
+            first_layer=True,
+            last_layer=last_layer,
+        )  # Node features are already converted to hidden_dim via one-hot embedding
         self.graph_convs.append(
-            self._apply_global_attn(
-                self.get_conv(
-                    self.hidden_dim,
-                    self.hidden_dim,
-                    first_layer=True,
-                    last_layer=last_layer,
-                )  # Node features are already converted to hidden_dim via one-hot embedding
-            )
+            first_conv
+            if last_layer and self.global_attn_engine == "EquivariantTransformer"
+            else self._apply_global_attn(first_conv, irreps=str(hidden_irreps))
         )
         irreps = hidden_irreps if not last_layer else final_hidden_irreps
         self.multihead_decoders.append(
@@ -255,12 +257,13 @@ class MACEStack(Base):
         # Variable number of convolutions and decoders
         for i in range(self.num_conv_layers - 1):
             last_layer = i == self.num_conv_layers - 2
+            conv = self.get_conv(
+                self.hidden_dim, self.hidden_dim, last_layer=last_layer
+            )
             self.graph_convs.append(
-                self._apply_global_attn(
-                    self.get_conv(
-                        self.hidden_dim, self.hidden_dim, last_layer=last_layer
-                    )
-                )
+                conv
+                if last_layer and self.global_attn_engine == "EquivariantTransformer"
+                else self._apply_global_attn(conv, irreps=str(hidden_irreps))
             )
             irreps = hidden_irreps if not last_layer else final_hidden_irreps
             self.multihead_decoders.append(
@@ -431,6 +434,13 @@ class MACEStack(Base):
             data.pos is not None
         ), "MACE requires node positions (data.pos) to be set."
 
+        if self.global_attn_engine == "EquivariantTransformer" and torch.any(
+            data.edge_shifts != 0
+        ):
+            raise ValueError(
+                "EquivariantTransformer does not yet support periodic images"
+            )
+
         # Center positions at 0 per graph. This is a requirement for equivariant models that
         # initialize the spherical harmonics, since the initial spherical harmonic projection
         # uses the nodal position vector  x/||x|| as the input to the spherical harmonics.
@@ -475,14 +485,33 @@ class MACEStack(Base):
             "edge_index": data.edge_index,
         }
 
+        if self.global_attn_engine == "EquivariantTransformer":
+            conv_args.update(
+                {
+                    "positions": data.pos,
+                    "graph_batch": (
+                        data.batch
+                        if data.batch is not None
+                        else torch.zeros(
+                            data.pos.shape[0], dtype=torch.long, device=data.pos.device
+                        )
+                    ),
+                }
+            )
+
         if self.use_global_attn:
-            # encode node positional embeddings
+            if self.global_attn_engine == "EquivariantTransformer":
+                return (
+                    data.node_features[:, : self.hidden_dim],
+                    data.node_features[:, self.hidden_dim :],
+                    conv_args,
+                )
+
+            # GPS combines learned node and positional encodings.
             x = self.pos_emb(data.pe)
-            # if node features are available, genrate mebeddings, concatenate with positional embeddings and map to hidden dim
             if self.input_dim:
                 x = torch.cat((data.node_features, x), 1)
                 x = self.node_lin(x)
-            # repeat for edge features and relative edge encodings
             if self.is_edge_model:
                 e = self.rel_pos_emb(data.rel_pe)
                 if self.use_edge_attr:

--- a/hydragnn/models/PAINNStack.py
+++ b/hydragnn/models/PAINNStack.py
@@ -40,6 +40,7 @@ class PAINNStack(Base):
         *args,
         **kwargs
     ):
+        self.equivariant_attn_adapter_type = "PAINN"
         self.edge_dim = edge_dim
         self.num_radial = num_radial
         self.radius = radius
@@ -166,6 +167,24 @@ class PAINNStack(Base):
             "dist": edge_dist,
         }
 
+        if self.global_attn_engine == "EquivariantTransformer":
+            if torch.any(data.edge_shifts != 0):
+                raise ValueError(
+                    "EquivariantTransformer does not yet support periodic images"
+                )
+            conv_args.update(
+                {
+                    "positions": data.pos,
+                    "graph_batch": (
+                        data.batch
+                        if data.batch is not None
+                        else torch.zeros(
+                            data.pos.shape[0], dtype=torch.long, device=data.pos.device
+                        )
+                    ),
+                }
+            )
+
         if self.use_edge_attr:
             assert (
                 data.edge_attr is not None
@@ -173,14 +192,20 @@ class PAINNStack(Base):
             conv_args.update({"edge_attr": data.edge_attr})
 
         if self.use_global_attn:
-            # encode node positional embeddings
-            x = self.pos_emb(data.pe)
-            # if node features are available, genrate mebeddings, concatenate with positional embeddings and map to hidden dim
-            if self.input_dim:
-                x = torch.cat((self.node_emb(data.x.float()), x), 1)
-                x = self.node_lin(x)
-            # repeat for edge features and relative edge encodings
-            if self.is_edge_model:
+            if self.global_attn_engine == "EquivariantTransformer":
+                if not self.input_dim:
+                    raise ValueError(
+                        "EquivariantTransformer requires invariant node features"
+                    )
+                x = self.node_emb(data.x.float())
+            else:
+                # GPS combines learned node and positional encodings.
+                x = self.pos_emb(data.pe)
+                if self.input_dim:
+                    x = torch.cat((self.node_emb(data.x.float()), x), 1)
+                    x = self.node_lin(x)
+
+            if self.is_edge_model and self.global_attn_engine == "GPS":
                 e = self.rel_pos_emb(data.rel_pe)
                 if self.use_edge_attr:
                     e = torch.cat((self.edge_emb(conv_args["edge_attr"]), e), 1)

--- a/hydragnn/models/PNAEqStack.py
+++ b/hydragnn/models/PNAEqStack.py
@@ -55,7 +55,7 @@ class PNAEqStack(Base):
         *args,
         **kwargs,
     ):
-
+        self.equivariant_attn_adapter_type = "PNAEq"
         self.x_aggregators = ["mean", "min", "max", "std"]
         self.x_scalers = [
             "identity",
@@ -212,6 +212,24 @@ class PNAEqStack(Base):
             "edge_vec": norm_edge_vec,
         }
 
+        if self.global_attn_engine == "EquivariantTransformer":
+            if torch.any(data.edge_shifts != 0):
+                raise ValueError(
+                    "EquivariantTransformer does not yet support periodic images"
+                )
+            conv_args.update(
+                {
+                    "positions": data.pos,
+                    "graph_batch": (
+                        data.batch
+                        if data.batch is not None
+                        else torch.zeros(
+                            data.pos.shape[0], dtype=torch.long, device=data.pos.device
+                        )
+                    ),
+                }
+            )
+
         if self.use_edge_attr:
             assert (
                 data.edge_attr is not None
@@ -219,14 +237,20 @@ class PNAEqStack(Base):
             conv_args.update({"edge_attr": data.edge_attr})
 
         if self.use_global_attn:
-            # encode node positional embeddings
-            x = self.pos_emb(data.pe)
-            # if node features are available, genrate mebeddings, concatenate with positional embeddings and map to hidden dim
-            if self.input_dim:
-                x = torch.cat((self.node_emb(data.x.float()), x), 1)
-                x = self.node_lin(x)
-            # repeat for edge features and relative edge encodings
-            if self.is_edge_model:
+            if self.global_attn_engine == "EquivariantTransformer":
+                if not self.input_dim:
+                    raise ValueError(
+                        "EquivariantTransformer requires invariant node features"
+                    )
+                x = self.node_emb(data.x.float())
+            else:
+                # GPS combines learned node and positional encodings.
+                x = self.pos_emb(data.pe)
+                if self.input_dim:
+                    x = torch.cat((self.node_emb(data.x.float()), x), 1)
+                    x = self.node_lin(x)
+
+            if self.is_edge_model and self.global_attn_engine == "GPS":
                 e = self.rel_pos_emb(data.rel_pe)
                 if self.use_edge_attr:
                     e = torch.cat((self.edge_emb(conv_args["edge_attr"]), e), 1)

--- a/hydragnn/models/SCFStack.py
+++ b/hydragnn/models/SCFStack.py
@@ -52,6 +52,7 @@ class SCFStack(Base):
         max_neighbours: Optional[int] = None,
         **kwargs,
     ):
+        self.equivariant_attn_adapter_type = "SchNet"
         self.radius = radius
         self.max_neighbours = max_neighbours
         self.num_filters = num_filters
@@ -111,7 +112,9 @@ class SCFStack(Base):
             equivariant=self.equivariance and not last_layer,
         )
 
-        if self.use_edge_attr or (self.use_global_attn and self.is_edge_model):
+        if self.use_edge_attr or (
+            self.global_attn_engine == "GPS" and self.is_edge_model
+        ):
             return PyGSeq(
                 "inv_node_feat, equiv_node_feat, edge_index, edge_weight, edge_rbf, batch, edge_attr",
                 [
@@ -163,13 +166,19 @@ class SCFStack(Base):
     def _embedding(self, data):
         super()._embedding(data)
 
-        if (self.use_edge_attr or (self.use_global_attn and self.is_edge_model)) and (
-            self.equivariance
+        if self.global_attn_engine == "EquivariantTransformer" and torch.any(
+            data.edge_shifts != 0
         ):
+            raise ValueError(
+                "EquivariantTransformer does not yet support periodic images"
+            )
+
+        gps_edge_encodings = self.global_attn_engine == "GPS" and self.is_edge_model
+        if (self.use_edge_attr or gps_edge_encodings) and self.equivariance:
             raise Exception(
                 "For SchNet if using edge attributes or edge encodings for gps, then E(3)-equivariance cannot be ensured. Please disable equivariance or edge attributes."
             )
-        elif self.use_edge_attr or (self.use_global_attn and self.is_edge_model):
+        elif self.use_edge_attr or gps_edge_encodings:
             edge_index = data.edge_index
             data.edge_shifts = torch.zeros(
                 (data.edge_index.size(1), 3), device=data.edge_index.device
@@ -196,12 +205,34 @@ class SCFStack(Base):
                 "batch": data.batch,
             }
 
+        if self.global_attn_engine == "EquivariantTransformer":
+            conv_args.update(
+                {
+                    "positions": data.pos,
+                    "graph_batch": (
+                        data.batch
+                        if data.batch is not None
+                        else torch.zeros(
+                            data.pos.shape[0], dtype=torch.long, device=data.pos.device
+                        )
+                    ),
+                }
+            )
+
         if self.use_global_attn:
-            x = self.pos_emb(data.pe)
-            if self.input_dim:
-                x = torch.cat((self.node_emb(data.x.float()), x), 1)
-                x = self.node_lin(x)
-            if self.is_edge_model:
+            if self.global_attn_engine == "EquivariantTransformer":
+                if not self.input_dim:
+                    raise ValueError(
+                        "EquivariantTransformer requires invariant node features"
+                    )
+                x = self.node_emb(data.x.float())
+            else:
+                x = self.pos_emb(data.pe)
+                if self.input_dim:
+                    x = torch.cat((self.node_emb(data.x.float()), x), 1)
+                    x = self.node_lin(x)
+
+            if self.is_edge_model and self.global_attn_engine == "GPS":
                 e = self.rel_pos_emb(data.rel_pe)
                 if self.use_edge_attr:
                     e = torch.cat((self.edge_emb(conv_args["edge_attr"]), e), 1)

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -420,6 +420,15 @@ def create_model(
             graph_pooling=graph_pooling,
             use_graph_attr_conditioning=use_graph_attr_conditioning,
             graph_attr_conditioning_mode=graph_attr_conditioning_mode,
+            equivariant_attn_lmax=equivariant_attn_lmax,
+            equivariant_attn_num_radial=equivariant_attn_num_radial,
+            equivariant_attn_feedforward_multiplier=(
+                equivariant_attn_feedforward_multiplier
+            ),
+            equivariant_attn_allow_scalar_only=equivariant_attn_allow_scalar_only,
+            equivariant_attn_require_tensor_coupling=(
+                equivariant_attn_require_tensor_coupling
+            ),
         )
 
     elif mpnn_type == "DimeNet":
@@ -468,6 +477,15 @@ def create_model(
             graph_pooling=graph_pooling,
             use_graph_attr_conditioning=use_graph_attr_conditioning,
             graph_attr_conditioning_mode=graph_attr_conditioning_mode,
+            equivariant_attn_lmax=equivariant_attn_lmax,
+            equivariant_attn_num_radial=equivariant_attn_num_radial,
+            equivariant_attn_feedforward_multiplier=(
+                equivariant_attn_feedforward_multiplier
+            ),
+            equivariant_attn_allow_scalar_only=equivariant_attn_allow_scalar_only,
+            equivariant_attn_require_tensor_coupling=(
+                equivariant_attn_require_tensor_coupling
+            ),
         )
 
     elif mpnn_type == "EGNN":

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -109,6 +109,9 @@ def create_model_config(
         equivariant_attn_require_tensor_coupling=config["Architecture"].get(
             "equivariant_attn_require_tensor_coupling", True
         ),
+        equivariant_attn_chunk_size=config["Architecture"].get(
+            "equivariant_attn_chunk_size", 512
+        ),
         verbosity=verbosity,
         use_gpu=use_gpu,
     )
@@ -174,6 +177,7 @@ def create_model(
     equivariant_attn_feedforward_multiplier: int = 2,
     equivariant_attn_allow_scalar_only: bool = False,
     equivariant_attn_require_tensor_coupling: bool = True,
+    equivariant_attn_chunk_size: int | None = 512,
     verbosity: int = 0,
     use_gpu: bool = True,
 ):
@@ -429,6 +433,7 @@ def create_model(
             equivariant_attn_require_tensor_coupling=(
                 equivariant_attn_require_tensor_coupling
             ),
+            equivariant_attn_chunk_size=equivariant_attn_chunk_size,
         )
 
     elif mpnn_type == "DimeNet":
@@ -486,6 +491,7 @@ def create_model(
             equivariant_attn_require_tensor_coupling=(
                 equivariant_attn_require_tensor_coupling
             ),
+            equivariant_attn_chunk_size=equivariant_attn_chunk_size,
         )
 
     elif mpnn_type == "EGNN":
@@ -552,6 +558,7 @@ def create_model(
             equivariant_attn_require_tensor_coupling=(
                 equivariant_attn_require_tensor_coupling
             ),
+            equivariant_attn_chunk_size=equivariant_attn_chunk_size,
         )
 
     elif mpnn_type == "PNAEq":
@@ -591,6 +598,7 @@ def create_model(
             equivariant_attn_require_tensor_coupling=(
                 equivariant_attn_require_tensor_coupling
             ),
+            equivariant_attn_chunk_size=equivariant_attn_chunk_size,
         )
 
     elif mpnn_type == "MACE":

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -112,6 +112,9 @@ def create_model_config(
         equivariant_attn_chunk_size=config["Architecture"].get(
             "equivariant_attn_chunk_size", 512
         ),
+        equivariant_attn_coupling_mode=config["Architecture"].get(
+            "equivariant_attn_coupling_mode", "parallel"
+        ),
         verbosity=verbosity,
         use_gpu=use_gpu,
     )
@@ -178,6 +181,7 @@ def create_model(
     equivariant_attn_allow_scalar_only: bool = False,
     equivariant_attn_require_tensor_coupling: bool = True,
     equivariant_attn_chunk_size: int | None = 512,
+    equivariant_attn_coupling_mode: str = "parallel",
     verbosity: int = 0,
     use_gpu: bool = True,
 ):
@@ -434,6 +438,7 @@ def create_model(
                 equivariant_attn_require_tensor_coupling
             ),
             equivariant_attn_chunk_size=equivariant_attn_chunk_size,
+            equivariant_attn_coupling_mode=equivariant_attn_coupling_mode,
         )
 
     elif mpnn_type == "DimeNet":
@@ -492,6 +497,7 @@ def create_model(
                 equivariant_attn_require_tensor_coupling
             ),
             equivariant_attn_chunk_size=equivariant_attn_chunk_size,
+            equivariant_attn_coupling_mode=equivariant_attn_coupling_mode,
         )
 
     elif mpnn_type == "EGNN":
@@ -559,6 +565,7 @@ def create_model(
                 equivariant_attn_require_tensor_coupling
             ),
             equivariant_attn_chunk_size=equivariant_attn_chunk_size,
+            equivariant_attn_coupling_mode=equivariant_attn_coupling_mode,
         )
 
     elif mpnn_type == "PNAEq":
@@ -599,6 +606,7 @@ def create_model(
                 equivariant_attn_require_tensor_coupling
             ),
             equivariant_attn_chunk_size=equivariant_attn_chunk_size,
+            equivariant_attn_coupling_mode=equivariant_attn_coupling_mode,
         )
 
     elif mpnn_type == "MACE":
@@ -651,6 +659,7 @@ def create_model(
                 equivariant_attn_require_tensor_coupling
             ),
             equivariant_attn_chunk_size=equivariant_attn_chunk_size,
+            equivariant_attn_coupling_mode=equivariant_attn_coupling_mode,
         )
     else:
         raise ValueError("Unknown mpnn_type: {0}".format(mpnn_type))

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -641,6 +641,16 @@ def create_model(
             graph_pooling=graph_pooling,
             use_graph_attr_conditioning=use_graph_attr_conditioning,
             graph_attr_conditioning_mode=graph_attr_conditioning_mode,
+            equivariant_attn_lmax=equivariant_attn_lmax,
+            equivariant_attn_num_radial=equivariant_attn_num_radial,
+            equivariant_attn_feedforward_multiplier=(
+                equivariant_attn_feedforward_multiplier
+            ),
+            equivariant_attn_allow_scalar_only=equivariant_attn_allow_scalar_only,
+            equivariant_attn_require_tensor_coupling=(
+                equivariant_attn_require_tensor_coupling
+            ),
+            equivariant_attn_chunk_size=equivariant_attn_chunk_size,
         )
     else:
         raise ValueError("Unknown mpnn_type: {0}".format(mpnn_type))

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -564,6 +564,15 @@ def create_model(
             graph_pooling=graph_pooling,
             use_graph_attr_conditioning=use_graph_attr_conditioning,
             graph_attr_conditioning_mode=graph_attr_conditioning_mode,
+            equivariant_attn_lmax=equivariant_attn_lmax,
+            equivariant_attn_num_radial=equivariant_attn_num_radial,
+            equivariant_attn_feedforward_multiplier=(
+                equivariant_attn_feedforward_multiplier
+            ),
+            equivariant_attn_allow_scalar_only=equivariant_attn_allow_scalar_only,
+            equivariant_attn_require_tensor_coupling=(
+                equivariant_attn_require_tensor_coupling
+            ),
         )
 
     elif mpnn_type == "MACE":

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -96,6 +96,19 @@ def create_model_config(
             "graph_attr_conditioning_mode", "concat_node"
         ),
         graph_pooling=config["Architecture"].get("graph_pooling", "mean"),
+        equivariant_attn_lmax=config["Architecture"].get("equivariant_attn_lmax", 1),
+        equivariant_attn_num_radial=config["Architecture"].get(
+            "equivariant_attn_num_radial", 16
+        ),
+        equivariant_attn_feedforward_multiplier=config["Architecture"].get(
+            "equivariant_attn_feedforward_multiplier", 2
+        ),
+        equivariant_attn_allow_scalar_only=config["Architecture"].get(
+            "equivariant_attn_allow_scalar_only", False
+        ),
+        equivariant_attn_require_tensor_coupling=config["Architecture"].get(
+            "equivariant_attn_require_tensor_coupling", True
+        ),
         verbosity=verbosity,
         use_gpu=use_gpu,
     )
@@ -156,6 +169,11 @@ def create_model(
     use_graph_attr_conditioning: bool = False,
     graph_attr_conditioning_mode: str = "fuse_pool",
     graph_pooling: str = "mean",
+    equivariant_attn_lmax: int = 1,
+    equivariant_attn_num_radial: int = 16,
+    equivariant_attn_feedforward_multiplier: int = 2,
+    equivariant_attn_allow_scalar_only: bool = False,
+    equivariant_attn_require_tensor_coupling: bool = True,
     verbosity: int = 0,
     use_gpu: bool = True,
 ):
@@ -507,6 +525,15 @@ def create_model(
             graph_pooling=graph_pooling,
             use_graph_attr_conditioning=use_graph_attr_conditioning,
             graph_attr_conditioning_mode=graph_attr_conditioning_mode,
+            equivariant_attn_lmax=equivariant_attn_lmax,
+            equivariant_attn_num_radial=equivariant_attn_num_radial,
+            equivariant_attn_feedforward_multiplier=(
+                equivariant_attn_feedforward_multiplier
+            ),
+            equivariant_attn_allow_scalar_only=equivariant_attn_allow_scalar_only,
+            equivariant_attn_require_tensor_coupling=(
+                equivariant_attn_require_tensor_coupling
+            ),
         )
 
     elif mpnn_type == "PNAEq":

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -50,6 +50,14 @@ def update_config(config, train_loader, val_loader, test_loader):
         # Used only by Performer attention. None disables projection redraw.
         config["NeuralNetwork"]["Training"]["global_attn_redraw_interval"] = 1000
 
+    architecture = config["NeuralNetwork"]["Architecture"]
+    architecture.setdefault("equivariant_attn_lmax", 1)
+    architecture.setdefault("equivariant_attn_num_radial", 16)
+    architecture.setdefault("equivariant_attn_feedforward_multiplier", 2)
+    architecture.setdefault("equivariant_attn_allow_scalar_only", False)
+    architecture.setdefault("equivariant_attn_require_tensor_coupling", True)
+    validate_equivariant_transformer_config(architecture)
+
     # update output_heads with latest config rules
     config["NeuralNetwork"]["Architecture"]["output_heads"] = update_multibranch_heads(
         config["NeuralNetwork"]["Architecture"]["output_heads"]
@@ -164,6 +172,29 @@ def update_config(config, train_loader, val_loader, test_loader):
         config["NeuralNetwork"]["Training"]["precision"] = "fp32"
 
     return config
+
+
+def validate_equivariant_transformer_config(config):
+    """Validate options whose meaning is specific to the equivariant engine."""
+    if config.get("global_attn_engine") != "EquivariantTransformer":
+        return
+    if config.get("mpnn_type") != "PAINN":
+        raise ValueError(
+            "EquivariantTransformer model integration currently supports PAINN; "
+            "the other adapters remain unavailable until their integration tests pass"
+        )
+    if config.get("global_attn_heads", 0) <= 0:
+        raise ValueError("EquivariantTransformer requires global_attn_heads > 0")
+    if config["equivariant_attn_lmax"] < 0:
+        raise ValueError("equivariant_attn_lmax must be nonnegative")
+    if config["equivariant_attn_num_radial"] <= 0:
+        raise ValueError("equivariant_attn_num_radial must be positive")
+    if config["equivariant_attn_feedforward_multiplier"] <= 0:
+        raise ValueError("equivariant_attn_feedforward_multiplier must be positive")
+    if not config["equivariant_attn_require_tensor_coupling"]:
+        raise ValueError(
+            "PAINN provides vector features; tensor coupling must remain enabled"
+        )
 
 
 def update_config_equivariance(config):

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -56,6 +56,7 @@ def update_config(config, train_loader, val_loader, test_loader):
     architecture.setdefault("equivariant_attn_feedforward_multiplier", 2)
     architecture.setdefault("equivariant_attn_allow_scalar_only", False)
     architecture.setdefault("equivariant_attn_require_tensor_coupling", True)
+    architecture.setdefault("equivariant_attn_chunk_size", 512)
     validate_equivariant_transformer_config(architecture)
 
     # update output_heads with latest config rules
@@ -193,6 +194,8 @@ def validate_equivariant_transformer_config(config):
         raise ValueError("equivariant_attn_num_radial must be positive")
     if config["equivariant_attn_feedforward_multiplier"] <= 0:
         raise ValueError("equivariant_attn_feedforward_multiplier must be positive")
+    if config.get("equivariant_attn_chunk_size", 512) <= 0:
+        raise ValueError("equivariant_attn_chunk_size must be positive")
     if (
         mpnn_type in {"PAINN", "PNAEq"}
         and not config["equivariant_attn_require_tensor_coupling"]

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -178,10 +178,11 @@ def validate_equivariant_transformer_config(config):
     """Validate options whose meaning is specific to the equivariant engine."""
     if config.get("global_attn_engine") != "EquivariantTransformer":
         return
-    if config.get("mpnn_type") not in {"PAINN", "PNAEq"}:
+    mpnn_type = config.get("mpnn_type")
+    if mpnn_type not in {"PAINN", "PNAEq", "SchNet", "DimeNet"}:
         raise ValueError(
             "EquivariantTransformer model integration currently supports "
-            "PAINN and PNAEq; "
+            "PAINN, PNAEq, SchNet, and DimeNet; "
             "the other adapters remain unavailable until their integration tests pass"
         )
     if config.get("global_attn_heads", 0) <= 0:
@@ -192,10 +193,27 @@ def validate_equivariant_transformer_config(config):
         raise ValueError("equivariant_attn_num_radial must be positive")
     if config["equivariant_attn_feedforward_multiplier"] <= 0:
         raise ValueError("equivariant_attn_feedforward_multiplier must be positive")
-    if not config["equivariant_attn_require_tensor_coupling"]:
+    if (
+        mpnn_type in {"PAINN", "PNAEq"}
+        and not config["equivariant_attn_require_tensor_coupling"]
+    ):
         raise ValueError(
-            f"{config['mpnn_type']} provides vector features; tensor coupling "
+            f"{mpnn_type} provides vector features; tensor coupling "
             "must remain enabled"
+        )
+    if mpnn_type in {"SchNet", "DimeNet"}:
+        if config["equivariant_attn_require_tensor_coupling"]:
+            raise ValueError(
+                f"{mpnn_type} cannot provide tensor-valued local/global coupling"
+            )
+        if not config["equivariant_attn_allow_scalar_only"]:
+            raise ValueError(
+                f"{mpnn_type} requires equivariant_attn_allow_scalar_only=true"
+            )
+    if mpnn_type == "SchNet" and config.get("equivariance"):
+        raise ValueError(
+            "SchNet with EquivariantTransformer cannot use coordinate updates; "
+            "set Architecture.equivariance=false"
         )
 
 

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -195,8 +195,16 @@ def validate_equivariant_transformer_config(config):
         raise ValueError("equivariant_attn_num_radial must be positive")
     if config["equivariant_attn_feedforward_multiplier"] <= 0:
         raise ValueError("equivariant_attn_feedforward_multiplier must be positive")
-    if config.get("equivariant_attn_chunk_size", 512) <= 0:
-        raise ValueError("equivariant_attn_chunk_size must be positive")
+    chunk_size = config.get("equivariant_attn_chunk_size", 512)
+    if chunk_size is not None:
+        if (
+            not isinstance(chunk_size, int)
+            or isinstance(chunk_size, bool)
+            or chunk_size <= 0
+        ):
+            raise ValueError(
+                "equivariant_attn_chunk_size must be a positive integer or null"
+            )
     if config.get("equivariant_attn_coupling_mode", "parallel") not in {
         "parallel",
         "sequential",

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -57,6 +57,7 @@ def update_config(config, train_loader, val_loader, test_loader):
     architecture.setdefault("equivariant_attn_allow_scalar_only", False)
     architecture.setdefault("equivariant_attn_require_tensor_coupling", True)
     architecture.setdefault("equivariant_attn_chunk_size", 512)
+    architecture.setdefault("equivariant_attn_coupling_mode", "parallel")
     validate_equivariant_transformer_config(architecture)
 
     # update output_heads with latest config rules
@@ -196,6 +197,13 @@ def validate_equivariant_transformer_config(config):
         raise ValueError("equivariant_attn_feedforward_multiplier must be positive")
     if config.get("equivariant_attn_chunk_size", 512) <= 0:
         raise ValueError("equivariant_attn_chunk_size must be positive")
+    if config.get("equivariant_attn_coupling_mode", "parallel") not in {
+        "parallel",
+        "sequential",
+    }:
+        raise ValueError(
+            "equivariant_attn_coupling_mode must be 'parallel' or 'sequential'"
+        )
     if (
         mpnn_type in {"PAINN", "PNAEq", "MACE"}
         and not config["equivariant_attn_require_tensor_coupling"]

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -178,9 +178,10 @@ def validate_equivariant_transformer_config(config):
     """Validate options whose meaning is specific to the equivariant engine."""
     if config.get("global_attn_engine") != "EquivariantTransformer":
         return
-    if config.get("mpnn_type") != "PAINN":
+    if config.get("mpnn_type") not in {"PAINN", "PNAEq"}:
         raise ValueError(
-            "EquivariantTransformer model integration currently supports PAINN; "
+            "EquivariantTransformer model integration currently supports "
+            "PAINN and PNAEq; "
             "the other adapters remain unavailable until their integration tests pass"
         )
     if config.get("global_attn_heads", 0) <= 0:
@@ -193,7 +194,8 @@ def validate_equivariant_transformer_config(config):
         raise ValueError("equivariant_attn_feedforward_multiplier must be positive")
     if not config["equivariant_attn_require_tensor_coupling"]:
         raise ValueError(
-            "PAINN provides vector features; tensor coupling must remain enabled"
+            f"{config['mpnn_type']} provides vector features; tensor coupling "
+            "must remain enabled"
         )
 
 

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -180,10 +180,10 @@ def validate_equivariant_transformer_config(config):
     if config.get("global_attn_engine") != "EquivariantTransformer":
         return
     mpnn_type = config.get("mpnn_type")
-    if mpnn_type not in {"PAINN", "PNAEq", "SchNet", "DimeNet"}:
+    if mpnn_type not in {"PAINN", "PNAEq", "SchNet", "DimeNet", "MACE"}:
         raise ValueError(
             "EquivariantTransformer model integration currently supports "
-            "PAINN, PNAEq, SchNet, and DimeNet; "
+            "PAINN, PNAEq, SchNet, DimeNet, and MACE; "
             "the other adapters remain unavailable until their integration tests pass"
         )
     if config.get("global_attn_heads", 0) <= 0:
@@ -197,7 +197,7 @@ def validate_equivariant_transformer_config(config):
     if config.get("equivariant_attn_chunk_size", 512) <= 0:
         raise ValueError("equivariant_attn_chunk_size must be positive")
     if (
-        mpnn_type in {"PAINN", "PNAEq"}
+        mpnn_type in {"PAINN", "PNAEq", "MACE"}
         and not config["equivariant_attn_require_tensor_coupling"]
     ):
         raise ValueError(
@@ -217,6 +217,11 @@ def validate_equivariant_transformer_config(config):
         raise ValueError(
             "SchNet with EquivariantTransformer cannot use coordinate updates; "
             "set Architecture.equivariance=false"
+        )
+    if mpnn_type == "MACE" and config.get("num_conv_layers", 0) < 2:
+        raise ValueError(
+            "MACE with EquivariantTransformer requires at least two convolution "
+            "layers because MACE's final layer contains scalar irreps only"
         )
 
 

--- a/tests/test_equivariant_attention.py
+++ b/tests/test_equivariant_attention.py
@@ -9,6 +9,8 @@
 # SPDX-License-Identifier: BSD-3-Clause                                      #
 ##############################################################################
 
+import copy
+
 import torch
 from e3nn import o3
 
@@ -108,3 +110,58 @@ def pytest_equivariant_attention_supports_backward_propagation():
     assert torch.isfinite(features.grad).all()
     assert torch.isfinite(positions.grad).all()
     assert all(parameter.grad is not None for parameter in module.parameters())
+
+
+def pytest_chunked_attention_matches_dense_outputs_and_gradients():
+    torch.manual_seed(15)
+    irreps = o3.Irreps("2x0e + 2x1o")
+    dense_module = EquivariantAllToAllAttention(
+        irreps, heads=2, lmax=1, num_radial=5
+    ).double()
+    chunked_module = copy.deepcopy(dense_module)
+    batch = torch.tensor([0, 0, 0, 0, 1, 1, 1])
+    dense_features = torch.randn(7, irreps.dim, dtype=torch.float64, requires_grad=True)
+    dense_positions = torch.randn(7, 3, dtype=torch.float64, requires_grad=True)
+    chunked_features = dense_features.detach().clone().requires_grad_()
+    chunked_positions = dense_positions.detach().clone().requires_grad_()
+    probe = torch.randn(7, irreps.dim, dtype=torch.float64)
+
+    dense_output = dense_module(
+        dense_features,
+        dense_positions,
+        complete_graph_edge_index(batch),
+    )
+    chunked_output = chunked_module.forward_chunked(
+        chunked_features, chunked_positions, batch, chunk_size=2
+    )
+    (dense_output * probe).sum().backward()
+    (chunked_output * probe).sum().backward()
+
+    torch.testing.assert_close(chunked_output, dense_output)
+    torch.testing.assert_close(chunked_features.grad, dense_features.grad)
+    torch.testing.assert_close(chunked_positions.grad, dense_positions.grad)
+    for (dense_name, dense_parameter), (chunked_name, chunked_parameter) in zip(
+        dense_module.named_parameters(), chunked_module.named_parameters()
+    ):
+        assert dense_name == chunked_name
+        if dense_parameter.grad is None:
+            assert chunked_parameter.grad is None
+        else:
+            torch.testing.assert_close(
+                chunked_parameter.grad, dense_parameter.grad, rtol=1.0e-10, atol=1.0e-12
+            )
+
+
+def pytest_chunked_attention_handles_interleaved_and_singleton_graphs():
+    torch.manual_seed(16)
+    irreps = o3.Irreps("1x0e + 1x1o")
+    module = EquivariantAllToAllAttention(irreps, heads=1).double()
+    features = torch.randn(6, irreps.dim, dtype=torch.float64)
+    positions = torch.randn(6, 3, dtype=torch.float64)
+    batch = torch.tensor([2, 7, 2, 9, 7, 2])
+
+    dense = module(features, positions, complete_graph_edge_index(batch))
+    chunked = module.forward_chunked(features, positions, batch, chunk_size=1)
+
+    torch.testing.assert_close(chunked, dense)
+    assert torch.equal(chunked[3], torch.zeros_like(chunked[3]))

--- a/tests/test_equivariant_attention.py
+++ b/tests/test_equivariant_attention.py
@@ -1,0 +1,110 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import torch
+from e3nn import o3
+
+from hydragnn.globalAtt.complete_graph import complete_graph_edge_index
+from hydragnn.globalAtt.equivariant_attention import EquivariantAllToAllAttention
+
+
+def _sample(dtype=torch.float64):
+    irreps = o3.Irreps("2x0e + 2x1o")
+    features = torch.randn(5, irreps.dim, dtype=dtype)
+    positions = torch.randn(5, 3, dtype=dtype)
+    batch = torch.tensor([0, 0, 0, 1, 1])
+    return irreps, features, positions, batch
+
+
+def pytest_equivariant_attention_is_rotation_equivariant_and_translation_invariant():
+    torch.manual_seed(11)
+    irreps, features, positions, batch = _sample()
+    module = EquivariantAllToAllAttention(irreps, heads=2, lmax=1).double()
+    edges = complete_graph_edge_index(batch)
+    rotation = o3.rand_matrix(dtype=torch.float64)
+    translation = torch.randn(1, 3, dtype=torch.float64)
+    representation = irreps.D_from_matrix(rotation)
+
+    output = module(features, positions, edges)
+    transformed_output = module(
+        features @ representation.T,
+        positions @ rotation.T + translation,
+        edges,
+    )
+
+    torch.testing.assert_close(
+        transformed_output,
+        output @ representation.T,
+        rtol=2.0e-5,
+        atol=3.0e-6,
+    )
+
+
+def pytest_equivariant_attention_is_permutation_equivariant():
+    torch.manual_seed(12)
+    irreps, features, positions, batch = _sample()
+    module = EquivariantAllToAllAttention(irreps, heads=2, lmax=1).double()
+    edges = complete_graph_edge_index(batch)
+    permutation = torch.tensor([2, 0, 1, 4, 3])
+
+    output = module(features, positions, edges)
+    permuted_output = module(
+        features[permutation],
+        positions[permutation],
+        complete_graph_edge_index(batch[permutation]),
+    )
+
+    torch.testing.assert_close(permuted_output, output[permutation])
+
+
+def pytest_equivariant_attention_isolates_graphs_and_normalizes_each_target():
+    torch.manual_seed(13)
+    irreps, features, positions, batch = _sample()
+    module = EquivariantAllToAllAttention(irreps, heads=3, lmax=1).double()
+    edges = complete_graph_edge_index(batch)
+
+    combined, attention = module(
+        features, positions, edges, return_attention_weights=True
+    )
+    first = module(
+        features[:3],
+        positions[:3],
+        complete_graph_edge_index(torch.zeros(3, dtype=torch.long)),
+    )
+    second = module(
+        features[3:],
+        positions[3:],
+        complete_graph_edge_index(torch.zeros(2, dtype=torch.long)),
+    )
+
+    torch.testing.assert_close(combined, torch.cat((first, second)))
+    for target in range(features.shape[0]):
+        target_weights = attention[edges[1] == target]
+        torch.testing.assert_close(
+            target_weights.sum(dim=0), torch.ones(module.heads, dtype=torch.float64)
+        )
+
+
+def pytest_equivariant_attention_supports_backward_propagation():
+    torch.manual_seed(14)
+    irreps, features, positions, batch = _sample()
+    features.requires_grad_()
+    positions.requires_grad_()
+    module = EquivariantAllToAllAttention(irreps, heads=2, lmax=1).double()
+
+    output = module(features, positions, complete_graph_edge_index(batch))
+    output.square().sum().backward()
+
+    assert features.grad is not None
+    assert positions.grad is not None
+    assert torch.isfinite(features.grad).all()
+    assert torch.isfinite(positions.grad).all()
+    assert all(parameter.grad is not None for parameter in module.parameters())

--- a/tests/test_equivariant_complete_graph.py
+++ b/tests/test_equivariant_complete_graph.py
@@ -1,0 +1,72 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import pytest
+import torch
+
+from hydragnn.globalAtt.complete_graph import complete_graph_edge_index
+
+
+def pytest_complete_graph_constructs_ordered_non_self_pairs():
+    edge_index = complete_graph_edge_index(torch.tensor([0, 0, 0]))
+
+    expected = torch.tensor(
+        [
+            [1, 2, 0, 2, 0, 1],
+            [0, 0, 1, 1, 2, 2],
+        ]
+    )
+    assert torch.equal(edge_index, expected)
+
+
+def pytest_complete_graph_keeps_batched_graphs_isolated():
+    batch = torch.tensor([3, 3, 8, 8, 8, 11])
+    edge_index = complete_graph_edge_index(batch)
+    source, target = edge_index
+
+    assert edge_index.shape == (2, 8)
+    assert torch.all(source != target)
+    assert torch.equal(batch[source], batch[target])
+
+    actual_pairs = set(zip(source.tolist(), target.tolist()))
+    expected_pairs = {
+        (0, 1),
+        (1, 0),
+        (2, 3),
+        (2, 4),
+        (3, 2),
+        (3, 4),
+        (4, 2),
+        (4, 3),
+    }
+    assert actual_pairs == expected_pairs
+
+
+def pytest_complete_graph_handles_empty_and_singleton_batches():
+    empty = complete_graph_edge_index(torch.empty(0, dtype=torch.long))
+    singletons = complete_graph_edge_index(torch.tensor([0, 2, 7]))
+
+    assert empty.shape == (2, 0)
+    assert singletons.shape == (2, 0)
+    assert empty.dtype == torch.long
+
+
+@pytest.mark.parametrize(
+    ("batch", "error", "message"),
+    [
+        (torch.tensor([[0, 0]]), ValueError, "one-dimensional"),
+        (torch.tensor([0.0, 0.0]), TypeError, "torch.long"),
+        (torch.tensor([0, -1]), ValueError, "nonnegative"),
+    ],
+)
+def pytest_complete_graph_rejects_invalid_batches(batch, error, message):
+    with pytest.raises(error, match=message):
+        complete_graph_edge_index(batch)

--- a/tests/test_equivariant_features.py
+++ b/tests/test_equivariant_features.py
@@ -87,12 +87,20 @@ def pytest_scalar_vector_adapter_rejects_invalid_encoded_width():
 
 @pytest.mark.parametrize("mpnn_type", ["SchNet", "DimeNet"])
 def pytest_scalar_local_models_require_explicit_limited_mode(mpnn_type):
+    with pytest.raises(ValueError, match="cannot provide tensor-valued"):
+        create_local_feature_adapter(mpnn_type, channels=4, allow_scalar_only=True)
+
     with pytest.raises(ValueError, match="allow_scalar_only"):
-        create_local_feature_adapter(mpnn_type, channels=4)
+        create_local_feature_adapter(
+            mpnn_type, channels=4, require_tensor_coupling=False
+        )
 
     with pytest.warns(UserWarning, match="scalar-only"):
         adapter = create_local_feature_adapter(
-            mpnn_type, channels=4, allow_scalar_only=True
+            mpnn_type,
+            channels=4,
+            allow_scalar_only=True,
+            require_tensor_coupling=False,
         )
 
     assert isinstance(adapter, ScalarIrrepsAdapter)
@@ -107,6 +115,7 @@ def pytest_schnet_scalar_mode_rejects_coordinate_updates():
             "SchNet",
             channels=4,
             allow_scalar_only=True,
+            require_tensor_coupling=False,
             local_equivariance=True,
         )
 

--- a/tests/test_equivariant_features.py
+++ b/tests/test_equivariant_features.py
@@ -1,0 +1,81 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import pytest
+import torch
+from e3nn import o3
+
+from hydragnn.globalAtt.equivariant_features import ScalarVectorIrrepsAdapter
+
+
+def pytest_scalar_vector_adapter_round_trip():
+    adapter = ScalarVectorIrrepsAdapter(channels=4)
+    scalars = torch.randn(5, 4)
+    vectors = torch.randn(5, 3, 4)
+
+    encoded = adapter(scalars, vectors)
+    decoded_scalars, decoded_vectors = adapter.decode(encoded)
+
+    assert adapter.irreps == o3.Irreps("4x0e + 4x1o")
+    assert encoded.shape == (5, adapter.irreps.dim)
+    assert torch.equal(decoded_scalars, scalars)
+    assert torch.equal(decoded_vectors, vectors)
+
+
+def pytest_scalar_vector_adapter_is_rotation_equivariant():
+    adapter = ScalarVectorIrrepsAdapter(channels=3).double()
+    scalars = torch.randn(7, 3, dtype=torch.float64)
+    vectors = torch.randn(7, 3, 3, dtype=torch.float64)
+    rotation = o3.rand_matrix(dtype=torch.float64)
+
+    rotated_vectors = torch.einsum("ij,njc->nic", rotation, vectors)
+    encoded_after_rotation = adapter(scalars, rotated_vectors)
+
+    representation = adapter.irreps.D_from_matrix(rotation)
+    rotated_after_encoding = adapter(scalars, vectors) @ representation.T
+
+    torch.testing.assert_close(
+        encoded_after_rotation,
+        rotated_after_encoding,
+        # e3nn obtains D matrices through an angle decomposition whose
+        # numerical error is larger than the feature-layout conversion.
+        rtol=1.0e-5,
+        atol=2.0e-6,
+    )
+
+
+@pytest.mark.parametrize(
+    ("scalars", "vectors", "message"),
+    [
+        (torch.randn(2, 3, 1), torch.randn(2, 3, 3), "inv_node_feat"),
+        (torch.randn(2, 3), torch.randn(2, 3, 2), "equiv_node_feat"),
+        (torch.randn(2, 3), torch.randn(3, 3, 3), "equiv_node_feat"),
+    ],
+)
+def pytest_scalar_vector_adapter_rejects_invalid_shapes(scalars, vectors, message):
+    adapter = ScalarVectorIrrepsAdapter(channels=3)
+
+    with pytest.raises(ValueError, match=message):
+        adapter(scalars, vectors)
+
+
+def pytest_scalar_vector_adapter_rejects_mixed_dtypes():
+    adapter = ScalarVectorIrrepsAdapter(channels=3)
+
+    with pytest.raises(ValueError, match="same dtype"):
+        adapter(torch.randn(2, 3), torch.randn(2, 3, 3, dtype=torch.float64))
+
+
+def pytest_scalar_vector_adapter_rejects_invalid_encoded_width():
+    adapter = ScalarVectorIrrepsAdapter(channels=3)
+
+    with pytest.raises(ValueError, match="12 entries per node"):
+        adapter.decode(torch.randn(2, 11))

--- a/tests/test_equivariant_features.py
+++ b/tests/test_equivariant_features.py
@@ -14,6 +14,7 @@ import torch
 from e3nn import o3
 
 from hydragnn.globalAtt.equivariant_features import (
+    IrrepsFeatureAdapter,
     ScalarIrrepsAdapter,
     ScalarVectorIrrepsAdapter,
     create_local_feature_adapter,
@@ -124,3 +125,28 @@ def pytest_equivariant_local_models_use_scalar_vector_adapter_without_opt_in():
     for mpnn_type in ("PAINN", "PNAEq"):
         adapter = create_local_feature_adapter(mpnn_type, channels=4)
         assert isinstance(adapter, ScalarVectorIrrepsAdapter)
+
+
+def pytest_mace_irreps_adapter_round_trip_and_rotation():
+    irreps = o3.Irreps("3x0e + 3x1o + 2x2e")
+    adapter = IrrepsFeatureAdapter(irreps)
+    features = torch.randn(5, irreps.dim, dtype=torch.float64)
+    scalars, tensors = adapter.decode(features)
+
+    assert scalars.shape == (5, 3)
+    assert tensors.shape == (5, irreps.dim - 3)
+    assert torch.equal(adapter(scalars, tensors), features)
+
+    rotation = o3.rand_matrix(dtype=torch.float64)
+    representation = irreps.D_from_matrix(rotation)
+    transformed = features @ representation.T
+    transformed_scalars, transformed_tensors = adapter.decode(transformed)
+    torch.testing.assert_close(transformed_scalars, scalars)
+    torch.testing.assert_close(
+        adapter(transformed_scalars, transformed_tensors), transformed
+    )
+
+
+def pytest_mace_irreps_adapter_rejects_nonleading_scalars():
+    with pytest.raises(ValueError, match="precede tensor irreps"):
+        IrrepsFeatureAdapter("1x1o + 1x0e")

--- a/tests/test_equivariant_features.py
+++ b/tests/test_equivariant_features.py
@@ -150,3 +150,15 @@ def pytest_mace_irreps_adapter_round_trip_and_rotation():
 def pytest_mace_irreps_adapter_rejects_nonleading_scalars():
     with pytest.raises(ValueError, match="precede tensor irreps"):
         IrrepsFeatureAdapter("1x1o + 1x0e")
+
+
+def pytest_mace_parallel_input_zero_initializes_absent_tensor_irreps():
+    adapter = IrrepsFeatureAdapter("2x0e + 2x1o")
+    scalars = torch.randn(3, 2)
+    features = adapter.encode_parallel_input(scalars, torch.empty(3, 0))
+
+    torch.testing.assert_close(features[:, :2], scalars)
+    torch.testing.assert_close(features[:, 2:], torch.zeros(3, 6))
+
+    with pytest.raises(ValueError, match="match.*or be absent"):
+        adapter.encode_parallel_input(scalars, torch.randn(3, 3))

--- a/tests/test_equivariant_features.py
+++ b/tests/test_equivariant_features.py
@@ -13,7 +13,11 @@ import pytest
 import torch
 from e3nn import o3
 
-from hydragnn.globalAtt.equivariant_features import ScalarVectorIrrepsAdapter
+from hydragnn.globalAtt.equivariant_features import (
+    ScalarIrrepsAdapter,
+    ScalarVectorIrrepsAdapter,
+    create_local_feature_adapter,
+)
 
 
 def pytest_scalar_vector_adapter_round_trip():
@@ -79,3 +83,35 @@ def pytest_scalar_vector_adapter_rejects_invalid_encoded_width():
 
     with pytest.raises(ValueError, match="12 entries per node"):
         adapter.decode(torch.randn(2, 11))
+
+
+@pytest.mark.parametrize("mpnn_type", ["SchNet", "DimeNet"])
+def pytest_scalar_local_models_require_explicit_limited_mode(mpnn_type):
+    with pytest.raises(ValueError, match="allow_scalar_only"):
+        create_local_feature_adapter(mpnn_type, channels=4)
+
+    with pytest.warns(UserWarning, match="scalar-only"):
+        adapter = create_local_feature_adapter(
+            mpnn_type, channels=4, allow_scalar_only=True
+        )
+
+    assert isinstance(adapter, ScalarIrrepsAdapter)
+    assert adapter.irreps == o3.Irreps("4x0e")
+    features = torch.randn(3, 4)
+    assert adapter.decode(adapter(features)) is features
+
+
+def pytest_schnet_scalar_mode_rejects_coordinate_updates():
+    with pytest.raises(ValueError, match="coordinate updates"):
+        create_local_feature_adapter(
+            "SchNet",
+            channels=4,
+            allow_scalar_only=True,
+            local_equivariance=True,
+        )
+
+
+def pytest_equivariant_local_models_use_scalar_vector_adapter_without_opt_in():
+    for mpnn_type in ("PAINN", "PNAEq"):
+        adapter = create_local_feature_adapter(mpnn_type, channels=4)
+        assert isinstance(adapter, ScalarVectorIrrepsAdapter)

--- a/tests/test_equivariant_local_global.py
+++ b/tests/test_equivariant_local_global.py
@@ -1,0 +1,124 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import pytest
+import torch
+from e3nn import o3
+
+from hydragnn.globalAtt.equivariant_local_global import EquivariantLocalGlobalConv
+
+
+class _EquivariantScaleConv(torch.nn.Module):
+    def __init__(self, scale=2.0):
+        super().__init__()
+        self.scale = torch.nn.Parameter(torch.tensor(scale))
+
+    def forward(self, inv_node_feat, equiv_node_feat, **kwargs):
+        return self.scale * inv_node_feat, self.scale * equiv_node_feat
+
+
+class _RecordingGlobal(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.input = None
+
+    def forward(self, features, positions, batch):
+        self.input = features.detach().clone()
+        return 3.0 * features
+
+    def forward_attention(self, features, positions, batch):
+        return self(features, positions, batch)
+
+    def forward_feedforward(self, features):
+        return features
+
+
+def _layer(coupling_mode):
+    return EquivariantLocalGlobalConv(
+        channels=2,
+        conv=_EquivariantScaleConv(),
+        mpnn_type="PAINN",
+        heads=1,
+        lmax=1,
+        num_radial=4,
+        feedforward_multiplier=2,
+        allow_scalar_only=False,
+        require_tensor_coupling=True,
+        local_equivariance=True,
+        chunk_size=None,
+        coupling_mode=coupling_mode,
+    ).double()
+
+
+@pytest.mark.parametrize(
+    ("coupling_mode", "expected_scale", "expected_global_input_scale"),
+    [("parallel", 5.0, 1.0), ("sequential", 6.0, 2.0)],
+)
+def pytest_equivariant_local_global_coupling_branch_isolation(
+    coupling_mode, expected_scale, expected_global_input_scale
+):
+    layer = _layer(coupling_mode)
+    recorder = _RecordingGlobal()
+    layer.global_layer = recorder
+    scalars = torch.randn(4, 2, dtype=torch.float64)
+    vectors = torch.randn(4, 3, 2, dtype=torch.float64)
+    positions = torch.randn(4, 3, dtype=torch.float64)
+    batch = torch.tensor([0, 0, 1, 1])
+
+    output_scalars, output_vectors = layer(scalars, vectors, positions, batch)
+    encoded_input = layer.adapter(scalars, vectors)
+
+    torch.testing.assert_close(
+        recorder.input, expected_global_input_scale * encoded_input
+    )
+    torch.testing.assert_close(output_scalars, expected_scale * scalars)
+    torch.testing.assert_close(output_vectors, expected_scale * vectors)
+
+
+@pytest.mark.parametrize("coupling_mode", ["parallel", "sequential"])
+def pytest_equivariant_local_global_modes_preserve_se3_and_backward(coupling_mode):
+    torch.manual_seed(41)
+    layer = _layer(coupling_mode)
+    scalars = torch.randn(4, 2, dtype=torch.float64, requires_grad=True)
+    vectors = torch.randn(4, 3, 2, dtype=torch.float64, requires_grad=True)
+    positions = torch.randn(4, 3, dtype=torch.float64, requires_grad=True)
+    batch = torch.tensor([0, 0, 0, 0])
+    rotation = o3.rand_matrix(dtype=torch.float64)
+    translation = torch.randn(1, 3, dtype=torch.float64)
+
+    output_scalars, output_vectors = layer(scalars, vectors, positions, batch)
+    transformed_scalars, transformed_vectors = layer(
+        scalars.detach(),
+        torch.einsum("ij,njc->nic", rotation, vectors.detach()),
+        positions.detach() @ rotation.T + translation,
+        batch,
+    )
+
+    torch.testing.assert_close(
+        transformed_scalars, output_scalars.detach(), rtol=3.0e-5, atol=5.0e-6
+    )
+    torch.testing.assert_close(
+        transformed_vectors,
+        torch.einsum("ij,njc->nic", rotation, output_vectors.detach()),
+        rtol=3.0e-5,
+        atol=5.0e-6,
+    )
+    (output_scalars.square().sum() + output_vectors.square().sum()).backward()
+    assert layer.conv.scale.grad is not None
+    assert positions.grad is not None and torch.isfinite(positions.grad).all()
+    assert any(
+        parameter.grad is not None for parameter in layer.global_layer.parameters()
+    )
+
+
+def pytest_equivariant_local_global_rejects_unknown_coupling_mode():
+    with pytest.raises(ValueError, match="parallel.*sequential"):
+        _layer("unknown")

--- a/tests/test_equivariant_mace_integration.py
+++ b/tests/test_equivariant_mace_integration.py
@@ -1,0 +1,130 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import pytest
+import torch
+from e3nn import o3
+from torch_geometric.data import Data
+
+from hydragnn.globalAtt.equivariant_local_global import EquivariantLocalGlobalConv
+from hydragnn.models.create import create_model
+from hydragnn.utils.input_config_parsing.config_utils import (
+    validate_equivariant_transformer_config,
+)
+from hydragnn.utils.model import update_multibranch_heads
+
+
+def _create_model():
+    heads = update_multibranch_heads(
+        {
+            "graph": {
+                "num_sharedlayers": 1,
+                "dim_sharedlayers": 4,
+                "num_headlayers": 1,
+                "dim_headlayers": [4],
+            }
+        }
+    )
+    return create_model(
+        mpnn_type="MACE",
+        input_dim=1,
+        hidden_dim=2,
+        output_dim=[1],
+        pe_dim=0,
+        global_attn_engine="EquivariantTransformer",
+        global_attn_type=None,
+        global_attn_heads=1,
+        output_type=["graph"],
+        output_heads=heads,
+        activation_function="relu",
+        loss_function_type="mse",
+        task_weights=[1.0],
+        num_conv_layers=2,
+        edge_dim=None,
+        num_radial=3,
+        radial_type="bessel",
+        distance_transform=None,
+        radius=3.0,
+        equivariance=True,
+        correlation=2,
+        max_ell=1,
+        node_max_ell=1,
+        avg_num_neighbors=2.0,
+        envelope_exponent=5,
+        equivariant_attn_chunk_size=2,
+        use_gpu=False,
+    )
+
+
+def _data(positions, edge_shifts=None):
+    edge_index = torch.tensor(
+        [[0, 1, 0, 2, 1, 2], [1, 0, 2, 0, 2, 1]], dtype=torch.long
+    )
+    if edge_shifts is None:
+        edge_shifts = torch.zeros(edge_index.shape[1], 3)
+    return Data(
+        x=torch.tensor([[1.0], [6.0], [8.0]]),
+        pos=positions,
+        edge_index=edge_index,
+        edge_shifts=edge_shifts,
+        batch=torch.zeros(3, dtype=torch.long),
+    )
+
+
+def pytest_mace_equivariant_transformer_forward_backward_and_se3():
+    torch.manual_seed(61)
+    model = _create_model()
+    positions = torch.tensor(
+        [[0.0, 0.0, 0.0], [1.0, 0.2, 0.0], [-0.1, 0.8, 0.3]],
+        requires_grad=True,
+    )
+    rotation = o3.rand_matrix(dtype=positions.dtype)
+    translation = torch.tensor([[-0.4, 0.9, 1.2]])
+
+    output = model(_data(positions))[0]
+    transformed_output = model(_data(positions.detach() @ rotation.T + translation))[0]
+
+    torch.testing.assert_close(
+        transformed_output, output.detach(), rtol=5.0e-5, atol=8.0e-6
+    )
+    output.square().sum().backward()
+    assert positions.grad is not None and torch.isfinite(positions.grad).all()
+    assert isinstance(model.graph_convs[0], EquivariantLocalGlobalConv)
+    assert not isinstance(model.graph_convs[-1], EquivariantLocalGlobalConv)
+    assert any(
+        parameter.grad is not None
+        for parameter in model.graph_convs[0].global_layer.parameters()
+    )
+
+
+def pytest_mace_equivariant_transformer_rejects_periodic_images():
+    model = _create_model()
+    shifts = torch.zeros(6, 3)
+    shifts[0, 0] = 3.0
+
+    with pytest.raises(ValueError, match="periodic images"):
+        model(_data(torch.randn(3, 3), edge_shifts=shifts))
+
+
+def pytest_mace_config_requires_a_tensor_hidden_layer():
+    config = {
+        "global_attn_engine": "EquivariantTransformer",
+        "mpnn_type": "MACE",
+        "global_attn_heads": 1,
+        "num_conv_layers": 1,
+        "equivariant_attn_lmax": 1,
+        "equivariant_attn_num_radial": 8,
+        "equivariant_attn_feedforward_multiplier": 2,
+        "equivariant_attn_allow_scalar_only": False,
+        "equivariant_attn_require_tensor_coupling": True,
+    }
+    with pytest.raises(ValueError, match="at least two convolution"):
+        validate_equivariant_transformer_config(config)

--- a/tests/test_equivariant_painn_integration.py
+++ b/tests/test_equivariant_painn_integration.py
@@ -73,6 +73,7 @@ def _data(positions, edge_shifts=None):
 def pytest_painn_equivariant_transformer_forward_backward_and_rotation():
     torch.manual_seed(31)
     model = _create_model()
+    assert all(conv.coupling_mode == "parallel" for conv in model.graph_convs)
     positions = torch.tensor(
         [[0.0, 0.0, 0.0], [1.0, 0.2, 0.0], [-0.1, 0.8, 0.3]],
         requires_grad=True,
@@ -117,4 +118,20 @@ def pytest_equivariant_transformer_config_rejects_untested_model_integration():
     }
 
     with pytest.raises(ValueError, match="currently supports PAINN, PNAEq"):
+        validate_equivariant_transformer_config(config)
+
+
+def pytest_equivariant_transformer_config_rejects_unknown_coupling_mode():
+    config = {
+        "global_attn_engine": "EquivariantTransformer",
+        "mpnn_type": "PAINN",
+        "global_attn_heads": 2,
+        "equivariant_attn_lmax": 1,
+        "equivariant_attn_num_radial": 8,
+        "equivariant_attn_feedforward_multiplier": 2,
+        "equivariant_attn_require_tensor_coupling": True,
+        "equivariant_attn_coupling_mode": "unknown",
+    }
+
+    with pytest.raises(ValueError, match="parallel.*sequential"):
         validate_equivariant_transformer_config(config)

--- a/tests/test_equivariant_painn_integration.py
+++ b/tests/test_equivariant_painn_integration.py
@@ -1,0 +1,120 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import pytest
+import torch
+from e3nn import o3
+from torch_geometric.data import Data
+
+from hydragnn.models.create import create_model
+from hydragnn.utils.input_config_parsing.config_utils import (
+    validate_equivariant_transformer_config,
+)
+from hydragnn.utils.model import update_multibranch_heads
+
+
+def _create_model():
+    heads = update_multibranch_heads(
+        {
+            "graph": {
+                "num_sharedlayers": 1,
+                "dim_sharedlayers": 4,
+                "num_headlayers": 1,
+                "dim_headlayers": [4],
+            }
+        }
+    )
+    return create_model(
+        mpnn_type="PAINN",
+        input_dim=1,
+        hidden_dim=4,
+        output_dim=[1],
+        pe_dim=0,
+        global_attn_engine="EquivariantTransformer",
+        global_attn_type=None,
+        global_attn_heads=2,
+        output_type=["graph"],
+        output_heads=heads,
+        activation_function="relu",
+        loss_function_type="mse",
+        task_weights=[1.0],
+        num_conv_layers=2,
+        edge_dim=None,
+        num_radial=4,
+        radius=3.0,
+        equivariance=True,
+        use_gpu=False,
+    )
+
+
+def _data(positions, edge_shifts=None):
+    edge_index = torch.tensor(
+        [[0, 1, 0, 2, 1, 2], [1, 0, 2, 0, 2, 1]], dtype=torch.long
+    )
+    if edge_shifts is None:
+        edge_shifts = torch.zeros(edge_index.shape[1], 3)
+    return Data(
+        x=torch.tensor([[0.2], [0.7], [-0.4]]),
+        pos=positions,
+        edge_index=edge_index,
+        edge_shifts=edge_shifts,
+        batch=torch.zeros(3, dtype=torch.long),
+    )
+
+
+def pytest_painn_equivariant_transformer_forward_backward_and_rotation():
+    torch.manual_seed(31)
+    model = _create_model()
+    positions = torch.tensor(
+        [[0.0, 0.0, 0.0], [1.0, 0.2, 0.0], [-0.1, 0.8, 0.3]],
+        requires_grad=True,
+    )
+    rotation = o3.rand_matrix(dtype=positions.dtype)
+    translation = torch.tensor([[0.4, -1.2, 0.7]])
+
+    output = model(_data(positions))[0]
+    transformed_output = model(_data(positions.detach() @ rotation.T + translation))[0]
+
+    torch.testing.assert_close(
+        transformed_output, output.detach(), rtol=2.0e-5, atol=3.0e-6
+    )
+    output.square().sum().backward()
+    assert positions.grad is not None and torch.isfinite(positions.grad).all()
+    assert any(
+        parameter.grad is not None
+        for convolution in model.graph_convs
+        for parameter in convolution.global_layer.parameters()
+    )
+
+
+def pytest_painn_equivariant_transformer_rejects_periodic_images():
+    model = _create_model()
+    positions = torch.randn(3, 3)
+    shifts = torch.zeros(6, 3)
+    shifts[0, 0] = 2.0
+
+    with pytest.raises(ValueError, match="periodic images"):
+        model(_data(positions, edge_shifts=shifts))
+
+
+def pytest_equivariant_transformer_config_rejects_untested_model_integration():
+    config = {
+        "global_attn_engine": "EquivariantTransformer",
+        "mpnn_type": "PNAEq",
+        "global_attn_heads": 2,
+        "equivariant_attn_lmax": 1,
+        "equivariant_attn_num_radial": 8,
+        "equivariant_attn_feedforward_multiplier": 2,
+        "equivariant_attn_require_tensor_coupling": True,
+    }
+
+    with pytest.raises(ValueError, match="currently supports PAINN"):
+        validate_equivariant_transformer_config(config)

--- a/tests/test_equivariant_pnaeq_integration.py
+++ b/tests/test_equivariant_pnaeq_integration.py
@@ -15,9 +15,6 @@ from e3nn import o3
 from torch_geometric.data import Data
 
 from hydragnn.models.create import create_model
-from hydragnn.utils.input_config_parsing.config_utils import (
-    validate_equivariant_transformer_config,
-)
 from hydragnn.utils.model import update_multibranch_heads
 
 
@@ -33,7 +30,7 @@ def _create_model():
         }
     )
     return create_model(
-        mpnn_type="PAINN",
+        mpnn_type="PNAEq",
         input_dim=1,
         hidden_dim=4,
         output_dim=[1],
@@ -48,6 +45,7 @@ def _create_model():
         task_weights=[1.0],
         num_conv_layers=2,
         edge_dim=None,
+        pna_deg=[1.0, 3.0, 2.0],
         num_radial=4,
         radius=3.0,
         equivariance=True,
@@ -70,21 +68,21 @@ def _data(positions, edge_shifts=None):
     )
 
 
-def pytest_painn_equivariant_transformer_forward_backward_and_rotation():
-    torch.manual_seed(31)
+def pytest_pnaeq_equivariant_transformer_forward_backward_and_se3():
+    torch.manual_seed(41)
     model = _create_model()
     positions = torch.tensor(
         [[0.0, 0.0, 0.0], [1.0, 0.2, 0.0], [-0.1, 0.8, 0.3]],
         requires_grad=True,
     )
     rotation = o3.rand_matrix(dtype=positions.dtype)
-    translation = torch.tensor([[0.4, -1.2, 0.7]])
+    translation = torch.tensor([[-0.3, 0.5, 1.1]])
 
     output = model(_data(positions))[0]
     transformed_output = model(_data(positions.detach() @ rotation.T + translation))[0]
 
     torch.testing.assert_close(
-        transformed_output, output.detach(), rtol=2.0e-5, atol=3.0e-6
+        transformed_output, output.detach(), rtol=3.0e-5, atol=5.0e-6
     )
     output.square().sum().backward()
     assert positions.grad is not None and torch.isfinite(positions.grad).all()
@@ -95,26 +93,11 @@ def pytest_painn_equivariant_transformer_forward_backward_and_rotation():
     )
 
 
-def pytest_painn_equivariant_transformer_rejects_periodic_images():
+def pytest_pnaeq_equivariant_transformer_rejects_periodic_images():
     model = _create_model()
     positions = torch.randn(3, 3)
     shifts = torch.zeros(6, 3)
-    shifts[0, 0] = 2.0
+    shifts[0, 1] = 2.0
 
     with pytest.raises(ValueError, match="periodic images"):
         model(_data(positions, edge_shifts=shifts))
-
-
-def pytest_equivariant_transformer_config_rejects_untested_model_integration():
-    config = {
-        "global_attn_engine": "EquivariantTransformer",
-        "mpnn_type": "SchNet",
-        "global_attn_heads": 2,
-        "equivariant_attn_lmax": 1,
-        "equivariant_attn_num_radial": 8,
-        "equivariant_attn_feedforward_multiplier": 2,
-        "equivariant_attn_require_tensor_coupling": True,
-    }
-
-    with pytest.raises(ValueError, match="currently supports PAINN and PNAEq"):
-        validate_equivariant_transformer_config(config)

--- a/tests/test_equivariant_scalar_mpnn_integration.py
+++ b/tests/test_equivariant_scalar_mpnn_integration.py
@@ -21,7 +21,7 @@ from hydragnn.utils.input_config_parsing.config_utils import (
 from hydragnn.utils.model import update_multibranch_heads
 
 
-def _create_model():
+def _create_model(mpnn_type):
     heads = update_multibranch_heads(
         {
             "graph": {
@@ -32,8 +32,24 @@ def _create_model():
             }
         }
     )
+    model_options = {}
+    if mpnn_type == "SchNet":
+        model_options.update(
+            num_gaussians=4, num_filters=4, max_neighbours=8, edge_dim=1
+        )
+    else:
+        model_options.update(
+            basis_emb_size=4,
+            envelope_exponent=5,
+            int_emb_size=4,
+            out_emb_size=8,
+            num_after_skip=1,
+            num_before_skip=1,
+            num_spherical=2,
+            edge_dim=None,
+        )
     return create_model(
-        mpnn_type="PAINN",
+        mpnn_type=mpnn_type,
         input_dim=1,
         hidden_dim=4,
         output_dim=[1],
@@ -47,11 +63,13 @@ def _create_model():
         loss_function_type="mse",
         task_weights=[1.0],
         num_conv_layers=2,
-        edge_dim=None,
         num_radial=4,
         radius=3.0,
-        equivariance=True,
+        equivariance=False,
+        equivariant_attn_allow_scalar_only=True,
+        equivariant_attn_require_tensor_coupling=False,
         use_gpu=False,
+        **model_options,
     )
 
 
@@ -66,25 +84,27 @@ def _data(positions, edge_shifts=None):
         pos=positions,
         edge_index=edge_index,
         edge_shifts=edge_shifts,
+        edge_attr=torch.zeros(edge_index.shape[1], 1),
         batch=torch.zeros(3, dtype=torch.long),
     )
 
 
-def pytest_painn_equivariant_transformer_forward_backward_and_rotation():
-    torch.manual_seed(31)
-    model = _create_model()
+@pytest.mark.parametrize("mpnn_type", ["SchNet", "DimeNet"])
+def pytest_scalar_mpnn_equivariant_transformer_forward_backward_and_se3(mpnn_type):
+    torch.manual_seed(51)
+    model = _create_model(mpnn_type)
     positions = torch.tensor(
         [[0.0, 0.0, 0.0], [1.0, 0.2, 0.0], [-0.1, 0.8, 0.3]],
         requires_grad=True,
     )
     rotation = o3.rand_matrix(dtype=positions.dtype)
-    translation = torch.tensor([[0.4, -1.2, 0.7]])
+    translation = torch.tensor([[0.6, -0.2, 1.3]])
 
     output = model(_data(positions))[0]
     transformed_output = model(_data(positions.detach() @ rotation.T + translation))[0]
 
     torch.testing.assert_close(
-        transformed_output, output.detach(), rtol=2.0e-5, atol=3.0e-6
+        transformed_output, output.detach(), rtol=3.0e-5, atol=5.0e-6
     )
     output.square().sum().backward()
     assert positions.grad is not None and torch.isfinite(positions.grad).all()
@@ -95,26 +115,49 @@ def pytest_painn_equivariant_transformer_forward_backward_and_rotation():
     )
 
 
-def pytest_painn_equivariant_transformer_rejects_periodic_images():
-    model = _create_model()
-    positions = torch.randn(3, 3)
+@pytest.mark.parametrize("mpnn_type", ["SchNet", "DimeNet"])
+def pytest_scalar_mpnn_equivariant_transformer_rejects_periodic_images(mpnn_type):
+    model = _create_model(mpnn_type)
     shifts = torch.zeros(6, 3)
-    shifts[0, 0] = 2.0
+    shifts[0, 2] = 2.0
 
     with pytest.raises(ValueError, match="periodic images"):
-        model(_data(positions, edge_shifts=shifts))
+        model(_data(torch.randn(3, 3), edge_shifts=shifts))
 
 
-def pytest_equivariant_transformer_config_rejects_untested_model_integration():
+@pytest.mark.parametrize("mpnn_type", ["SchNet", "DimeNet"])
+def pytest_scalar_mpnn_config_requires_both_safeguards(mpnn_type):
     config = {
         "global_attn_engine": "EquivariantTransformer",
-        "mpnn_type": "EGNN",
+        "mpnn_type": mpnn_type,
         "global_attn_heads": 2,
         "equivariant_attn_lmax": 1,
         "equivariant_attn_num_radial": 8,
         "equivariant_attn_feedforward_multiplier": 2,
+        "equivariant_attn_allow_scalar_only": True,
         "equivariant_attn_require_tensor_coupling": True,
+        "equivariance": False,
     }
+    with pytest.raises(ValueError, match="cannot provide tensor-valued"):
+        validate_equivariant_transformer_config(config)
 
-    with pytest.raises(ValueError, match="currently supports PAINN, PNAEq"):
+    config["equivariant_attn_require_tensor_coupling"] = False
+    config["equivariant_attn_allow_scalar_only"] = False
+    with pytest.raises(ValueError, match="allow_scalar_only"):
+        validate_equivariant_transformer_config(config)
+
+
+def pytest_schnet_config_rejects_coordinate_updates():
+    config = {
+        "global_attn_engine": "EquivariantTransformer",
+        "mpnn_type": "SchNet",
+        "global_attn_heads": 2,
+        "equivariant_attn_lmax": 1,
+        "equivariant_attn_num_radial": 8,
+        "equivariant_attn_feedforward_multiplier": 2,
+        "equivariant_attn_allow_scalar_only": True,
+        "equivariant_attn_require_tensor_coupling": False,
+        "equivariance": True,
+    }
+    with pytest.raises(ValueError, match="coordinate updates"):
         validate_equivariant_transformer_config(config)

--- a/tests/test_equivariant_transformer.py
+++ b/tests/test_equivariant_transformer.py
@@ -1,0 +1,122 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import pytest
+import torch
+from e3nn import o3
+
+from hydragnn.globalAtt.equivariant_transformer import (
+    EquivariantRMSNorm,
+    EquivariantTransformerLayer,
+)
+
+
+def _sample(dtype=torch.float64):
+    irreps = o3.Irreps("2x0e + 2x1o")
+    features = torch.randn(6, irreps.dim, dtype=dtype)
+    positions = torch.randn(6, 3, dtype=dtype)
+    batch = torch.tensor([0, 0, 0, 0, 1, 1])
+    return irreps, features, positions, batch
+
+
+def pytest_equivariant_rms_norm_is_rotation_equivariant():
+    irreps, features, _, _ = _sample()
+    norm = EquivariantRMSNorm(irreps).double()
+    rotation = o3.rand_matrix(dtype=torch.float64)
+    representation = irreps.D_from_matrix(rotation)
+
+    transformed = norm(features @ representation.T)
+    expected = norm(features) @ representation.T
+
+    torch.testing.assert_close(transformed, expected, rtol=2.0e-5, atol=3.0e-6)
+    torch.testing.assert_close(
+        norm(features).square().mean(dim=-1),
+        torch.ones(features.shape[0], dtype=torch.float64),
+        rtol=1.0e-7,
+        atol=1.0e-7,
+    )
+
+
+def pytest_equivariant_transformer_layer_preserves_se3_equivariance():
+    torch.manual_seed(21)
+    irreps, features, positions, batch = _sample()
+    layer = EquivariantTransformerLayer(
+        irreps, heads=2, lmax=1, feedforward_multiplier=2
+    ).double()
+    rotation = o3.rand_matrix(dtype=torch.float64)
+    translation = torch.randn(1, 3, dtype=torch.float64)
+    representation = irreps.D_from_matrix(rotation)
+
+    output = layer(features, positions, batch)
+    transformed_output = layer(
+        features @ representation.T,
+        positions @ rotation.T + translation,
+        batch,
+    )
+
+    torch.testing.assert_close(
+        transformed_output,
+        output @ representation.T,
+        rtol=3.0e-5,
+        atol=5.0e-6,
+    )
+
+
+def pytest_equivariant_transformer_layer_is_permutation_equivariant():
+    torch.manual_seed(22)
+    irreps, features, positions, batch = _sample()
+    layer = EquivariantTransformerLayer(irreps, heads=2, lmax=1).double()
+    permutation = torch.tensor([3, 0, 2, 1, 5, 4])
+
+    output = layer(features, positions, batch)
+    permuted_output = layer(
+        features[permutation], positions[permutation], batch[permutation]
+    )
+
+    torch.testing.assert_close(permuted_output, output[permutation])
+
+
+def pytest_equivariant_transformer_layer_handles_singleton_graphs_and_backward():
+    torch.manual_seed(23)
+    irreps = o3.Irreps("2x0e + 2x1o")
+    features = torch.randn(2, irreps.dim, dtype=torch.float64, requires_grad=True)
+    positions = torch.randn(2, 3, dtype=torch.float64, requires_grad=True)
+    batch = torch.tensor([0, 1])
+    layer = EquivariantTransformerLayer(irreps, heads=2, lmax=1).double()
+
+    output = layer(features, positions, batch)
+    output.square().sum().backward()
+
+    assert output.shape == features.shape
+    assert torch.isfinite(output).all()
+    assert features.grad is not None and torch.isfinite(features.grad).all()
+    # With no geometric pairs, the layer is correctly independent of position.
+    assert positions.grad is None
+
+
+@pytest.mark.parametrize(
+    ("edge_index", "message"),
+    [
+        (torch.tensor([[0], [0]]), "self-pairs"),
+        (torch.tensor([[0], [2]]), "cross-graph"),
+    ],
+)
+def pytest_equivariant_transformer_layer_rejects_invalid_explicit_pairs(
+    edge_index, message
+):
+    irreps = o3.Irreps("1x0e + 1x1o")
+    layer = EquivariantTransformerLayer(irreps)
+    features = torch.randn(3, irreps.dim)
+    positions = torch.randn(3, 3)
+    batch = torch.tensor([0, 0, 1])
+
+    with pytest.raises(ValueError, match=message):
+        layer(features, positions, batch, edge_index=edge_index)

--- a/tests/test_equivariant_transformer.py
+++ b/tests/test_equivariant_transformer.py
@@ -120,3 +120,15 @@ def pytest_equivariant_transformer_layer_rejects_invalid_explicit_pairs(
 
     with pytest.raises(ValueError, match=message):
         layer(features, positions, batch, edge_index=edge_index)
+
+
+def pytest_equivariant_transformer_rejects_tensor_coupling_without_tensor_irreps():
+    with pytest.raises(ValueError, match="requires at least one non-scalar"):
+        EquivariantTransformerLayer("4x0e")
+
+    # Scalar-only operation remains available, but must be explicit.
+    layer = EquivariantTransformerLayer("4x0e", require_tensor_coupling=False)
+    features = torch.randn(3, 4)
+    positions = torch.randn(3, 3)
+    output = layer(features, positions, torch.tensor([0, 0, 0]))
+    assert output.shape == features.shape


### PR DESCRIPTION
## Summary

This draft replaces the closed EquiformerV2 prototype in #378 with a clean design for a new HydraGNN global-attention engine.

The proposed `EquivariantTransformer` is a GraphGPS-style hybrid that combines a local equivariant MPNN with explicitly SE(3)-equivariant all-to-all attention. It uses invariant scalar attention logits and equivariant tensor-product values over complete per-graph connectivity.

## Why a new architecture

EquiformerV2 is a local equivariant Transformer and should not be represented as an all-to-all global-attention wrapper. AllScAIP provides all-to-all attention but learns rotational equivariance rather than encoding it through irreducible tensor operations. This design targets the combination that HydraGNN does not currently provide: explicit tensor equivariance plus direct global communication.

## Current commit

The initial commit defines:

- the mathematical equivariance contract
- complete-graph and batching semantics
- explicit adapters for PaiNN/PNAEq and MACE feature layouts
- the reason EGNN and scalar-only MPNNs are initially unsupported
- finite-system and periodic-boundary scope
- dense and chunked execution requirements
- the required symmetry, parity, gradient, and integration test matrix

## Planned implementation

- invariant query-key contractions for attention weights
- spherical-harmonic tensor-product value messages
- equivariant residual, normalization, and feed-forward paths
- PaiNN/PNAEq and MACE adapters
- per-graph all-to-all construction with a chunked production path
- rotation, translation, permutation, batching, gradient, and adapter tests

## Status

Draft: architecture specification is ready; implementation and validation remain in progress.
