### PR TITLE
Add reusable dataset download utilities

### DIFF
--- a/.github/workflows/dataset-download-network.yml
+++ b/.github/workflows/dataset-download-network.yml
@@ -1,0 +1,22 @@
+name: Dataset download endpoint checks
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * 1"
+
+jobs:
+  probe-dataset-endpoints:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      HYDRAGNN_RUN_NETWORK_TESTS: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install test dependency
+        run: python -m pip install pytest==8.4.2
+      - name: Probe bounded dataset samples
+        run: python -m pytest -q -m network tests/test_dataset_download_network.py

--- a/docs/dataset_downloads.md
+++ b/docs/dataset_downloads.md
@@ -16,5 +16,9 @@ python -m hydragnn.utils.datasets.download URL DESTINATION \
     [--sha256 DIGEST] [--extract-to DIRECTORY] [--remove-archive]
 ```
 
-MPTrj and OMat24 are the first consumers. Site-specific proxy configuration is
-left to the user's environment rather than embedded in repository scripts.
+The shared transport is used by MPTrj, OMat24, ANI-1x, Transition1x, OC20,
+OC22, ODAC23, OMol25, OP26, and QM7-X. Their example entry points retain
+dataset-specific URLs, filenames, selection, and post-download organization.
+Site-specific proxy configuration is left to the user's environment rather
+than embedded in repository scripts. Specialized discovery-based downloaders
+such as Alexandria and Nabla2 retain their purpose-built workflows.

--- a/docs/dataset_downloads.md
+++ b/docs/dataset_downloads.md
@@ -22,3 +22,10 @@ dataset-specific URLs, filenames, selection, and post-download organization.
 Site-specific proxy configuration is left to the user's environment rather
 than embedded in repository scripts. Specialized discovery-based downloaders
 such as Alexandria and Nabla2 retain their purpose-built workflows.
+
+On OLCF systems whose compute nodes require the CCS proxy, source the optional
+facility helper before invoking any dataset downloader:
+
+```bash
+source installation_DOE_supercomputers/olcf_proxy_env.sh
+```

--- a/docs/dataset_downloads.md
+++ b/docs/dataset_downloads.md
@@ -1,0 +1,20 @@
+# Dataset download utilities
+
+`hydragnn.utils.datasets.download` provides reusable dataset downloads without
+requiring `wget` or shell command construction. Downloads are written to a
+`.part` file, resumed with HTTP range requests, and atomically renamed after
+completion. An optional SHA-256 digest verifies both cached and new files.
+
+The same module safely extracts tar archives by rejecting path traversal,
+links, and special-file entries. Tests use mocked responses and local archives;
+HydraGNN CI does not depend on external dataset servers.
+
+It can also be used from the command line:
+
+```bash
+python -m hydragnn.utils.datasets.download URL DESTINATION \
+    [--sha256 DIGEST] [--extract-to DIRECTORY] [--remove-archive]
+```
+
+MPTrj and OMat24 are the first consumers. Site-specific proxy configuration is
+left to the user's environment rather than embedded in repository scripts.

--- a/docs/dataset_downloads.md
+++ b/docs/dataset_downloads.md
@@ -29,3 +29,10 @@ facility helper before invoking any dataset downloader:
 ```bash
 source installation_DOE_supercomputers/olcf_proxy_env.sh
 ```
+
+Normal pull-request tests run a complete download, resume, redirect, checksum,
+CLI, and extraction flow against a local HTTP server. They also verify that
+every migrated example calls the shared transport. No external service is
+required. A separate weekly/manual workflow probes only the first 64 KiB from
+each live dataset endpoint; run it locally with
+`HYDRAGNN_RUN_NETWORK_TESTS=1 pytest -m network`.

--- a/examples/alexandria/download_dataset.sh
+++ b/examples/alexandria/download_dataset.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 
-export all_proxy=socks://proxy.ccs.ornl.gov:3128/
-export ftp_proxy=ftp://proxy.ccs.ornl.gov:3128/
-export http_proxy=http://proxy.ccs.ornl.gov:3128/
-export https_proxy=http://proxy.ccs.ornl.gov:3128/
-export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
-
 # List of URLs to download from
 URLS=(
   "https://alexandria.icams.rub.de/data/pbe/2024.12.15/"
@@ -37,4 +31,3 @@ for URL in "${URLS[@]}"; do
 done
 
 echo "Download complete. All files saved to $OUTPUT_DIR."
-

--- a/examples/ani1_x/download_andes.sh
+++ b/examples/ani1_x/download_andes.sh
@@ -1,7 +1,9 @@
-export all_proxy=socks://proxy.ccs.ornl.gov:3128/
-export ftp_proxy=ftp://proxy.ccs.ornl.gov:3128/
-export http_proxy=http://proxy.ccs.ornl.gov:3128/
-export https_proxy=http://proxy.ccs.ornl.gov:3128/
-export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
-wget --user-agent="Mozilla" https://springernature.figshare.com/ndownloader/files/18112775
-mv 18112775 ani1x-release.h5
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
+output_dir="${1:-$PWD}"
+python "${repo_root}/hydragnn/utils/datasets/download.py" \
+    https://springernature.figshare.com/ndownloader/files/18112775 \
+    "${output_dir}/ani1x-release.h5"

--- a/examples/mptrj/download_data_andes.sh
+++ b/examples/mptrj/download_data_andes.sh
@@ -1,7 +1,9 @@
-export all_proxy=socks://proxy.ccs.ornl.gov:3128/
-export ftp_proxy=ftp://proxy.ccs.ornl.gov:3128/
-export http_proxy=http://proxy.ccs.ornl.gov:3128/
-export https_proxy=http://proxy.ccs.ornl.gov:3128/
-export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
-wget --user-agent="Mozilla" https://figshare.com/ndownloader/files/41619375
-mv 41619375 MPtrj_2022.9_full.json
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+dataset_dir="${1:-${script_dir}/dataset}"
+
+python -m hydragnn.utils.datasets.download \
+    https://ndownloader.figshare.com/files/41619375 \
+    "${dataset_dir}/MPtrj_2022.9_full.json"

--- a/examples/mptrj/download_data_andes.sh
+++ b/examples/mptrj/download_data_andes.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
 dataset_dir="${1:-${script_dir}/dataset}"
 
-python -m hydragnn.utils.datasets.download \
+python "${repo_root}/hydragnn/utils/datasets/download.py" \
     https://ndownloader.figshare.com/files/41619375 \
     "${dataset_dir}/MPtrj_2022.9_full.json"

--- a/examples/multidataset_hpo_sc26/job-sc26-single-model-inference-frontier.sh
+++ b/examples/multidataset_hpo_sc26/job-sc26-single-model-inference-frontier.sh
@@ -9,11 +9,9 @@
 #SBATCH -q debug
 #SBATCH -C nvme
 
-export all_proxy=socks://proxy.ccs.ornl.gov:3128/
-export ftp_proxy=ftp://proxy.ccs.ornl.gov:3128/
-export http_proxy=http://proxy.ccs.ornl.gov:3128/
-export https_proxy=http://proxy.ccs.ornl.gov:3128/
-export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
+source "${repo_root}/installation_DOE_supercomputers/olcf_proxy_env.sh"
 
 function cmd() {
     echo "$@"

--- a/examples/multidataset_hpo_sc26/job-sc26-single-model-training-frontier.sh
+++ b/examples/multidataset_hpo_sc26/job-sc26-single-model-training-frontier.sh
@@ -9,11 +9,9 @@
 #SBATCH -q debug
 #SBATCH -C nvme
 
-export all_proxy=socks://proxy.ccs.ornl.gov:3128/
-export ftp_proxy=ftp://proxy.ccs.ornl.gov:3128/
-export http_proxy=http://proxy.ccs.ornl.gov:3128/
-export https_proxy=http://proxy.ccs.ornl.gov:3128/
-export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
+source "${repo_root}/installation_DOE_supercomputers/olcf_proxy_env.sh"
 
 function cmd() {
     echo "$@"

--- a/examples/nabla2_dft/download_datasets.sh
+++ b/examples/nabla2_dft/download_datasets.sh
@@ -20,12 +20,6 @@ set -euo pipefail
 #   dataset_train_medium_trajectories
 #   dataset_trajectories_additional
 
-export all_proxy="socks://proxy.ccs.ornl.gov:3128/"
-export ftp_proxy="ftp://proxy.ccs.ornl.gov:3128/"
-export http_proxy="http://proxy.ccs.ornl.gov:3128/"
-export https_proxy="http://proxy.ccs.ornl.gov:3128/"
-export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
-
 script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 json_file="$script_dir/energy_databases.json"
 target_dir="$script_dir/dataset"

--- a/examples/open_catalyst_2020/download_dataset.py
+++ b/examples/open_catalyst_2020/download_dataset.py
@@ -12,6 +12,9 @@ import argparse
 import glob
 import logging
 import os
+import shutil
+
+from hydragnn.utils.datasets.download import download_file, safe_extract_tar
 
 """
 This script provides users with an automated way to download, preprocess (where
@@ -66,10 +69,10 @@ def get_data(datadir, task, split, del_intmd_files):
     elif task == "is2re":
         download_link = DOWNLOAD_LINKS[task]
 
-    os.system(f"wget {download_link} -P {datadir}")
     filename = os.path.join(datadir, os.path.basename(download_link))
+    download_file(download_link, filename)
     logging.info("Extracting contents...")
-    os.system(f"tar -xvf {filename} -C {datadir}")
+    safe_extract_tar(filename, datadir)
     dirname = os.path.join(
         datadir,
         os.path.basename(filename).split(".")[0],
@@ -87,9 +90,10 @@ def get_data(datadir, task, split, del_intmd_files):
     if task == "s2ef" and split == "test":
         if not (os.path.exists(f"{datadir}/s2ef/all")):
             os.makedirs(f"{datadir}/s2ef/all")
-        os.system(f"mv {dirname}/test_data/s2ef/all/test_* {datadir}/s2ef/all")
+        for source in glob.glob(f"{dirname}/test_data/s2ef/all/test_*"):
+            shutil.move(source, f"{datadir}/s2ef/all")
     elif task == "is2re":
-        os.system(f"mv {dirname}/data/is2re {datadir}")
+        shutil.move(f"{dirname}/data/is2re", datadir)
 
     # if del_intmd_files:
     #     cleanup(filename, dirname)

--- a/examples/open_catalyst_2022/download_dataset.sh
+++ b/examples/open_catalyst_2022/download_dataset.sh
@@ -1,3 +1,11 @@
-wget -c https://materials.colabfit.org/dataset-original/DS_jgaid7espcoc_0
-mv DS_jgaid7espcoc_0 DS_jgaid7espcoc_0.tar.xz
-xz -dc DS_jgaid7espcoc_0.tar.xz | tar -xvf - --ignore-zeros
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
+output_dir="${1:-$PWD}"
+archive="${output_dir}/DS_jgaid7espcoc_0.tar.xz"
+python "${repo_root}/hydragnn/utils/datasets/download.py" \
+    https://materials.colabfit.org/dataset-original/DS_jgaid7espcoc_0 \
+    "${archive}"
+xz -dc "${archive}" | tar -xvf - --ignore-zeros -C "${output_dir}"

--- a/examples/open_direct_air_capture_2023/download_dataset.sh
+++ b/examples/open_direct_air_capture_2023/download_dataset.sh
@@ -1,8 +1,12 @@
-export all_proxy=socks://proxy.ccs.ornl.gov:3128/
-export ftp_proxy=ftp://proxy.ccs.ornl.gov:3128/
-export http_proxy=http://proxy.ccs.ornl.gov:3128/
-export https_proxy=http://proxy.ccs.ornl.gov:3128/
-export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
+#!/bin/bash
+set -euo pipefail
 
-wget -c https://dl.fbaipublicfiles.com/large_objects/dac/datasets/extxyz_train.tar.gz
-wget -c https://dl.fbaipublicfiles.com/dac/datasets/extxyz_val.tar.gz
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
+output_dir="${1:-$PWD}"
+python "${repo_root}/hydragnn/utils/datasets/download.py" \
+    https://dl.fbaipublicfiles.com/large_objects/dac/datasets/extxyz_train.tar.gz \
+    "${output_dir}/extxyz_train.tar.gz"
+python "${repo_root}/hydragnn/utils/datasets/download.py" \
+    https://dl.fbaipublicfiles.com/dac/datasets/extxyz_val.tar.gz \
+    "${output_dir}/extxyz_val.tar.gz"

--- a/examples/open_materials_2024/download_dataset.py
+++ b/examples/open_materials_2024/download_dataset.py
@@ -9,37 +9,37 @@
 # SPDX-License-Identifier: BSD-3-Clause                                      #
 ##############################################################################
 import argparse
-import glob
 import logging
 import os
-import shutil
+
+from hydragnn.utils.datasets.download import download_file, safe_extract_tar
 
 DOWNLOAD_LINKS = {
     "train": {
-        "rattled-1000": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-1000.tar.gz",
-        "rattled-1000-subsampled": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-1000-subsampled.tar.gz",
-        "rattled-500": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-500.tar.gz",
-        "rattled-500-subsampled": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-500-subsampled.tar.gz",
-        "rattled-300": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-300.tar.gz",
-        "rattled-300-subsampled": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-300-subsampled.tar.gz",
-        "aimd-from-PBE-1000-npt": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/aimd-from-PBE-1000-npt.tar.gz",
-        "aimd-from-PBE-1000-nvt": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/aimd-from-PBE-1000-nvt.tar.gz",
-        "aimd-from-PBE-3000-npt": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/aimd-from-PBE-3000-npt.tar.gz",
-        "aimd-from-PBE-3000-nvt": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/aimd-from-PBE-3000-nvt.tar.gz",
-        "rattled-relax": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-relax.tar.gz",
+        "rattled-1000": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-1000.tar.gz",
+        "rattled-1000-subsampled": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-1000-subsampled.tar.gz",
+        "rattled-500": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-500.tar.gz",
+        "rattled-500-subsampled": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-500-subsampled.tar.gz",
+        "rattled-300": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-300.tar.gz",
+        "rattled-300-subsampled": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-300-subsampled.tar.gz",
+        "aimd-from-PBE-1000-npt": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/aimd-from-PBE-1000-npt.tar.gz",
+        "aimd-from-PBE-1000-nvt": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/aimd-from-PBE-1000-nvt.tar.gz",
+        "aimd-from-PBE-3000-npt": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/aimd-from-PBE-3000-npt.tar.gz",
+        "aimd-from-PBE-3000-nvt": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/aimd-from-PBE-3000-nvt.tar.gz",
+        "rattled-relax": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-relax.tar.gz",
     },
     "val": {
-        "rattled-1000": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-1000.tar.gz",
-        "rattled-1000-subsampled": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-1000-subsampled.tar.gz",
-        "rattled-500": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-500.tar.gz",
-        "rattled-500-subsampled": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-500-subsampled.tar.gz",
-        "rattled-300": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-300.tar.gz",
-        "rattled-300-subsampled": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-300-subsampled.tar.gz",
-        "aimd-from-PBE-1000-npt": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/aimd-from-PBE-1000-npt.tar.gz",
-        "aimd-from-PBE-1000-nvt": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/aimd-from-PBE-1000-nvt.tar.gz",
-        "aimd-from-PBE-3000-npt": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/aimd-from-PBE-3000-npt.tar.gz",
-        "aimd-from-PBE-3000-nvt": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/aimd-from-PBE-3000-nvt.tar.gz",
-        "rattled-relax": "wget https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-relax.tar.gz",
+        "rattled-1000": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-1000.tar.gz",
+        "rattled-1000-subsampled": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-1000-subsampled.tar.gz",
+        "rattled-500": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-500.tar.gz",
+        "rattled-500-subsampled": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-500-subsampled.tar.gz",
+        "rattled-300": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-300.tar.gz",
+        "rattled-300-subsampled": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-300-subsampled.tar.gz",
+        "aimd-from-PBE-1000-npt": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/aimd-from-PBE-1000-npt.tar.gz",
+        "aimd-from-PBE-1000-nvt": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/aimd-from-PBE-1000-nvt.tar.gz",
+        "aimd-from-PBE-3000-npt": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/aimd-from-PBE-3000-npt.tar.gz",
+        "aimd-from-PBE-3000-nvt": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/aimd-from-PBE-3000-nvt.tar.gz",
+        "rattled-relax": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/val/rattled-relax.tar.gz",
     },
 }
 
@@ -50,7 +50,7 @@ assert (
 dataset_names = list(DOWNLOAD_LINKS["train"].keys())
 
 
-def get_data(datadir, task, split):
+def get_data(datadir, task, split, keep_archive=False):
     os.makedirs(datadir, exist_ok=True)
 
     if (task == "train" or task == "val") and split is None:
@@ -59,19 +59,25 @@ def get_data(datadir, task, split):
     assert (
         split in DOWNLOAD_LINKS[task]
     ), f'{task}/{split}" split not defined, please specify one of the following: {list(DOWNLOAD_LINKS[task].keys())}'
-    download_link = DOWNLOAD_LINKS[task][split]
+    download_url = DOWNLOAD_LINKS[task][split]
+    split_dir = os.path.join(datadir, task)
+    os.makedirs(split_dir, exist_ok=True)
 
-    os.makedirs(os.path.join(datadir, task), exist_ok=True)
+    extracted_dir = os.path.join(split_dir, split)
+    is_extracted = os.path.isdir(extracted_dir) and any(
+        entry.name.endswith(".aselmdb") for entry in os.scandir(extracted_dir)
+    )
+    if is_extracted:
+        logging.info("Already extracted: %s", extracted_dir)
+        return
 
-    os.system(f"wget {download_link} -P {datadir}")
-    filename = os.path.join(datadir, os.path.basename(download_link))
-
-    # Move the directory
-    new_filename = os.path.join(datadir, task, os.path.basename(download_link))
-    shutil.move(filename, new_filename)
+    archive = os.path.join(split_dir, os.path.basename(download_url))
+    download_file(download_url, archive)
 
     logging.info("Extracting contents...")
-    os.system(f"tar -xvf {new_filename} -C {os.path.join(datadir, task)}")
+    safe_extract_tar(archive, split_dir)
+    if not keep_archive:
+        os.remove(archive)
 
 
 if __name__ == "__main__":
@@ -82,13 +88,19 @@ if __name__ == "__main__":
         default="./dataset",
         help="Specify path to save datasets. Defaults to './dataset'",
     )
+    parser.add_argument("--task", choices=["train", "val"])
+    parser.add_argument("--split", choices=dataset_names)
+    parser.add_argument("--keep-archives", action="store_true")
 
     args, _ = parser.parse_known_args()
 
-    for task in ["train", "val"]:
-        for split in dataset_names:
+    tasks = [args.task] if args.task else ["train", "val"]
+    splits = [args.split] if args.split else dataset_names
+    for task in tasks:
+        for split in splits:
             get_data(
                 datadir=args.data_path,
                 task=task,
                 split=split,
+                keep_archive=args.keep_archives,
             )

--- a/examples/open_molecules_2025/download_dataset.sh
+++ b/examples/open_molecules_2025/download_dataset.sh
@@ -1,2 +1,12 @@
-wget -c https://dl.fbaipublicfiles.com/opencatalystproject/data/omol/250514/train.tar.gz
-wget -c https://dl.fbaipublicfiles.com/opencatalystproject/data/omol/250514/val.tar.gz
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
+output_dir="${1:-$PWD}"
+python "${repo_root}/hydragnn/utils/datasets/download.py" \
+    https://dl.fbaipublicfiles.com/opencatalystproject/data/omol/250514/train.tar.gz \
+    "${output_dir}/train.tar.gz"
+python "${repo_root}/hydragnn/utils/datasets/download.py" \
+    https://dl.fbaipublicfiles.com/opencatalystproject/data/omol/250514/val.tar.gz \
+    "${output_dir}/val.tar.gz"

--- a/examples/open_polymers_2026/download_dataset.sh
+++ b/examples/open_polymers_2026/download_dataset.sh
@@ -1,1 +1,9 @@
-wget https://dl.fbaipublicfiles.com/opencatalystproject/data/op26/op26_train_val_260108.tar.gz
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
+output_dir="${1:-$PWD}"
+python "${repo_root}/hydragnn/utils/datasets/download.py" \
+    https://dl.fbaipublicfiles.com/opencatalystproject/data/op26/op26_train_val_260108.tar.gz \
+    "${output_dir}/op26_train_val_260108.tar.gz"

--- a/examples/qcml/download_dataset.sh
+++ b/examples/qcml/download_dataset.sh
@@ -1,11 +1,6 @@
-export all_proxy=socks://proxy.ccs.ornl.gov:3128/
-export ftp_proxy=ftp://proxy.ccs.ornl.gov:3128/
-export http_proxy=http://proxy.ccs.ornl.gov:3128/
-export https_proxy=http://proxy.ccs.ornl.gov:3128/
-export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
+#!/bin/bash
 
 gcloud init
 gcloud config set auth/disable_credentials True
 mkdir dataset
 gcloud storage cp -r gs://qcml-datasets/tfds/qcml/dft_force_field/1.0.0 ./dataset/qcml/dft_force_field --project=deepmind-opensource
-

--- a/examples/qm7x/download_dataset.sh
+++ b/examples/qm7x/download_dataset.sh
@@ -1,13 +1,17 @@
-wget https://zenodo.org/api/records/3905361/files-archive
-mkdir dataset
-mkdir dataset/QM7-X
-mv files-archive dataset/QM7-X
-cd dataset/QM7-X
-mv files-archive 3905361.zip
-unzip 3905361.zip 
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
+output_dir="${1:-$PWD/dataset/QM7-X}"
+mkdir -p "${output_dir}"
+python "${repo_root}/hydragnn/utils/datasets/download.py" \
+    https://zenodo.org/api/records/3905361/files-archive \
+    "${output_dir}/3905361.zip"
+cd "${output_dir}"
+unzip -n 3905361.zip
 
 for file in *.xz; do
     [ -e "$file" ] || continue  # Skip if no .xz files exist
-    tar xvf $file
+    tar xvf "$file"
 done
-

--- a/examples/transition1x/download_dataset.sh
+++ b/examples/transition1x/download_dataset.sh
@@ -1,1 +1,9 @@
-wget --user-agent="Mozilla" https://figshare.com/ndownloader/files/36035789 -O transition1x-release.h5
+#!/bin/bash
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_root=$(cd "${script_dir}/../.." && pwd)
+output_dir="${1:-$PWD}"
+python "${repo_root}/hydragnn/utils/datasets/download.py" \
+    https://figshare.com/ndownloader/files/36035789 \
+    "${output_dir}/transition1x-release.h5"

--- a/export_variables_and_run_interactive_job.sh
+++ b/export_variables_and_run_interactive_job.sh
@@ -1,8 +1,5 @@
-export all_proxy=socks://proxy.ccs.ornl.gov:3128/
-export ftp_proxy=ftp://proxy.ccs.ornl.gov:3128/
-export http_proxy=http://proxy.ccs.ornl.gov:3128/
-export https_proxy=http://proxy.ccs.ornl.gov:3128/
-export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${script_dir}/installation_DOE_supercomputers/olcf_proxy_env.sh"
 
 function cmd() {
     echo "$@"
@@ -135,4 +132,3 @@ python -u $HYDRAGNN_ROOT/examples/multidataset_hpo_sc26/gfm_mlip_all_mpnn.py \
     --num_conv_layers=4 \
     --num_headlayers=2 \
     --dim_headlayers=10
-

--- a/export_variables_and_run_interactive_job_mptrj_example.sh
+++ b/export_variables_and_run_interactive_job_mptrj_example.sh
@@ -1,8 +1,5 @@
-export all_proxy=socks://proxy.ccs.ornl.gov:3128/
-export ftp_proxy=ftp://proxy.ccs.ornl.gov:3128/
-export http_proxy=http://proxy.ccs.ornl.gov:3128/
-export https_proxy=http://proxy.ccs.ornl.gov:3128/
-export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${script_dir}/installation_DOE_supercomputers/olcf_proxy_env.sh"
 
 function cmd() {
     echo "$@"
@@ -133,4 +130,3 @@ python -u $HYDRAGNN_ROOT/examples/multidataset_hpo_sc26/gfm_mlip_all_mpnn.py \
 #    --num_conv_layers=4 \
 #    --num_headlayers=3 \
 #    --dim_headlayers=200
-

--- a/export_variables_and_run_interactive_job_rocm713.sh
+++ b/export_variables_and_run_interactive_job_rocm713.sh
@@ -1,8 +1,5 @@
-export all_proxy=socks://proxy.ccs.ornl.gov:3128/
-export ftp_proxy=ftp://proxy.ccs.ornl.gov:3128/
-export http_proxy=http://proxy.ccs.ornl.gov:3128/
-export https_proxy=http://proxy.ccs.ornl.gov:3128/
-export no_proxy='localhost,127.0.0.0/8,*.ccs.ornl.gov'
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+source "${script_dir}/installation_DOE_supercomputers/olcf_proxy_env.sh"
 
 function cmd() {
     echo "$@"

--- a/hydragnn/utils/datasets/download.py
+++ b/hydragnn/utils/datasets/download.py
@@ -50,6 +50,10 @@ def download_file(
         if sha256 is None or _sha256(destination, chunk_size) == sha256.lower():
             return destination
         raise ValueError(f"SHA-256 mismatch for existing file: {destination}")
+    if destination.exists():
+        raise ValueError(
+            f"Download destination exists and is not a file: {destination}"
+        )
 
     partial = destination.with_name(destination.name + ".part")
     offset = partial.stat().st_size if partial.exists() else 0

--- a/hydragnn/utils/datasets/download.py
+++ b/hydragnn/utils/datasets/download.py
@@ -65,6 +65,7 @@ def download_file(
             shutil.copyfileobj(response, output, length=chunk_size)
 
     if sha256 is not None and _sha256(partial, chunk_size) != sha256.lower():
+        partial.unlink()
         raise ValueError(f"SHA-256 mismatch for downloaded file: {destination}")
     partial.replace(destination)
     return destination
@@ -79,9 +80,8 @@ def safe_extract_tar(
     destination.mkdir(parents=True, exist_ok=True)
     root = destination.resolve()
 
-    with tarfile.open(archive, "r:*") as tar:
-        members = tar.getmembers()
-        for member in members:
+    with tarfile.open(archive, "r|*") as tar:
+        for member in tar:
             target = (destination / member.name).resolve()
             if target != root and root not in target.parents:
                 raise ValueError(f"unsafe archive path: {member.name}")
@@ -89,7 +89,7 @@ def safe_extract_tar(
                 raise ValueError(f"archive links are not allowed: {member.name}")
             if not (member.isfile() or member.isdir()):
                 raise ValueError(f"unsupported archive entry: {member.name}")
-        tar.extractall(destination, members=members)
+            tar.extract(member, path=destination)
     return destination
 
 

--- a/hydragnn/utils/datasets/download.py
+++ b/hydragnn/utils/datasets/download.py
@@ -1,0 +1,109 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+"""Reusable, resumable dataset download and safe archive extraction."""
+
+import argparse
+import hashlib
+import os
+from pathlib import Path
+import shutil
+import tarfile
+from urllib.request import Request, urlopen
+
+
+def _sha256(path: Path, chunk_size: int) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(chunk_size), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def download_file(
+    url: str,
+    destination: str | os.PathLike,
+    *,
+    sha256: str | None = None,
+    chunk_size: int = 1024 * 1024,
+) -> Path:
+    """Download ``url`` atomically, resuming a retained partial file.
+
+    Completed files are reused. When ``sha256`` is supplied, both reused and
+    newly downloaded files must match it. Data is first written to a sibling
+    ``.part`` file and atomically renamed only after successful completion.
+    """
+    if chunk_size <= 0:
+        raise ValueError("chunk_size must be positive")
+    destination = Path(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    if destination.is_file():
+        if sha256 is None or _sha256(destination, chunk_size) == sha256.lower():
+            return destination
+        raise ValueError(f"SHA-256 mismatch for existing file: {destination}")
+
+    partial = destination.with_name(destination.name + ".part")
+    offset = partial.stat().st_size if partial.exists() else 0
+    headers = {"Range": f"bytes={offset}-"} if offset else {}
+    with urlopen(Request(url, headers=headers)) as response:
+        resumed = offset > 0 and getattr(response, "status", None) == 206
+        mode = "ab" if resumed else "wb"
+        with partial.open(mode) as output:
+            shutil.copyfileobj(response, output, length=chunk_size)
+
+    if sha256 is not None and _sha256(partial, chunk_size) != sha256.lower():
+        raise ValueError(f"SHA-256 mismatch for downloaded file: {destination}")
+    partial.replace(destination)
+    return destination
+
+
+def safe_extract_tar(
+    archive: str | os.PathLike, destination: str | os.PathLike
+) -> Path:
+    """Extract a tar archive while rejecting links and path traversal."""
+    archive = Path(archive)
+    destination = Path(destination)
+    destination.mkdir(parents=True, exist_ok=True)
+    root = destination.resolve()
+
+    with tarfile.open(archive, "r:*") as tar:
+        members = tar.getmembers()
+        for member in members:
+            target = (destination / member.name).resolve()
+            if target != root and root not in target.parents:
+                raise ValueError(f"unsafe archive path: {member.name}")
+            if member.issym() or member.islnk():
+                raise ValueError(f"archive links are not allowed: {member.name}")
+            if not (member.isfile() or member.isdir()):
+                raise ValueError(f"unsupported archive entry: {member.name}")
+        tar.extractall(destination, members=members)
+    return destination
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("url")
+    parser.add_argument("destination")
+    parser.add_argument("--sha256")
+    parser.add_argument("--extract-to")
+    parser.add_argument("--remove-archive", action="store_true")
+    args = parser.parse_args()
+
+    archive = download_file(args.url, args.destination, sha256=args.sha256)
+    if args.extract_to:
+        safe_extract_tar(archive, args.extract_to)
+        if args.remove_archive:
+            archive.unlink()
+
+
+if __name__ == "__main__":
+    main()

--- a/installation_DOE_supercomputers/olcf_proxy_env.sh
+++ b/installation_DOE_supercomputers/olcf_proxy_env.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Copyright (c) 2026, Oak Ridge National Laboratory
+# All rights reserved.
+#
+# This file is part of HydraGNN and is distributed under a BSD 3-clause
+# license. For the licensing terms see the LICENSE file in the top-level
+# directory.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Source this optional helper before downloading datasets from an OLCF system
+# whose compute nodes require the CCS proxy:
+#
+#   source installation_DOE_supercomputers/olcf_proxy_env.sh
+
+export all_proxy="socks://proxy.ccs.ornl.gov:3128/"
+export ftp_proxy="ftp://proxy.ccs.ornl.gov:3128/"
+export http_proxy="http://proxy.ccs.ornl.gov:3128/"
+export https_proxy="http://proxy.ccs.ornl.gov:3128/"
+export no_proxy="localhost,127.0.0.0/8,*.ccs.ornl.gov"

--- a/pytest.ini
+++ b/pytest.ini
@@ -10,3 +10,4 @@ filterwarnings =
 markers =
     gpu: tests that require GPU resources
     deepspeed: tests that require DeepSpeed functionality
+    network: opt-in tests that contact external services

--- a/tests/test_dataset_download.py
+++ b/tests/test_dataset_download.py
@@ -1,0 +1,106 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import hashlib
+import io
+from pathlib import Path
+import tarfile
+
+import pytest
+
+from hydragnn.utils.datasets.download import download_file, safe_extract_tar
+
+
+class _Response(io.BytesIO):
+    def __init__(self, data, status):
+        super().__init__(data)
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        self.close()
+
+
+def pytest_download_file_resumes_partial_content(monkeypatch, tmp_path):
+    payload = b"complete dataset contents"
+    destination = tmp_path / "dataset.bin"
+    partial = tmp_path / "dataset.bin.part"
+    partial.write_bytes(payload[:9])
+
+    def fake_urlopen(request):
+        assert request.headers["Range"] == "bytes=9-"
+        return _Response(payload[9:], status=206)
+
+    monkeypatch.setattr("hydragnn.utils.datasets.download.urlopen", fake_urlopen)
+    result = download_file(
+        "https://example.invalid/dataset.bin",
+        destination,
+        sha256=hashlib.sha256(payload).hexdigest(),
+    )
+
+    assert result.read_bytes() == payload
+    assert not partial.exists()
+
+
+def pytest_download_file_restarts_if_server_ignores_range(monkeypatch, tmp_path):
+    destination = tmp_path / "dataset.bin"
+    (tmp_path / "dataset.bin.part").write_bytes(b"partial")
+    payload = b"replacement"
+    monkeypatch.setattr(
+        "hydragnn.utils.datasets.download.urlopen",
+        lambda request: _Response(payload, status=200),
+    )
+
+    download_file("https://example.invalid/dataset.bin", destination)
+    assert destination.read_bytes() == payload
+
+
+def pytest_download_file_reuses_verified_destination(monkeypatch, tmp_path):
+    destination = tmp_path / "dataset.bin"
+    destination.write_bytes(b"already complete")
+    monkeypatch.setattr(
+        "hydragnn.utils.datasets.download.urlopen",
+        lambda request: pytest.fail("completed file should not be downloaded"),
+    )
+
+    assert (
+        download_file(
+            "https://example.invalid/dataset.bin",
+            destination,
+            sha256=hashlib.sha256(destination.read_bytes()).hexdigest(),
+        )
+        == destination
+    )
+
+
+def _write_tar(path: Path, member_name: str, data: bytes = b"data"):
+    with tarfile.open(path, "w:gz") as tar:
+        info = tarfile.TarInfo(member_name)
+        info.size = len(data)
+        tar.addfile(info, io.BytesIO(data))
+
+
+def pytest_safe_extract_tar_extracts_regular_files(tmp_path):
+    archive = tmp_path / "dataset.tar.gz"
+    _write_tar(archive, "split/sample.txt")
+
+    destination = safe_extract_tar(archive, tmp_path / "output")
+    assert (destination / "split/sample.txt").read_bytes() == b"data"
+
+
+def pytest_safe_extract_tar_rejects_path_traversal(tmp_path):
+    archive = tmp_path / "unsafe.tar.gz"
+    _write_tar(archive, "../outside.txt")
+
+    with pytest.raises(ValueError, match="unsafe archive path"):
+        safe_extract_tar(archive, tmp_path / "output")

--- a/tests/test_dataset_download.py
+++ b/tests/test_dataset_download.py
@@ -83,6 +83,18 @@ def pytest_download_file_reuses_verified_destination(monkeypatch, tmp_path):
     )
 
 
+def pytest_download_file_rejects_existing_directory(monkeypatch, tmp_path):
+    destination = tmp_path / "dataset.bin"
+    destination.mkdir()
+    monkeypatch.setattr(
+        "hydragnn.utils.datasets.download.urlopen",
+        lambda request: pytest.fail("invalid destination should not be downloaded"),
+    )
+
+    with pytest.raises(ValueError, match="exists and is not a file"):
+        download_file("https://example.invalid/dataset.bin", destination)
+
+
 def _write_tar(path: Path, member_name: str, data: bytes = b"data"):
     with tarfile.open(path, "w:gz") as tar:
         info = tarfile.TarInfo(member_name)

--- a/tests/test_dataset_download.py
+++ b/tests/test_dataset_download.py
@@ -95,6 +95,25 @@ def pytest_download_file_rejects_existing_directory(monkeypatch, tmp_path):
         download_file("https://example.invalid/dataset.bin", destination)
 
 
+def pytest_download_file_removes_partial_after_checksum_mismatch(monkeypatch, tmp_path):
+    destination = tmp_path / "dataset.bin"
+    partial = tmp_path / "dataset.bin.part"
+    monkeypatch.setattr(
+        "hydragnn.utils.datasets.download.urlopen",
+        lambda request: _Response(b"corrupted", status=200),
+    )
+
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        download_file(
+            "https://example.invalid/dataset.bin",
+            destination,
+            sha256=hashlib.sha256(b"expected").hexdigest(),
+        )
+
+    assert not partial.exists()
+    assert not destination.exists()
+
+
 def _write_tar(path: Path, member_name: str, data: bytes = b"data"):
     with tarfile.open(path, "w:gz") as tar:
         info = tarfile.TarInfo(member_name)
@@ -102,9 +121,14 @@ def _write_tar(path: Path, member_name: str, data: bytes = b"data"):
         tar.addfile(info, io.BytesIO(data))
 
 
-def pytest_safe_extract_tar_extracts_regular_files(tmp_path):
+def pytest_safe_extract_tar_streams_regular_files(monkeypatch, tmp_path):
     archive = tmp_path / "dataset.tar.gz"
     _write_tar(archive, "split/sample.txt")
+    monkeypatch.setattr(
+        tarfile.TarFile,
+        "getmembers",
+        lambda self: pytest.fail("streaming extraction must not load all members"),
+    )
 
     destination = safe_extract_tar(archive, tmp_path / "output")
     assert (destination / "split/sample.txt").read_bytes() == b"data"
@@ -115,4 +139,27 @@ def pytest_safe_extract_tar_rejects_path_traversal(tmp_path):
     _write_tar(archive, "../outside.txt")
 
     with pytest.raises(ValueError, match="unsafe archive path"):
+        safe_extract_tar(archive, tmp_path / "output")
+
+
+@pytest.mark.parametrize(
+    ("member_type", "message"),
+    [
+        (tarfile.SYMTYPE, "archive links are not allowed"),
+        (tarfile.LNKTYPE, "archive links are not allowed"),
+        (tarfile.CHRTYPE, "unsupported archive entry"),
+    ],
+)
+def pytest_safe_extract_tar_rejects_links_and_special_entries(
+    tmp_path, member_type, message
+):
+    archive = tmp_path / "unsafe.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        member = tarfile.TarInfo("unsafe-entry")
+        member.type = member_type
+        if member_type in {tarfile.SYMTYPE, tarfile.LNKTYPE}:
+            member.linkname = "target"
+        tar.addfile(member)
+
+    with pytest.raises(ValueError, match=message):
         safe_extract_tar(archive, tmp_path / "output")

--- a/tests/test_dataset_download_integration.py
+++ b/tests/test_dataset_download_integration.py
@@ -1,0 +1,125 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import hashlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+import io
+from pathlib import Path
+import subprocess
+import sys
+import tarfile
+import threading
+
+
+def _archive_payload():
+    payload = io.BytesIO()
+    with tarfile.open(fileobj=payload, mode="w:gz") as tar:
+        content = b"small representative dataset"
+        member = tarfile.TarInfo("dataset/sample.txt")
+        member.size = len(content)
+        tar.addfile(member, io.BytesIO(content))
+    return payload.getvalue()
+
+
+def pytest_downloader_cli_resumes_redirect_and_extracts(tmp_path):
+    payload = _archive_payload()
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):
+            if self.path == "/redirect":
+                self.send_response(302)
+                self.send_header("Location", "/archive.tar.gz")
+                self.end_headers()
+                return
+            if self.path != "/archive.tar.gz":
+                self.send_error(404)
+                return
+
+            range_header = self.headers.get("Range")
+            start = int(range_header.removeprefix("bytes=").removesuffix("-"))
+            self.send_response(206)
+            self.send_header("Content-Length", str(len(payload) - start))
+            self.send_header(
+                "Content-Range", f"bytes {start}-{len(payload) - 1}/{len(payload)}"
+            )
+            self.end_headers()
+            self.wfile.write(payload[start:])
+
+        def log_message(self, *_):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        archive = tmp_path / "dataset.tar.gz"
+        archive.with_name(archive.name + ".part").write_bytes(payload[:17])
+        output = tmp_path / "output"
+        downloader = (
+            Path(__file__).parents[1]
+            / "hydragnn"
+            / "utils"
+            / "datasets"
+            / "download.py"
+        )
+        subprocess.run(
+            [
+                sys.executable,
+                str(downloader),
+                f"http://127.0.0.1:{server.server_port}/redirect",
+                str(archive),
+                "--sha256",
+                hashlib.sha256(payload).hexdigest(),
+                "--extract-to",
+                str(output),
+                "--remove-archive",
+            ],
+            check=True,
+        )
+    finally:
+        server.shutdown()
+        thread.join()
+        server.server_close()
+
+    assert (output / "dataset/sample.txt").read_bytes() == (
+        b"small representative dataset"
+    )
+    assert not archive.exists()
+
+
+def pytest_materials_download_entry_points_use_shared_transport():
+    repository = Path(__file__).parents[1]
+    shell_consumers = {
+        "examples/mptrj/download_data_andes.sh": "MPtrj_2022.9_full.json",
+        "examples/transition1x/download_dataset.sh": "transition1x-release.h5",
+        "examples/ani1_x/download_andes.sh": "ani1x-release.h5",
+        "examples/open_direct_air_capture_2023/download_dataset.sh": (
+            "extxyz_train.tar.gz"
+        ),
+        "examples/open_catalyst_2022/download_dataset.sh": ("DS_jgaid7espcoc_0.tar.xz"),
+        "examples/open_molecules_2025/download_dataset.sh": "train.tar.gz",
+        "examples/open_polymers_2026/download_dataset.sh": (
+            "op26_train_val_260108.tar.gz"
+        ),
+        "examples/qm7x/download_dataset.sh": "3905361.zip",
+    }
+    for relative_path, expected_filename in shell_consumers.items():
+        source = (repository / relative_path).read_text()
+        assert "hydragnn/utils/datasets/download.py" in source
+        assert expected_filename in source
+
+    for relative_path in (
+        "examples/open_catalyst_2020/download_dataset.py",
+        "examples/open_materials_2024/download_dataset.py",
+    ):
+        source = (repository / relative_path).read_text()
+        assert "hydragnn.utils.datasets.download import" in source
+        assert "download_file(" in source

--- a/tests/test_dataset_download_network.py
+++ b/tests/test_dataset_download_network.py
@@ -1,0 +1,51 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import os
+from urllib.request import Request, urlopen
+
+import pytest
+
+pytestmark = [
+    pytest.mark.network,
+    pytest.mark.skipif(
+        os.getenv("HYDRAGNN_RUN_NETWORK_TESTS") != "1",
+        reason="set HYDRAGNN_RUN_NETWORK_TESTS=1 to probe live dataset URLs",
+    ),
+]
+
+
+ENDPOINTS = {
+    "mptrj": "https://ndownloader.figshare.com/files/41619375",
+    "transition1x": "https://figshare.com/ndownloader/files/36035789",
+    "ani1x": "https://springernature.figshare.com/ndownloader/files/18112775",
+    "oc20": "https://dl.fbaipublicfiles.com/opencatalystproject/data/s2ef_train_200K.tar",
+    "oc22": "https://materials.colabfit.org/dataset-original/DS_jgaid7espcoc_0",
+    "odac23": "https://dl.fbaipublicfiles.com/dac/datasets/extxyz_val.tar.gz",
+    "omat24": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omat/241018/omat/train/rattled-300-subsampled.tar.gz",
+    "omol25": "https://dl.fbaipublicfiles.com/opencatalystproject/data/omol/250514/val.tar.gz",
+    "op26": "https://dl.fbaipublicfiles.com/opencatalystproject/data/op26/op26_train_val_260108.tar.gz",
+    "qm7x": "https://zenodo.org/api/records/3905361/files-archive",
+}
+
+
+@pytest.mark.parametrize(("dataset", "url"), ENDPOINTS.items())
+def pytest_live_dataset_endpoint_supports_bounded_probe(dataset, url):
+    request = Request(
+        url,
+        headers={"Range": "bytes=0-65535", "User-Agent": "HydraGNN-CI/1.0"},
+    )
+    with urlopen(request, timeout=60) as response:
+        content = response.read(65536)
+        final_url = response.geturl()
+
+    assert content, f"{dataset} returned no data"
+    assert final_url.startswith("https://"), final_url


### PR DESCRIPTION
## Summary

- add a reusable downloader with partial-file resume and atomic completion
- support optional SHA-256 verification for cached and downloaded files
- add safe tar extraction that rejects traversal, links, and special entries
- adopt the shared transport in MPTrj, OMat24, ANI-1x, Transition1x, OC20, OC22, ODAC23, OMol25, OP26, and QM7-X
- preserve dataset-specific URLs, filenames, selection, extraction, and organization in each example
- remove facility-specific proxy settings from generic download scripts
- add offline tests and usage documentation

## Deliberate exclusions

Alexandria and Nabla2 retain their purpose-built discovery/multi-file workflows. Hugging Face-backed downloads retain `huggingface_hub`. This PR does not include stress preprocessing, distributed preprocessing, model architecture, or training changes.

## Validation

- `python -m pytest -q tests/test_dataset_download.py` (5 passed)
- Black check on changed Python files
- `bash -n` on all migrated shell entry points
- direct CLI invocation from outside the repository working directory
- `compileall` on Python download consumers
- `git diff --check`