### PR TITLE
Add SiLU activation support

### DIFF
--- a/hydragnn/utils/model/model.py
+++ b/hydragnn/utils/model/model.py
@@ -30,6 +30,8 @@ from torch.distributed.optim import ZeroRedundancyOptimizer
 def activation_function_selection(activation_function_string: str):
     if activation_function_string == "relu":
         return torch.nn.ReLU()
+    elif activation_function_string == "silu":
+        return torch.nn.SiLU()
     elif activation_function_string == "selu":
         return torch.nn.SELU()
     elif activation_function_string == "prelu":

--- a/tests/test_loss_and_activation_functions.py
+++ b/tests/test_loss_and_activation_functions.py
@@ -115,7 +115,16 @@ def pytest_loss_functions(loss_function_type, ci_input="ci.json", overwrite_data
 # Test all supported activation function types.
 @pytest.mark.parametrize(
     "activation_function_type",
-    ["relu", "selu", "prelu", "elu", "lrelu_01", "lrelu_025", "lrelu_05"],
+    [
+        "relu",
+        "silu",
+        "selu",
+        "prelu",
+        "elu",
+        "lrelu_01",
+        "lrelu_025",
+        "lrelu_05",
+    ],
 )
 def pytest_activation_functions_multihead(
     activation_function_type, ci_input="ci_multihead.json", overwrite_data=False
@@ -128,7 +137,16 @@ def pytest_activation_functions_multihead(
 # Test all supported activation function types.
 @pytest.mark.parametrize(
     "activation_function_type",
-    ["relu", "selu", "prelu", "elu", "lrelu_01", "lrelu_025", "lrelu_05"],
+    [
+        "relu",
+        "silu",
+        "selu",
+        "prelu",
+        "elu",
+        "lrelu_01",
+        "lrelu_025",
+        "lrelu_05",
+    ],
 )
 def pytest_activation_functions_vectoroutput(
     activation_function_type, ci_input="ci_vectoroutput.json", overwrite_data=False


### PR DESCRIPTION
## Summary

- add `silu` to HydraGNN's activation-function selector
- map it to PyTorch's `torch.nn.SiLU`
- cover SiLU in the existing multihead and vector-output activation test matrices

## Validation

- `python3 -m py_compile hydragnn/utils/model/model.py tests/test_loss_and_activation_functions.py`
- `git diff --check`

The full pytest suite was not run locally because the current environment does not have PyTorch or pytest installed.