### PR TITLE
Add reusable materials preprocessing utilities

### DIFF
--- a/docs/materials_preprocessing.md
+++ b/docs/materials_preprocessing.md
@@ -1,0 +1,16 @@
+# Materials preprocessing utilities
+
+HydraGNN normalizes material stresses to full symmetric `3 x 3` tensors in
+eV/Å³ with tensile stress positive. Dataset adapters must state their source
+unit and sign convention when calling `normalize_stress`; this prevents unit
+or sign assumptions from being hidden in individual example loaders.
+
+`validate_materials_sample` checks the common atomistic schema before scalable
+serialization: positions, atomic numbers, forces, optional cell and stress,
+finite values, consistent atom counts, and self-loop-free graph connectivity.
+It raises a field-specific `ValueError` so distributed preprocessors can count
+and report rejected records.
+
+MPTrj and OMat24 are the first consumers. MPTrj converts VASP stress from kbar
+with compression positive. OMat24 receives ASE stress already expressed in
+eV/Å³ with tension positive.

--- a/examples/mptrj/train.py
+++ b/examples/mptrj/train.py
@@ -38,6 +38,7 @@ from hydragnn.utils.datasets.pickledataset import (
     SimplePickleWriter,
     SimplePickleDataset,
 )
+from hydragnn.utils.materials import normalize_stress, validate_materials_sample
 from hydragnn.preprocess.graph_samples_checks_and_updates import gather_deg
 from hydragnn.preprocess.graph_samples_checks_and_updates import (
     RadiusGraph,
@@ -197,6 +198,11 @@ class MPTrjDataset(AbstractBaseDataset):
                 energy = torch.tensor(total_energy, dtype=torch.float32).unsqueeze(0)
                 energy_per_atom = energy.detach().clone() / natoms
                 forces = torch.tensor(forces, dtype=torch.float32)
+                stress = normalize_stress(
+                    stresses,
+                    source_unit="kbar",
+                    source_sign="compression_positive",
+                )
                 x = torch.cat([atomic_numbers, pos, forces], dim=1)
 
                 # Calculate chemical composition
@@ -221,7 +227,7 @@ class MPTrjDataset(AbstractBaseDataset):
                     x=x,
                     energy=energy,
                     energy_per_atom=energy_per_atom,
-                    # stress=torch.tensor(stresses, dtype=torch.float32),
+                    stress=stress,
                     # magmom=torch.tensor(magmom, dtype=torch.float32),
                     forces=forces,
                     graph_attr=graph_attr,
@@ -247,15 +253,11 @@ class MPTrjDataset(AbstractBaseDataset):
                     data_object = self.radius_graph(data_object)
                     data_object = transform_coordinates(data_object)
 
-                # Skip samples that still contain self-loops
-                if data_object.edge_index is not None:
-                    loop_mask = data_object.edge_index[0] != data_object.edge_index[1]
-                    if not torch.all(loop_mask):
-                        print(
-                            "Skipping sample: self-loops detected in edge_index.",
-                            flush=True,
-                        )
-                        continue
+                try:
+                    validate_materials_sample(data_object, require_stress=True)
+                except ValueError as error:
+                    print(f"Skipping sample: {error}", flush=True)
+                    continue
 
                 # Default edge_shifts for when radius_graph_pbc is not activated
                 if not hasattr(data_object, "edge_shifts"):

--- a/examples/open_materials_2024/omat24.py
+++ b/examples/open_materials_2024/omat24.py
@@ -24,9 +24,9 @@ from hydragnn.preprocess.graph_samples_checks_and_updates import (
     PBCLocalCartesian,
     pbc_as_tensor,
     gather_deg,
-    should_skip_self_loops,
 )
 from hydragnn.utils.distributed import nsplit
+from hydragnn.utils.materials import normalize_stress, validate_materials_sample
 from utils import balance_load
 
 # transform_coordinates = Spherical(norm=False, cat=False)
@@ -199,6 +199,11 @@ class OMat2024(AbstractBaseDataset):
 
             energy_per_atom = energy.detach().clone() / natoms
             forces = torch.as_tensor(atoms.get_forces(), dtype=torch.float32)
+            stress = normalize_stress(
+                atoms.get_stress(apply_constraint=False, voigt=False),
+                source_unit="ev_per_angstrom_cubed",
+                source_sign="tension_positive",
+            )
 
             chemical_formula = atoms.get_chemical_formula()
 
@@ -260,6 +265,7 @@ class OMat2024(AbstractBaseDataset):
                 energy=energy,
                 energy_per_atom=energy_per_atom,
                 forces=forces,
+                stress=stress,
                 graph_attr=graph_attr,
             )
 
@@ -283,9 +289,11 @@ class OMat2024(AbstractBaseDataset):
                 data_object = self.radius_graph(data_object)
                 data_object = transform_coordinates(data_object)
 
-            # Skip samples that still contain self-loops
-            if should_skip_self_loops(data_object, context="omat24"):
-                continue
+            try:
+                validate_materials_sample(data_object, require_stress=True)
+            except ValueError as error:
+                print(f"Skipping sample: {error}. Context: omat24", flush=True)
+                return
 
             # Default edge_shifts for when radius_graph_pbc is not activated
             if not hasattr(data_object, "edge_shifts"):

--- a/hydragnn/utils/materials/__init__.py
+++ b/hydragnn/utils/materials/__init__.py
@@ -1,0 +1,14 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+from .preprocessing import normalize_stress, validate_materials_sample
+
+__all__ = ["normalize_stress", "validate_materials_sample"]

--- a/hydragnn/utils/materials/preprocessing.py
+++ b/hydragnn/utils/materials/preprocessing.py
@@ -1,0 +1,118 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+"""Dataset-independent preprocessing helpers for atomistic materials data."""
+
+from typing import Literal
+
+import torch
+
+GPA_PER_EV_PER_ANGSTROM_CUBED = 160.21766208
+
+StressUnit = Literal["ev_per_angstrom_cubed", "gpa", "kbar"]
+StressSign = Literal["tension_positive", "compression_positive"]
+
+
+def _voigt_to_full(stress: torch.Tensor) -> torch.Tensor:
+    """Convert ASE-order Voigt stress ``[xx, yy, zz, yz, xz, xy]`` to 3x3."""
+    xx, yy, zz, yz, xz, xy = stress.unbind()
+    return torch.stack(
+        (
+            torch.stack((xx, xy, xz)),
+            torch.stack((xy, yy, yz)),
+            torch.stack((xz, yz, zz)),
+        )
+    )
+
+
+def normalize_stress(
+    stress,
+    *,
+    source_unit: StressUnit,
+    source_sign: StressSign,
+    dtype: torch.dtype = torch.float32,
+) -> torch.Tensor:
+    """Return a symmetric 3x3 stress tensor in eV/Å³, positive in tension.
+
+    One-dimensional input uses ASE's Voigt ordering
+    ``[xx, yy, zz, yz, xz, xy]``. Full tensors must already be symmetric;
+    silently symmetrizing malformed source data would hide conversion errors.
+    """
+    value = torch.as_tensor(stress, dtype=dtype)
+    if value.shape == (6,):
+        value = _voigt_to_full(value)
+    elif value.shape != (3, 3):
+        raise ValueError("stress must have shape (6,) or (3, 3)")
+    if not torch.isfinite(value).all():
+        raise ValueError("stress contains non-finite values")
+    if not torch.allclose(value, value.T, rtol=1.0e-5, atol=1.0e-7):
+        raise ValueError("stress tensor must be symmetric")
+
+    unit_scale = {
+        "ev_per_angstrom_cubed": 1.0,
+        "gpa": 1.0 / GPA_PER_EV_PER_ANGSTROM_CUBED,
+        "kbar": 0.1 / GPA_PER_EV_PER_ANGSTROM_CUBED,
+    }
+    if source_unit not in unit_scale:
+        raise ValueError(f"unsupported stress unit: {source_unit}")
+    if source_sign not in {"tension_positive", "compression_positive"}:
+        raise ValueError(f"unsupported stress sign convention: {source_sign}")
+
+    sign = -1.0 if source_sign == "compression_positive" else 1.0
+    return value * (sign * unit_scale[source_unit])
+
+
+def validate_materials_sample(data, *, require_stress: bool = False):
+    """Validate fields required for scalable atomistic serialization.
+
+    The validated object is returned unchanged so this helper composes easily
+    with dataset pipelines. Invalid samples raise ``ValueError`` with a field-
+    specific reason, allowing callers to count and report rejected records.
+    """
+    required = ("pos", "atomic_numbers", "forces")
+    for name in required:
+        value = getattr(data, name, None)
+        if value is None:
+            raise ValueError(f"materials sample is missing {name}")
+        if not torch.isfinite(value).all():
+            raise ValueError(f"{name} contains non-finite values")
+
+    num_nodes = data.pos.shape[0]
+    if data.pos.shape != (num_nodes, 3):
+        raise ValueError("pos must have shape [N, 3]")
+    if data.forces.shape != (num_nodes, 3):
+        raise ValueError("forces must have shape [N, 3]")
+    if data.atomic_numbers.shape not in {(num_nodes,), (num_nodes, 1)}:
+        raise ValueError("atomic_numbers must have shape [N] or [N, 1]")
+
+    cell = getattr(data, "cell", None)
+    if cell is not None and cell.shape not in {(3, 3), (1, 3, 3)}:
+        raise ValueError("cell must have shape [3, 3] or [1, 3, 3]")
+
+    stress = getattr(data, "stress", None)
+    if require_stress and stress is None:
+        raise ValueError("materials sample is missing stress")
+    if stress is not None:
+        if stress.shape != (3, 3):
+            raise ValueError("stress must have shape [3, 3]")
+        if not torch.isfinite(stress).all():
+            raise ValueError("stress contains non-finite values")
+        if not torch.allclose(stress, stress.T, rtol=1.0e-5, atol=1.0e-7):
+            raise ValueError("stress tensor must be symmetric")
+
+    edge_index = getattr(data, "edge_index", None)
+    if edge_index is not None and edge_index.numel() > 0:
+        if edge_index.ndim != 2 or edge_index.shape[0] != 2:
+            raise ValueError("edge_index must have shape [2, E]")
+        if torch.any(edge_index[0] == edge_index[1]):
+            raise ValueError("edge_index contains self-loops")
+
+    return data

--- a/tests/test_materials_preprocessing.py
+++ b/tests/test_materials_preprocessing.py
@@ -1,0 +1,102 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import pytest
+import torch
+from torch_geometric.data import Data
+
+from hydragnn.utils.materials import normalize_stress, validate_materials_sample
+from hydragnn.utils.materials.preprocessing import (
+    GPA_PER_EV_PER_ANGSTROM_CUBED,
+)
+
+
+def _sample(**updates):
+    values = {
+        "pos": torch.zeros(2, 3),
+        "atomic_numbers": torch.tensor([[1.0], [8.0]]),
+        "forces": torch.zeros(2, 3),
+        "cell": torch.eye(3),
+        "stress": torch.eye(3),
+        "edge_index": torch.tensor([[0, 1], [1, 0]]),
+    }
+    values.update(updates)
+    return Data(**values)
+
+
+def pytest_normalize_vasp_kbar_stress_and_expand_voigt():
+    stress = normalize_stress(
+        [10.0, 20.0, 30.0, 4.0, 5.0, 6.0],
+        source_unit="kbar",
+        source_sign="compression_positive",
+        dtype=torch.float64,
+    )
+    expected = (
+        -0.1
+        * torch.tensor(
+            [[10.0, 6.0, 5.0], [6.0, 20.0, 4.0], [5.0, 4.0, 30.0]],
+            dtype=torch.float64,
+        )
+        / GPA_PER_EV_PER_ANGSTROM_CUBED
+    )
+    torch.testing.assert_close(stress, expected)
+
+
+def pytest_normalize_stress_preserves_ase_convention():
+    stress = torch.tensor([[1.0, 0.2, 0.0], [0.2, 2.0, 0.3], [0.0, 0.3, 3.0]])
+    output = normalize_stress(
+        stress,
+        source_unit="ev_per_angstrom_cubed",
+        source_sign="tension_positive",
+    )
+    torch.testing.assert_close(output, stress)
+
+
+@pytest.mark.parametrize(
+    ("stress", "message"),
+    [
+        (torch.zeros(2, 2), "shape"),
+        (
+            torch.tensor([[0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+            "symmetric",
+        ),
+        (
+            torch.tensor([[float("nan"), 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]]),
+            "non-finite",
+        ),
+    ],
+)
+def pytest_normalize_stress_rejects_malformed_input(stress, message):
+    with pytest.raises(ValueError, match=message):
+        normalize_stress(
+            stress,
+            source_unit="gpa",
+            source_sign="tension_positive",
+        )
+
+
+def pytest_validate_materials_sample_accepts_consistent_data():
+    sample = _sample()
+    assert validate_materials_sample(sample, require_stress=True) is sample
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({"forces": torch.zeros(3, 3)}, "forces"),
+        ({"pos": torch.tensor([[float("nan"), 0.0, 0.0], [0.0, 0.0, 0.0]])}, "pos"),
+        ({"stress": torch.zeros(6)}, "stress"),
+        ({"edge_index": torch.tensor([[0, 1], [0, 0]])}, "self-loops"),
+    ],
+)
+def pytest_validate_materials_sample_rejects_invalid_data(updates, message):
+    with pytest.raises(ValueError, match=message):
+        validate_materials_sample(_sample(**updates), require_stress=True)


### PR DESCRIPTION
## Summary

- add dataset-independent stress normalization to symmetric 3x3 eV/Å³ tensors with an explicit sign convention
- add common atomistic sample validation for shapes, finite values, self-loops, and optional stress
- migrate MPTrj and OMat24 preprocessing to the shared utilities
- document the convention and add focused regression tests

## Scope

This PR intentionally excludes downloader refactoring, distributed preprocessing orchestration, model architecture, and training changes.

## Validation

- `python -m pytest -q tests/test_materials_preprocessing.py` (10 passed)
- Black check on all changed Python files
- `compileall` on the shared utility and migrated adapters
- `git diff --check`