### PR TITLE
Fix invalid sample-skip control flow in dataset examples

### DIFF
--- a/examples/open_direct_air_capture_2023/odac23.py
+++ b/examples/open_direct_air_capture_2023/odac23.py
@@ -295,7 +295,7 @@ class ODAC2023(AbstractBaseDataset):
 
             # Skip samples that still contain self-loops
             if should_skip_self_loops(data_object, context="odac23"):
-                continue
+                return
 
             # Default edge_shifts for when radius_graph_pbc is not activated
             if not hasattr(data_object, "edge_shifts"):

--- a/examples/open_molecules_2025/omol25.py
+++ b/examples/open_molecules_2025/omol25.py
@@ -225,7 +225,7 @@ class OMol2025(AbstractBaseDataset):
 
                 # Skip samples that still contain self-loops
                 if should_skip_self_loops(data_object, context="omol25"):
-                    continue
+                    return
 
             # Default edge_shifts for when radius_graph_pbc is not activated
             if not hasattr(data_object, "edge_shifts"):

--- a/examples/open_polymers_2026/opoly26.py
+++ b/examples/open_polymers_2026/opoly26.py
@@ -225,7 +225,7 @@ class OPoly2026(AbstractBaseDataset):
 
             # Skip samples that still contain self-loops
             if should_skip_self_loops(data_object, context="opoly26"):
-                continue
+                return
 
             # Default edge_shifts for when radius_graph_pbc is not activated
             if not hasattr(data_object, "edge_shifts"):


### PR DESCRIPTION
## Summary

- replace three syntactically invalid `continue` statements with `return`
- restore importability of the affected ODAC23, OMol25, and OPoly26 preprocessing examples
- preserve the intended behavior of skipping only the current invalid sample

## What was broken

The affected self-loop checks are inside `_create_pytorch_data_object(...)`, which processes one sample per invocation. The dataset iteration occurs in the caller. A `continue` statement is therefore invalid at those locations because there is no enclosing loop in the helper function, causing Python to fail while importing or compiling the files:

```text
SyntaxError: 'continue' not properly in loop
```

The issue affected:

- `examples/open_direct_air_capture_2023/odac23.py`
- `examples/open_molecules_2025/omol25.py`
- `examples/open_polymers_2026/opoly26.py`

## Fix

Each invalid `continue` is replaced with `return`. Returning exits processing for the current sample. Control then returns to the caller's dataset loop, which proceeds to the next sample, preserving the intended skip-one-sample behavior.

## Validation

- `python -m compileall -q hydragnn tests examples`
- `git diff --check`

Both checks pass.
