### PR TITLE
Add cost-aware graph batching

### DIFF
--- a/docs/cost_aware_batching.md
+++ b/docs/cost_aware_batching.md
@@ -23,6 +23,8 @@ node budget:
 optional secondary bound for datasets containing many small graphs. The number
 of graphs per batch is therefore variable; `batch_size` is ignored in this
 mode and remains available for configurations using the default `fixed` mode.
+When `drop_last` is enabled, the final batch is dropped unless it reaches
+either `max_nodes` or the configured `max_graphs` limit.
 
 The `oversized_sample` policy controls graphs larger than `max_nodes`:
 

--- a/docs/cost_aware_batching.md
+++ b/docs/cost_aware_batching.md
@@ -34,6 +34,9 @@ Shuffling is reproducible from `seed + epoch`. The core sampler also accepts
 precomputed costs, allowing dataset implementations to avoid loading every
 sample merely to determine its size.
 
-The initial implementation supports single-process loading. Distributed
-cost-aware allocation will be added separately; enabling `node_budget` after a
-distributed process group is initialized raises an explicit error.
+In distributed training, all ranks construct the same cost-bounded batches.
+HydraGNN groups similarly sized batches into distributed steps, assigns one to
+each rank, and rotates rank assignments to avoid repeatedly giving the largest
+batch to the same rank. Batches are padded by repetition so every rank executes
+the same number of optimizer steps. Setting `drop_last` discards the incomplete
+final distributed step instead.

--- a/docs/cost_aware_batching.md
+++ b/docs/cost_aware_batching.md
@@ -34,6 +34,10 @@ Shuffling is reproducible from `seed + epoch`. The core sampler also accepts
 precomputed costs, allowing dataset implementations to avoid loading every
 sample merely to determine its size.
 
+DDStore-backed `DistDataset` instances expose their global node counts from
+existing variable-shape metadata. Batch planning therefore performs no DDStore
+payload reads: each rank retrieves only the samples assigned to its batches.
+
 In distributed training, all ranks construct the same cost-bounded batches.
 HydraGNN groups similarly sized batches into distributed steps, assigns one to
 each rank, and rotates rank assignments to avoid repeatedly giving the largest

--- a/docs/cost_aware_batching.md
+++ b/docs/cost_aware_batching.md
@@ -1,0 +1,39 @@
+# Cost-aware graph batching
+
+Graph datasets can contain samples with very different numbers of nodes. A
+fixed number of graphs per batch can consequently produce large variations in
+memory use and execution time. HydraGNN can instead construct batches using a
+node budget:
+
+```json
+"Training": {
+    "batch_size": 32,
+    "Batching": {
+        "mode": "node_budget",
+        "max_nodes": 4096,
+        "max_graphs": 64,
+        "oversized_sample": "error",
+        "shuffle": true,
+        "seed": 0
+    }
+}
+```
+
+`max_nodes` limits the sum of graph nodes in a batch. `max_graphs` is an
+optional secondary bound for datasets containing many small graphs. The number
+of graphs per batch is therefore variable; `batch_size` is ignored in this
+mode and remains available for configurations using the default `fixed` mode.
+
+The `oversized_sample` policy controls graphs larger than `max_nodes`:
+
+- `error` (default) stops immediately and identifies the sample.
+- `single` places the graph alone in a batch that exceeds the budget.
+- `skip` omits the graph and records it in the sampler diagnostics.
+
+Shuffling is reproducible from `seed + epoch`. The core sampler also accepts
+precomputed costs, allowing dataset implementations to avoid loading every
+sample merely to determine its size.
+
+The initial implementation supports single-process loading. Distributed
+cost-aware allocation will be added separately; enabling `node_budget` after a
+distributed process group is initialized raises an explicit error.

--- a/hydragnn/preprocess/__init__.py
+++ b/hydragnn/preprocess/__init__.py
@@ -23,7 +23,12 @@ from .graph_samples_checks_and_updates import (
 )
 
 from .stratified_sampling import stratified_sampling
-from .batch_sampler import BatchStatistics, CostAwareBatchSampler, graph_node_cost
+from .batch_sampler import (
+    BatchStatistics,
+    CostAwareBatchSampler,
+    DistributedCostAwareBatchSampler,
+    graph_node_cost,
+)
 
 from .load_data import (
     dataset_loading_and_splitting,

--- a/hydragnn/preprocess/__init__.py
+++ b/hydragnn/preprocess/__init__.py
@@ -23,6 +23,7 @@ from .graph_samples_checks_and_updates import (
 )
 
 from .stratified_sampling import stratified_sampling
+from .batch_sampler import BatchStatistics, CostAwareBatchSampler, graph_node_cost
 
 from .load_data import (
     dataset_loading_and_splitting,

--- a/hydragnn/preprocess/__init__.py
+++ b/hydragnn/preprocess/__init__.py
@@ -28,6 +28,7 @@ from .batch_sampler import (
     CostAwareBatchSampler,
     DistributedCostAwareBatchSampler,
     graph_node_cost,
+    graph_node_costs,
 )
 
 from .load_data import (

--- a/hydragnn/preprocess/batch_sampler.py
+++ b/hydragnn/preprocess/batch_sampler.py
@@ -1,0 +1,170 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+"""Cost-aware batching for variable-size graph datasets."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Sequence
+from dataclasses import dataclass
+import math
+
+import torch
+from torch.utils.data import Sampler
+
+
+@dataclass(frozen=True)
+class BatchStatistics:
+    """Summary of the batches constructed for one sampler epoch."""
+
+    num_batches: int
+    num_samples: int
+    skipped_samples: int
+    min_cost: int
+    max_cost: int
+    mean_cost: float
+
+
+def graph_node_cost(sample) -> int:
+    """Return the number of nodes in a graph-like sample."""
+    value = getattr(sample, "num_nodes", None)
+    if value is None:
+        features = getattr(sample, "x", None)
+        if features is None:
+            raise ValueError("sample has neither num_nodes nor node features x")
+        value = len(features)
+    return int(value)
+
+
+class CostAwareBatchSampler(Sampler[list[int]]):
+    """Pack dataset samples into batches bounded by an additive cost.
+
+    Sample order is shuffled deterministically from ``seed + epoch``. Batches
+    are then constructed greedily, retaining dataset order when shuffling is
+    disabled. Costs are computed once and cached for the sampler lifetime.
+
+    Args:
+        dataset: Indexable dataset.
+        max_cost: Maximum summed cost of an ordinary batch.
+        cost_fn: Function mapping a dataset sample to a positive integer cost.
+        costs: Optional precomputed costs, avoiding sample materialization.
+        max_graphs: Optional maximum number of samples in a batch.
+        shuffle: Whether to shuffle samples before packing.
+        seed: Base seed used for deterministic epoch shuffling.
+        oversized_sample: Policy for a sample whose cost exceeds ``max_cost``:
+            ``"error"``, ``"single"``, or ``"skip"``.
+        drop_last: Drop the final batch when its cost is below ``max_cost``.
+    """
+
+    def __init__(
+        self,
+        dataset,
+        max_cost: int,
+        *,
+        cost_fn: Callable[[object], int] = graph_node_cost,
+        costs: Sequence[int] | None = None,
+        max_graphs: int | None = None,
+        shuffle: bool = True,
+        seed: int = 0,
+        oversized_sample: str = "error",
+        drop_last: bool = False,
+    ) -> None:
+        if max_cost <= 0:
+            raise ValueError("max_cost must be positive")
+        if max_graphs is not None and max_graphs <= 0:
+            raise ValueError("max_graphs must be positive when provided")
+        if oversized_sample not in {"error", "single", "skip"}:
+            raise ValueError("oversized_sample must be one of: error, single, skip")
+
+        self.dataset = dataset
+        self.max_cost = int(max_cost)
+        self.max_graphs = max_graphs
+        self.shuffle = shuffle
+        self.seed = int(seed)
+        self.oversized_sample = oversized_sample
+        self.drop_last = drop_last
+        self.epoch = 0
+
+        if costs is None:
+            costs = [cost_fn(dataset[index]) for index in range(len(dataset))]
+        if len(costs) != len(dataset):
+            raise ValueError("costs must contain one value per dataset sample")
+        self.costs = tuple(int(cost) for cost in costs)
+        if any(cost <= 0 for cost in self.costs):
+            raise ValueError("all sample costs must be positive")
+
+    def set_epoch(self, epoch: int) -> None:
+        """Select the deterministic ordering for an epoch."""
+        self.epoch = int(epoch)
+
+    def _ordered_indices(self) -> list[int]:
+        if not self.shuffle:
+            return list(range(len(self.dataset)))
+        generator = torch.Generator().manual_seed(self.seed + self.epoch)
+        return torch.randperm(len(self.dataset), generator=generator).tolist()
+
+    def _batches(self) -> tuple[list[list[int]], int]:
+        batches: list[list[int]] = []
+        batch: list[int] = []
+        batch_cost = 0
+        skipped = 0
+
+        for index in self._ordered_indices():
+            cost = self.costs[index]
+            if cost > self.max_cost:
+                if self.oversized_sample == "error":
+                    raise ValueError(
+                        f"sample {index} has cost {cost}, exceeding max_cost "
+                        f"{self.max_cost}"
+                    )
+                if self.oversized_sample == "skip":
+                    skipped += 1
+                    continue
+                if batch:
+                    batches.append(batch)
+                    batch, batch_cost = [], 0
+                batches.append([index])
+                continue
+
+            exceeds_cost = batch_cost + cost > self.max_cost
+            exceeds_graphs = (
+                self.max_graphs is not None and len(batch) >= self.max_graphs
+            )
+            if batch and (exceeds_cost or exceeds_graphs):
+                batches.append(batch)
+                batch, batch_cost = [], 0
+            batch.append(index)
+            batch_cost += cost
+
+        if batch and not (self.drop_last and batch_cost < self.max_cost):
+            batches.append(batch)
+        return batches, skipped
+
+    def __iter__(self) -> Iterator[list[int]]:
+        batches, _ = self._batches()
+        return iter(batches)
+
+    def __len__(self) -> int:
+        batches, _ = self._batches()
+        return len(batches)
+
+    def statistics(self) -> BatchStatistics:
+        """Return packing diagnostics for the currently selected epoch."""
+        batches, skipped = self._batches()
+        totals = [sum(self.costs[index] for index in batch) for batch in batches]
+        return BatchStatistics(
+            num_batches=len(batches),
+            num_samples=sum(map(len, batches)),
+            skipped_samples=skipped,
+            min_cost=min(totals, default=0),
+            max_cost=max(totals, default=0),
+            mean_cost=math.fsum(totals) / len(totals) if totals else 0.0,
+        )

--- a/hydragnn/preprocess/batch_sampler.py
+++ b/hydragnn/preprocess/batch_sampler.py
@@ -85,7 +85,8 @@ class CostAwareBatchSampler(Sampler[list[int]]):
         seed: Base seed used for deterministic epoch shuffling.
         oversized_sample: Policy for a sample whose cost exceeds ``max_cost``:
             ``"error"``, ``"single"``, or ``"skip"``.
-        drop_last: Drop the final batch when its cost is below ``max_cost``.
+        drop_last: Drop the final batch unless it reaches ``max_cost`` or,
+            when configured, ``max_graphs``.
     """
 
     def __init__(
@@ -116,6 +117,7 @@ class CostAwareBatchSampler(Sampler[list[int]]):
         self.oversized_sample = oversized_sample
         self.drop_last = drop_last
         self.epoch = 0
+        self._batch_cache: tuple[list[list[int]], int] | None = None
 
         if costs is None:
             costs = graph_node_costs(dataset)
@@ -130,6 +132,7 @@ class CostAwareBatchSampler(Sampler[list[int]]):
     def set_epoch(self, epoch: int) -> None:
         """Select the deterministic ordering for an epoch."""
         self.epoch = int(epoch)
+        self._batch_cache = None
 
     def _ordered_indices(self) -> list[int]:
         if not self.shuffle:
@@ -138,6 +141,9 @@ class CostAwareBatchSampler(Sampler[list[int]]):
         return torch.randperm(len(self.dataset), generator=generator).tolist()
 
     def _batches(self) -> tuple[list[list[int]], int]:
+        if self._batch_cache is not None:
+            return self._batch_cache
+
         batches: list[list[int]] = []
         batch: list[int] = []
         batch_cost = 0
@@ -170,9 +176,16 @@ class CostAwareBatchSampler(Sampler[list[int]]):
             batch.append(index)
             batch_cost += cost
 
-        if batch and not (self.drop_last and batch_cost < self.max_cost):
-            batches.append(batch)
-        return batches, skipped
+        if batch:
+            reached_cost_limit = batch_cost == self.max_cost
+            reached_graph_limit = (
+                self.max_graphs is not None and len(batch) == self.max_graphs
+            )
+            if not self.drop_last or reached_cost_limit or reached_graph_limit:
+                batches.append(batch)
+
+        self._batch_cache = (batches, skipped)
+        return self._batch_cache
 
     def __iter__(self) -> Iterator[list[int]]:
         batches, _ = self._batches()
@@ -225,7 +238,10 @@ class DistributedCostAwareBatchSampler(CostAwareBatchSampler):
         super().__init__(dataset, max_cost, **kwargs)
 
     def _distributed_batches(self) -> list[list[int]]:
-        batches, _ = self._batches()
+        packed_batches, _ = self._batches()
+        # Distribution sorts and may pad the global plan. Keep the cached core
+        # batches immutable from the perspective of this operation.
+        batches = [batch.copy() for batch in packed_batches]
         if not batches:
             return []
 

--- a/hydragnn/preprocess/batch_sampler.py
+++ b/hydragnn/preprocess/batch_sampler.py
@@ -44,6 +44,30 @@ def graph_node_cost(sample) -> int:
     return int(value)
 
 
+def graph_node_costs(dataset) -> Sequence[int] | None:
+    """Return node counts from dataset metadata without loading samples.
+
+    Dataset implementations may expose a ``get_node_counts`` method. The
+    fallback recognizes HydraGNN datasets carrying global variable-shape
+    metadata, including DDStore- and ADIOS-backed datasets.
+    """
+    getter = getattr(dataset, "get_node_counts", None)
+    if callable(getter):
+        costs = getter()
+        if costs is not None:
+            return costs
+
+    variable_count = getattr(dataset, "variable_count", None)
+    variable_dim = getattr(dataset, "variable_dim", None)
+    if isinstance(variable_count, dict) and isinstance(variable_dim, dict):
+        for key in ("x", "pos"):
+            if key in variable_count and variable_dim.get(key) == 0:
+                costs = variable_count[key]
+                if len(costs) == len(dataset):
+                    return costs
+    return None
+
+
 class CostAwareBatchSampler(Sampler[list[int]]):
     """Pack dataset samples into batches bounded by an additive cost.
 
@@ -93,6 +117,8 @@ class CostAwareBatchSampler(Sampler[list[int]]):
         self.drop_last = drop_last
         self.epoch = 0
 
+        if costs is None:
+            costs = graph_node_costs(dataset)
         if costs is None:
             costs = [cost_fn(dataset[index]) for index in range(len(dataset))]
         if len(costs) != len(dataset):

--- a/hydragnn/preprocess/batch_sampler.py
+++ b/hydragnn/preprocess/batch_sampler.py
@@ -168,3 +168,78 @@ class CostAwareBatchSampler(Sampler[list[int]]):
             max_cost=max(totals, default=0),
             mean_cost=math.fsum(totals) / len(totals) if totals else 0.0,
         )
+
+
+class DistributedCostAwareBatchSampler(CostAwareBatchSampler):
+    """Distribute cost-bounded batches with equal steps on every rank.
+
+    Complete batches are created identically on every rank. They are ordered by
+    cost and grouped into distributed steps so batches executed concurrently
+    have similar estimated costs. Step order and the rank-to-batch mapping are
+    shuffled deterministically each epoch.
+    """
+
+    def __init__(
+        self,
+        dataset,
+        max_cost: int,
+        *,
+        num_replicas: int,
+        rank: int,
+        pad_batches: bool = True,
+        **kwargs,
+    ) -> None:
+        if num_replicas <= 0:
+            raise ValueError("num_replicas must be positive")
+        if rank < 0 or rank >= num_replicas:
+            raise ValueError("rank must be in [0, num_replicas)")
+        self.num_replicas = int(num_replicas)
+        self.rank = int(rank)
+        self.pad_batches = pad_batches
+        super().__init__(dataset, max_cost, **kwargs)
+
+    def _distributed_batches(self) -> list[list[int]]:
+        batches, _ = self._batches()
+        if not batches:
+            return []
+
+        remainder = len(batches) % self.num_replicas
+        if remainder:
+            if self.pad_batches:
+                needed = self.num_replicas - remainder
+                batches.extend(batches[index % len(batches)] for index in range(needed))
+            else:
+                batches = batches[: len(batches) - remainder]
+        if not batches:
+            return []
+
+        def batch_cost(batch):
+            return sum(self.costs[index] for index in batch)
+
+        batches.sort(key=batch_cost)
+        steps = [
+            batches[start : start + self.num_replicas]
+            for start in range(0, len(batches), self.num_replicas)
+        ]
+
+        if self.shuffle:
+            generator = torch.Generator().manual_seed(self.seed + self.epoch)
+            step_order = torch.randperm(len(steps), generator=generator).tolist()
+            steps = [steps[index] for index in step_order]
+
+        local_batches = []
+        for step, candidates in enumerate(steps):
+            # Rotation prevents one rank from consistently receiving the most
+            # expensive member of each similarly sized group.
+            local_index = (self.rank + step) % self.num_replicas
+            local_batches.append(candidates[local_index])
+        return local_batches
+
+    def __iter__(self) -> Iterator[list[int]]:
+        return iter(self._distributed_batches())
+
+    def __len__(self) -> int:
+        batches, _ = self._batches()
+        if self.pad_batches:
+            return math.ceil(len(batches) / self.num_replicas)
+        return len(batches) // self.num_replicas

--- a/hydragnn/preprocess/load_data.py
+++ b/hydragnn/preprocess/load_data.py
@@ -25,7 +25,10 @@ except:
     from torch_geometric.data import DataLoader
 
 from hydragnn.preprocess.serialized_dataset_loader import SerializedDataLoader
-from hydragnn.preprocess.batch_sampler import CostAwareBatchSampler
+from hydragnn.preprocess.batch_sampler import (
+    CostAwareBatchSampler,
+    DistributedCostAwareBatchSampler,
+)
 from hydragnn.preprocess.lsms_raw_dataset_loader import LSMS_RawDataLoader
 from hydragnn.preprocess.cfg_raw_dataset_loader import CFG_RawDataLoader
 from hydragnn.utils.datasets.compositional_data_splitting import (
@@ -240,26 +243,53 @@ def create_dataloaders(
     batching=None,
 ):
     if batching and batching.get("mode", "fixed") != "fixed":
-        if dist.is_initialized():
-            raise NotImplementedError(
-                "cost-aware distributed batching is not yet supported"
-            )
         if oversampling:
             raise ValueError("cost-aware batching cannot be combined with oversampling")
         if batching["mode"] != "node_budget":
             raise ValueError(f"unsupported batching mode: {batching['mode']}")
 
+        sampler_type = CostAwareBatchSampler
+        distributed_options = {}
+        if dist.is_initialized():
+            if group is None:
+                group = dist.group.WORLD
+            if isinstance(group, dist.ProcessGroup):
+                group_size = dist.get_world_size(group=group)
+                group_rank = dist.get_rank(group=group)
+            elif isinstance(group, MPI.Comm):
+                group_size = group.Get_size()
+                group_rank = group.Get_rank()
+            else:
+                raise ValueError("Unsupported group type for distributed sampling")
+            sampler_type = DistributedCostAwareBatchSampler
+            distributed_options = {
+                "num_replicas": group_size,
+                "rank": group_rank,
+                "pad_batches": not batching.get("drop_last", False),
+            }
+
         def make_loader(dataset, shuffle):
-            batch_sampler = CostAwareBatchSampler(
+            sampler_drop_last = (
+                batching.get("drop_last", False)
+                if sampler_type is CostAwareBatchSampler
+                else False
+            )
+            batch_sampler = sampler_type(
                 dataset,
                 max_cost=batching["max_nodes"],
                 max_graphs=batching.get("max_graphs"),
                 shuffle=batching.get("shuffle", shuffle),
                 seed=batching.get("seed", 0),
                 oversized_sample=batching.get("oversized_sample", "error"),
-                drop_last=batching.get("drop_last", False),
+                drop_last=sampler_drop_last,
+                **distributed_options,
             )
-            return DataLoader(dataset, batch_sampler=batch_sampler)
+            return DataLoader(
+                dataset,
+                batch_sampler=batch_sampler,
+                num_workers=int(os.getenv("HYDRAGNN_NUM_WORKERS", "0")),
+                pin_memory=dist.is_initialized(),
+            )
 
         return (
             make_loader(trainset, train_sampler_shuffle),

--- a/hydragnn/preprocess/load_data.py
+++ b/hydragnn/preprocess/load_data.py
@@ -25,6 +25,7 @@ except:
     from torch_geometric.data import DataLoader
 
 from hydragnn.preprocess.serialized_dataset_loader import SerializedDataLoader
+from hydragnn.preprocess.batch_sampler import CostAwareBatchSampler
 from hydragnn.preprocess.lsms_raw_dataset_loader import LSMS_RawDataLoader
 from hydragnn.preprocess.cfg_raw_dataset_loader import CFG_RawDataLoader
 from hydragnn.utils.datasets.compositional_data_splitting import (
@@ -221,6 +222,7 @@ def dataset_loading_and_splitting(config: {}):
         valset,
         testset,
         batch_size=config["NeuralNetwork"]["Training"]["batch_size"],
+        batching=config["NeuralNetwork"]["Training"].get("Batching"),
     )
 
 
@@ -235,7 +237,36 @@ def create_dataloaders(
     group=None,
     oversampling=False,
     num_samples=None,  ## tuple of number of samples (train, val, test)
+    batching=None,
 ):
+    if batching and batching.get("mode", "fixed") != "fixed":
+        if dist.is_initialized():
+            raise NotImplementedError(
+                "cost-aware distributed batching is not yet supported"
+            )
+        if oversampling:
+            raise ValueError("cost-aware batching cannot be combined with oversampling")
+        if batching["mode"] != "node_budget":
+            raise ValueError(f"unsupported batching mode: {batching['mode']}")
+
+        def make_loader(dataset, shuffle):
+            batch_sampler = CostAwareBatchSampler(
+                dataset,
+                max_cost=batching["max_nodes"],
+                max_graphs=batching.get("max_graphs"),
+                shuffle=batching.get("shuffle", shuffle),
+                seed=batching.get("seed", 0),
+                oversized_sample=batching.get("oversized_sample", "error"),
+                drop_last=batching.get("drop_last", False),
+            )
+            return DataLoader(dataset, batch_sampler=batch_sampler)
+
+        return (
+            make_loader(trainset, train_sampler_shuffle),
+            make_loader(valset, val_sampler_shuffle),
+            make_loader(testset, test_sampler_shuffle),
+        )
+
     if dist.is_initialized():
         if oversampling:
             assert num_samples is not None

--- a/hydragnn/preprocess/load_data.py
+++ b/hydragnn/preprocess/load_data.py
@@ -284,11 +284,17 @@ def create_dataloaders(
                 drop_last=sampler_drop_last,
                 **distributed_options,
             )
-            return DataLoader(
+            loader_type = DataLoader
+            if dist.is_initialized() and int(
+                os.getenv("HYDRAGNN_CUSTOM_DATALOADER", "0")
+            ):
+                loader_type = HydraDataLoader
+            return loader_type(
                 dataset,
                 batch_sampler=batch_sampler,
                 num_workers=int(os.getenv("HYDRAGNN_NUM_WORKERS", "0")),
                 pin_memory=dist.is_initialized(),
+                persistent_workers=False,
             )
 
         return (

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -341,10 +341,12 @@ def train_validate_test(
         profiler.set_current_epoch(epoch)
         for dataloader in [train_loader, val_loader, test_loader]:
             sampler = getattr(dataloader, "batch_sampler", None)
-            if getattr(sampler, "set_epoch", None) is None:
-                sampler = dataloader.sampler
             if getattr(sampler, "set_epoch", None) is not None:
                 sampler.set_epoch(epoch)
+            else:
+                sampler = dataloader.sampler
+                if getattr(sampler, "set_epoch", None) is not None:
+                    sampler.set_epoch(epoch)
 
         with profiler as prof:
             tr.enable()

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -171,11 +171,8 @@ def _set_reshard_after_backward(model, enabled):
 
 
 def get_nbatch(loader):
-    ## calculate numbrer of batches for a given loader
-    m = len(loader.sampler)
-    nbatch = (m - 1) // loader.batch_size + 1
-    extra = -1 if m - nbatch * loader.batch_size > 0 and loader.drop_last else 0
-    nbatch = nbatch + extra
+    """Calculate the number of batches produced by a loader."""
+    nbatch = len(loader)
 
     if os.getenv("HYDRAGNN_MAX_NUM_BATCH") is not None:
         nbatch = min(nbatch, int(os.environ["HYDRAGNN_MAX_NUM_BATCH"]))
@@ -343,8 +340,11 @@ def train_validate_test(
         t0 = time.time()
         profiler.set_current_epoch(epoch)
         for dataloader in [train_loader, val_loader, test_loader]:
-            if getattr(dataloader.sampler, "set_epoch", None) is not None:
-                dataloader.sampler.set_epoch(epoch)
+            sampler = getattr(dataloader, "batch_sampler", None)
+            if getattr(sampler, "set_epoch", None) is None:
+                sampler = dataloader.sampler
+            if getattr(sampler, "set_epoch", None) is not None:
+                sampler.set_epoch(epoch)
 
         with profiler as prof:
             tr.enable()

--- a/hydragnn/utils/datasets/distdataset.py
+++ b/hydragnn/utils/datasets/distdataset.py
@@ -311,6 +311,17 @@ class DistDataset(AbstractBaseDataset):
     def len(self):
         return self.total_ns
 
+    def get_node_counts(self):
+        """Return global per-sample node counts without reading DDStore data."""
+        for key in ("x", "pos"):
+            if key in self.variable_count and self.variable_dim.get(key) == 0:
+                counts = self.variable_count[key]
+                if len(counts) == self.total_ns:
+                    return counts
+        raise ValueError(
+            "DDStore dataset has no node-indexed x or pos metadata for batching"
+        )
+
     def update_data_object(self, data_object):
         if self.var_config is not None:
             update_predicted_values(

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -60,6 +60,14 @@ def update_config(config, train_loader, val_loader, test_loader):
     architecture.setdefault("equivariant_attn_coupling_mode", "parallel")
     validate_equivariant_transformer_config(architecture)
 
+    batching = config["NeuralNetwork"]["Training"].get("Batching")
+    if batching is not None:
+        mode = batching.get("mode", "fixed")
+        if mode not in {"fixed", "node_budget"}:
+            raise ValueError(f"unsupported batching mode: {mode}")
+        if mode == "node_budget" and "max_nodes" not in batching:
+            raise ValueError("node_budget batching requires max_nodes")
+
     # update output_heads with latest config rules
     config["NeuralNetwork"]["Architecture"]["output_heads"] = update_multibranch_heads(
         config["NeuralNetwork"]["Architecture"]["output_heads"]

--- a/tests/test_cost_aware_batch_sampler.py
+++ b/tests/test_cost_aware_batch_sampler.py
@@ -12,12 +12,14 @@
 import pytest
 import torch
 from torch_geometric.data import Data
+from mpi4py import MPI
 
 from hydragnn.preprocess.batch_sampler import (
     CostAwareBatchSampler,
     DistributedCostAwareBatchSampler,
 )
 from hydragnn.preprocess.load_data import create_dataloaders
+import hydragnn.preprocess.load_data as load_data_module
 
 
 def _dataset(costs):
@@ -48,6 +50,38 @@ def pytest_cost_sampler_shuffle_is_deterministic_per_epoch():
     second.set_epoch(1)
     assert list(first) == list(second)
     assert list(first) != list(CostAwareBatchSampler(dataset, 3, seed=17))
+
+
+def pytest_cost_sampler_caches_batches_until_epoch_changes(monkeypatch):
+    sampler = CostAwareBatchSampler(_dataset([1] * 8), 3, seed=17)
+    calls = 0
+    original = sampler._ordered_indices
+
+    def counted_order():
+        nonlocal calls
+        calls += 1
+        return original()
+
+    monkeypatch.setattr(sampler, "_ordered_indices", counted_order)
+    list(sampler)
+    len(sampler)
+    sampler.statistics()
+    assert calls == 1
+
+    sampler.set_epoch(1)
+    list(sampler)
+    assert calls == 2
+
+
+def pytest_drop_last_considers_graph_limit():
+    sampler = CostAwareBatchSampler(
+        _dataset([1] * 5),
+        max_cost=10,
+        max_graphs=2,
+        shuffle=False,
+        drop_last=True,
+    )
+    assert list(sampler) == [[0, 1], [2, 3]]
 
 
 @pytest.mark.parametrize("policy", ["error", "single", "skip"])
@@ -112,6 +146,36 @@ def pytest_node_budget_configuration_builds_variable_graph_batches():
         [2, 5],
         [2, 5],
     ]
+
+
+def pytest_node_budget_preserves_custom_distributed_loader_settings(monkeypatch):
+    calls = []
+
+    class RecordingLoader:
+        def __init__(self, dataset, **kwargs):
+            self.dataset = dataset
+            calls.append(kwargs)
+
+    monkeypatch.setenv("HYDRAGNN_CUSTOM_DATALOADER", "1")
+    monkeypatch.setenv("HYDRAGNN_NUM_WORKERS", "3")
+    monkeypatch.setattr(load_data_module.dist, "is_initialized", lambda: True)
+    monkeypatch.setattr(load_data_module, "HydraDataLoader", RecordingLoader)
+
+    dataset = _dataset([2, 3, 4])
+    loaders = load_data_module.create_dataloaders(
+        dataset,
+        dataset,
+        dataset,
+        batch_size=99,
+        group=MPI.COMM_SELF,
+        batching={"mode": "node_budget", "max_nodes": 5},
+    )
+
+    assert all(isinstance(loader, RecordingLoader) for loader in loaders)
+    assert len(calls) == 3
+    assert all(call["num_workers"] == 3 for call in calls)
+    assert all(call["pin_memory"] is True for call in calls)
+    assert all(call["persistent_workers"] is False for call in calls)
 
 
 def pytest_distributed_sampler_has_equal_steps_and_complete_step_assignment():

--- a/tests/test_cost_aware_batch_sampler.py
+++ b/tests/test_cost_aware_batch_sampler.py
@@ -1,0 +1,95 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import pytest
+import torch
+from torch_geometric.data import Data
+
+from hydragnn.preprocess.batch_sampler import CostAwareBatchSampler
+from hydragnn.preprocess.load_data import create_dataloaders
+
+
+def _dataset(costs):
+    return [Data(x=torch.zeros(cost, 2)) for cost in costs]
+
+
+def pytest_cost_sampler_respects_node_and_graph_budgets():
+    sampler = CostAwareBatchSampler(
+        _dataset([2, 3, 4, 1, 2]),
+        max_cost=6,
+        max_graphs=2,
+        shuffle=False,
+    )
+    batches = list(sampler)
+
+    assert batches == [[0, 1], [2, 3], [4]]
+    assert all(sum(sampler.costs[i] for i in batch) <= 6 for batch in batches)
+    assert all(len(batch) <= 2 for batch in batches)
+
+
+def pytest_cost_sampler_shuffle_is_deterministic_per_epoch():
+    dataset = _dataset([1] * 12)
+    first = CostAwareBatchSampler(dataset, 3, seed=17)
+    second = CostAwareBatchSampler(dataset, 3, seed=17)
+
+    assert list(first) == list(second)
+    first.set_epoch(1)
+    second.set_epoch(1)
+    assert list(first) == list(second)
+    assert list(first) != list(CostAwareBatchSampler(dataset, 3, seed=17))
+
+
+@pytest.mark.parametrize("policy", ["error", "single", "skip"])
+def pytest_cost_sampler_has_explicit_oversized_policy(policy):
+    sampler = CostAwareBatchSampler(
+        _dataset([2, 8, 3]), 5, shuffle=False, oversized_sample=policy
+    )
+    if policy == "error":
+        with pytest.raises(ValueError, match="sample 1.*exceeding"):
+            list(sampler)
+    elif policy == "single":
+        assert list(sampler) == [[0], [1], [2]]
+    else:
+        assert list(sampler) == [[0, 2]]
+        assert sampler.statistics().skipped_samples == 1
+
+
+def pytest_cost_sampler_uses_precomputed_costs_without_loading_dataset():
+    class MetadataOnlyDataset:
+        def __len__(self):
+            return 3
+
+        def __getitem__(self, index):
+            raise AssertionError("samples should not be loaded")
+
+    sampler = CostAwareBatchSampler(
+        MetadataOnlyDataset(), 4, costs=[1, 2, 3], shuffle=False
+    )
+    assert list(sampler) == [[0, 1], [2]]
+
+
+def pytest_node_budget_configuration_builds_variable_graph_batches():
+    dataset = _dataset([2, 3, 4, 1])
+    loaders = create_dataloaders(
+        dataset,
+        dataset,
+        dataset,
+        batch_size=99,
+        train_sampler_shuffle=False,
+        val_sampler_shuffle=False,
+        test_sampler_shuffle=False,
+        batching={"mode": "node_budget", "max_nodes": 5},
+    )
+
+    assert [[batch.num_graphs, batch.num_nodes] for batch in loaders[0]] == [
+        [2, 5],
+        [2, 5],
+    ]

--- a/tests/test_cost_aware_batch_sampler.py
+++ b/tests/test_cost_aware_batch_sampler.py
@@ -73,9 +73,25 @@ def pytest_cost_sampler_uses_precomputed_costs_without_loading_dataset():
         def __getitem__(self, index):
             raise AssertionError("samples should not be loaded")
 
-    sampler = CostAwareBatchSampler(
-        MetadataOnlyDataset(), 4, costs=[1, 2, 3], shuffle=False
-    )
+        def get_node_counts(self):
+            return [1, 2, 3]
+
+    sampler = CostAwareBatchSampler(MetadataOnlyDataset(), 4, shuffle=False)
+    assert list(sampler) == [[0, 1], [2]]
+
+
+def pytest_cost_sampler_reads_ddstore_style_shape_metadata_without_samples():
+    class MetadataOnlyDataset:
+        variable_count = {"x": [2, 4, 3], "edge_index": [5, 9, 7]}
+        variable_dim = {"x": 0, "edge_index": 1}
+
+        def __len__(self):
+            return 3
+
+        def __getitem__(self, index):
+            raise AssertionError("DDStore payload should not be read")
+
+    sampler = CostAwareBatchSampler(MetadataOnlyDataset(), 6, shuffle=False)
     assert list(sampler) == [[0, 1], [2]]
 
 

--- a/tests/test_cost_aware_batch_sampler.py
+++ b/tests/test_cost_aware_batch_sampler.py
@@ -13,7 +13,10 @@ import pytest
 import torch
 from torch_geometric.data import Data
 
-from hydragnn.preprocess.batch_sampler import CostAwareBatchSampler
+from hydragnn.preprocess.batch_sampler import (
+    CostAwareBatchSampler,
+    DistributedCostAwareBatchSampler,
+)
 from hydragnn.preprocess.load_data import create_dataloaders
 
 
@@ -93,3 +96,54 @@ def pytest_node_budget_configuration_builds_variable_graph_batches():
         [2, 5],
         [2, 5],
     ]
+
+
+def pytest_distributed_sampler_has_equal_steps_and_complete_step_assignment():
+    dataset = _dataset([1, 2, 3, 4, 5, 6, 7, 8, 9])
+    samplers = [
+        DistributedCostAwareBatchSampler(
+            dataset,
+            10,
+            num_replicas=3,
+            rank=rank,
+            shuffle=False,
+        )
+        for rank in range(3)
+    ]
+    rank_batches = [list(sampler) for sampler in samplers]
+
+    assert len({len(batches) for batches in rank_batches}) == 1
+    for step in range(len(rank_batches[0])):
+        step_batches = [rank_batches[rank][step] for rank in range(3)]
+        assert len({tuple(batch) for batch in step_batches}) == 3
+
+
+def pytest_distributed_sampler_groups_similar_costs_per_step():
+    dataset = _dataset([1, 2, 3, 4, 5, 6, 7, 8])
+    samplers = [
+        DistributedCostAwareBatchSampler(
+            dataset,
+            8,
+            num_replicas=2,
+            rank=rank,
+            shuffle=False,
+        )
+        for rank in range(2)
+    ]
+    rank_batches = [list(sampler) for sampler in samplers]
+
+    for left, right in zip(*rank_batches):
+        left_cost = sum(samplers[0].costs[index] for index in left)
+        right_cost = sum(samplers[1].costs[index] for index in right)
+        assert abs(left_cost - right_cost) <= 2
+
+
+def pytest_distributed_sampler_epoch_shuffle_is_reproducible():
+    dataset = _dataset([1] * 20)
+    first = DistributedCostAwareBatchSampler(dataset, 3, num_replicas=2, rank=0, seed=9)
+    second = DistributedCostAwareBatchSampler(
+        dataset, 3, num_replicas=2, rank=0, seed=9
+    )
+    first.set_epoch(4)
+    second.set_epoch(4)
+    assert list(first) == list(second)


### PR DESCRIPTION
## Summary

- add a reusable model-independent `CostAwareBatchSampler`
- support deterministic node-budget packing with optional graph-count limits
- provide explicit error, singleton, and skip policies for oversized samples
- expose packing diagnostics and precomputed-cost support
- consume DDStore global shape metadata without reading graph payloads
- integrate `NeuralNetwork.Training.Batching` with HydraGNN data loaders
- distribute complete batches with equal step counts across ranks
- group similar-cost batches per synchronized distributed step
- rotate rank assignments and support deterministic padding or dropping
- update training batch counting and epoch propagation for batch samplers
- document configuration and add focused tests

## Configuration

```json
"Batching": {
  "mode": "node_budget",
  "max_nodes": 4096,
  "max_graphs": 64,
  "oversized_sample": "error",
  "shuffle": true,
  "seed": 0
}
```

## Scope

This PR implements both core batching and distributed cost-balanced rank
allocation. Dynamic online inference batching is intentionally reserved for a
separate follow-up PR because it addresses request serving rather than dataset
loading.

## Validation

- `pytest -q tests/test_cost_aware_batch_sampler.py tests/test_datasetclass_inheritance.py tests/test_config.py tests/test_precision_control.py`
- 15 passed, 1 skipped
- Python compile checks and `git diff --check`
