### PR TITLE
Organize HPC installation scripts by system

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -109,9 +109,10 @@ python -c "import hydragnn; print('HydraGNN installed successfully')"
 
 ### DOE Supercomputer Installation
 
-Tested installation scripts are provided for major leadership-class machines in the `installation_DOE_supercomputers/` directory:
+Tested installation scripts are organized by facility and system under
+`scripts/hpc/<facility>/<system>/installation/`:
 
-- **Frontier** (AMD, ROCm 6.4 and 7.1)
+- **Frontier** (AMD, ROCm 6.4, 7.1, 7.2, and 7.13)
 - **Aurora** (Intel XPU)
 - **Perlmutter** (NVIDIA)
 - **Andes** (NVIDIA)

--- a/docs/dataset_downloads.md
+++ b/docs/dataset_downloads.md
@@ -27,7 +27,7 @@ On OLCF systems whose compute nodes require the CCS proxy, source the optional
 facility helper before invoking any dataset downloader:
 
 ```bash
-source installation_DOE_supercomputers/olcf_proxy_env.sh
+source scripts/hpc/olcf/proxy-env.sh
 ```
 
 Normal pull-request tests run a complete download, resume, redirect, checksum,

--- a/examples/multidataset_hpo_sc26/job-sc26-single-model-inference-aurora-pbs.sh
+++ b/examples/multidataset_hpo_sc26/job-sc26-single-model-inference-aurora-pbs.sh
@@ -17,7 +17,7 @@ function cmd() {
 
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 HYDRAGNN_ROOT=${HYDRAGNN_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}
-VENV_PATH=${VENV_PATH:-$HYDRAGNN_ROOT/installation_DOE_supercomputers/HydraGNN-Installation-Aurora/hydragnn_venv}
+VENV_PATH=${VENV_PATH:-$HYDRAGNN_ROOT/HydraGNN-Installation-Aurora/hydragnn_venv}
 EXAMPLE_DIR=$HYDRAGNN_ROOT/examples/multidataset_hpo_sc26
 
 # Aurora proxy (needed on compute nodes for outbound HTTPS in some environments)

--- a/examples/multidataset_hpo_sc26/job-sc26-single-model-inference-frontier.sh
+++ b/examples/multidataset_hpo_sc26/job-sc26-single-model-inference-frontier.sh
@@ -11,7 +11,7 @@
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "${script_dir}/../.." && pwd)
-source "${repo_root}/installation_DOE_supercomputers/olcf_proxy_env.sh"
+source "${repo_root}/scripts/hpc/olcf/proxy-env.sh"
 
 function cmd() {
     echo "$@"
@@ -23,7 +23,7 @@ EXAMPLE_DIR=$HYDRAGNN_ROOT/examples/multidataset_hpo_sc26
 
 # Load conda environment (same pattern as job-sc26-oom.sh)
 source /lustre/orion/mat746/world-shared/mlupopa/module-to-load-frontier-rocm640.sh
-source activate /lustre/orion/mat746/world-shared/mlupopa/HydraGNN/installation_DOE_supercomputers/HydraGNN-Installation-Frontier-ROCm6.4/hydragnn_venv
+source activate /lustre/orion/mat746/world-shared/mlupopa/HydraGNN/HydraGNN-Installation-Frontier-ROCm6.4/hydragnn_venv
 
 cd "$HYDRAGNN_ROOT"
 export PYTHONPATH=$PWD:$PYTHONPATH

--- a/examples/multidataset_hpo_sc26/job-sc26-single-model-inference-perlmutter.sh
+++ b/examples/multidataset_hpo_sc26/job-sc26-single-model-inference-perlmutter.sh
@@ -18,7 +18,7 @@ function cmd() {
 
 # --- Paths (override with environment variables if needed) ---
 HYDRAGNN_ROOT=${HYDRAGNN_ROOT:-/global/cfs/projectdirs/amsc001/cm2us/mlupopa/HydraGNN}
-VENV_PATH=${VENV_PATH:-$HYDRAGNN_ROOT/installation_DOE_supercomputers/HydraGNN-Installation-Perlmutter/hydragnn_venv}
+VENV_PATH=${VENV_PATH:-$HYDRAGNN_ROOT/HydraGNN-Installation-Perlmutter/hydragnn_venv}
 EXAMPLE_DIR=$HYDRAGNN_ROOT/examples/multidataset_hpo_sc26
 
 # --- Perlmutter module + conda setup ---

--- a/examples/multidataset_hpo_sc26/job-sc26-single-model-training-aurora-pbs.sh
+++ b/examples/multidataset_hpo_sc26/job-sc26-single-model-training-aurora-pbs.sh
@@ -18,7 +18,7 @@ function cmd() {
 SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 HYDRAGNN_ROOT=${HYDRAGNN_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}
 EXAMPLES_DIR=$HYDRAGNN_ROOT/examples/multidataset_hpo_sc26
-VENV_PATH=${VENV_PATH:-$HYDRAGNN_ROOT/installation_DOE_supercomputers/HydraGNN-Installation-Aurora/hydragnn_venv}
+VENV_PATH=${VENV_PATH:-$HYDRAGNN_ROOT/HydraGNN-Installation-Aurora/hydragnn_venv}
 
 # Aurora proxy (needed on compute nodes for outbound HTTPS in some environments)
 export HTTP_PROXY=${HTTP_PROXY:-http://proxy.alcf.anl.gov:3128}

--- a/examples/multidataset_hpo_sc26/job-sc26-single-model-training-frontier.sh
+++ b/examples/multidataset_hpo_sc26/job-sc26-single-model-training-frontier.sh
@@ -11,7 +11,7 @@
 
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "${script_dir}/../.." && pwd)
-source "${repo_root}/installation_DOE_supercomputers/olcf_proxy_env.sh"
+source "${repo_root}/scripts/hpc/olcf/proxy-env.sh"
 
 function cmd() {
     echo "$@"
@@ -49,7 +49,7 @@ HYDRAGNN_ROOT=/lustre/orion/mat746/proj-shared/mlupopa/HydraGNN
 # Load conda environemnt
 source /lustre/orion/mat746/proj-shared/mlupopa/module-to-load-frontier-rocm640.sh
 
-source activate /lustre/orion/mat746/proj-shared/mlupopa/HydraGNN/installation_DOE_supercomputers/HydraGNN-Installation-Frontier-ROCm6.4/hydragnn_venv
+source activate /lustre/orion/mat746/proj-shared/mlupopa/HydraGNN/HydraGNN-Installation-Frontier-ROCm6.4/hydragnn_venv
 
 
 # setup_bb

--- a/examples/multidataset_hpo_sc26/job-sc26-single-model-training-perlmutter.sh
+++ b/examples/multidataset_hpo_sc26/job-sc26-single-model-training-perlmutter.sh
@@ -18,7 +18,7 @@ function cmd() {
 
 # --- Paths (override with environment variables if needed) ---
 HYDRAGNN_ROOT=${HYDRAGNN_ROOT:-/global/cfs/projectdirs/amsc001/cm2us/mlupopa/HydraGNN}
-VENV_PATH=${VENV_PATH:-$HYDRAGNN_ROOT/installation_DOE_supercomputers/HydraGNN-Installation-Perlmutter/hydragnn_venv}
+VENV_PATH=${VENV_PATH:-$HYDRAGNN_ROOT/HydraGNN-Installation-Perlmutter/hydragnn_venv}
 EXAMPLE_DIR=$HYDRAGNN_ROOT/examples/multidataset_hpo_sc26
 
 # --- Perlmutter module + conda setup ---

--- a/scripts/hpc/README.md
+++ b/scripts/hpc/README.md
@@ -8,4 +8,6 @@ scripts/hpc/<facility>/<system>/
 
 For example, `olcf/frontier/environments` contains interactive Frontier setup
 scripts, while `olcf/frontier/omnistat` contains the corresponding Omnistat
-collector configurations. Keep portable HydraGNN utilities outside this hierarchy.
+collector configurations and `olcf/frontier/installation` contains installation
+scripts. Facility-wide helpers, such as `olcf/proxy-env.sh`, live at the facility
+level. Keep portable HydraGNN utilities outside this hierarchy.

--- a/scripts/hpc/alcf/aurora/installation/install.sh
+++ b/scripts/hpc/alcf/aurora/installation/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# hydragnn_installation_bash_script_aurora.sh
+# HydraGNN installation for Aurora
 #
 # Aurora approach (with ADIOS2/DDStore build-from-source):
 # - PyTorch: use "module load frameworks" (do NOT pip-install torch wheels)
@@ -12,7 +12,7 @@
 # - Install HydraGNN editable
 #
 # Run:
-#   nohup ./hydragnn_installation_bash_script_aurora.sh > installation_aurora.log 2>&1 &
+#   nohup scripts/hpc/alcf/aurora/installation/install.sh > installation_aurora.log 2>&1 &
 
 # ============================================================
 # Aurora compute node proxy (required for outbound HTTPS)

--- a/scripts/hpc/nersc/perlmutter/installation/install.sh
+++ b/scripts/hpc/nersc/perlmutter/installation/install.sh
@@ -41,7 +41,7 @@ banner "Configure Perlmutter Modules"
 EXPECTED_CUDA_MM="${EXPECTED_CUDA_MM:-12.9}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
-source "${SCRIPT_DIR}/module_loads_perlmutter.sh"
+source "${SCRIPT_DIR}/module-loads.sh"
 load_perlmutter_modules "${EXPECTED_CUDA_MM}"
 
 # ============================================================
@@ -406,4 +406,3 @@ EOF
 echo "✅ HydraGNN-Installation-Perlmutter environment setup complete!"
 echo ""
 print_perlmutter_activation_instructions "${EXPECTED_CUDA_MM}" "${VENV_PATH}"
-

--- a/scripts/hpc/nersc/perlmutter/installation/module-loads.sh
+++ b/scripts/hpc/nersc/perlmutter/installation/module-loads.sh
@@ -2,7 +2,7 @@
 
 # Shared module loader for Perlmutter installation scripts.
 # Usage:
-#   source ".../module_loads_perlmutter.sh"
+#   source ".../module-loads.sh"
 #   load_perlmutter_modules "12.4"
 
 # Paths are declared as env-overridable variables so callers can adjust

--- a/scripts/hpc/olcf/andes/installation/install-parallel.sh
+++ b/scripts/hpc/olcf/andes/installation/install-parallel.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# setup_env.sh
-# Complete automated setup for HydraGNN environment and dependencies on Frontier.
+# setup_env_andes.sh
+# Complete automated setup for HydraGNN environment and dependencies on Andes (CPU-only).
 
 set -Eeuo pipefail
 
@@ -10,18 +10,6 @@ set -Eeuo pipefail
 hr() { printf '%*s\n' "${COLUMNS:-80}" '' | tr ' ' '='; }
 banner() { hr; echo ">>> $1"; hr; }
 subbanner() { echo "-- $1"; }
-
-# =========================
-# Config (env-overridable)
-# =========================
-FRONTIER_ROCM_MODULE_VERSION="${FRONTIER_ROCM_MODULE_VERSION:-6.4.0}"
-FRONTIER_AMD_MIXED_MODULE_VERSION="${FRONTIER_AMD_MIXED_MODULE_VERSION:-6.4.0}"
-EXPECTED_ROCM_MM="${EXPECTED_ROCM_MM:-6.4}"
-PYTORCH_ROCM_INDEX_URL="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm${EXPECTED_ROCM_MM}}"
-PYTORCH_SCATTER_ROCM_REPO="${PYTORCH_SCATTER_ROCM_REPO:-https://github.com/Looong01/pytorch_scatter-rocm.git}"
-PYTORCH_SCATTER_ROCM_COMMIT="${PYTORCH_SCATTER_ROCM_COMMIT:-9799c51}"
-PYTORCH_SPARSE_ROCM_REPO="${PYTORCH_SPARSE_ROCM_REPO:-https://github.com/Looong01/pytorch_sparse-rocm.git}"
-PYTORCH_SPARSE_ROCM_COMMIT="${PYTORCH_SPARSE_ROCM_COMMIT:-2340737}"
 
 timeit() {
   SECONDS=0
@@ -54,22 +42,42 @@ progress() {
   echo -ne "\b"
 }
 
-banner "Starting HydraGNN environment setup ($(date))"
+banner "Starting HydraGNN environment setup on ANDES ($(date))"
 
 # ============================================================
-# Module initialization & Frontier stack
+# Module initialization & Andes stack
 # ============================================================
-banner "Configure Frontier Modules"
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck disable=SC1091
-source "${SCRIPT_DIR}/module_loads_frontier.sh"
-load_frontier_modules "${FRONTIER_ROCM_MODULE_VERSION}" "${FRONTIER_AMD_MIXED_MODULE_VERSION}"
+banner "Configure Andes Modules"
+if ! command -v module >/dev/null 2>&1; then
+  if [[ -f /etc/profile.d/modules.sh ]]; then
+    source /etc/profile.d/modules.sh
+  elif [[ -f /usr/share/lmod/lmod/init/bash ]]; then
+    source /usr/share/lmod/lmod/init/bash
+  elif [[ -f /usr/share/Modules/init/bash ]]; then
+    source /usr/share/Modules/init/bash
+  fi
+fi
+
+if ! command -v module >/dev/null 2>&1; then
+  echo "⚠️  'module' command not found. Ensure you're running on Andes."
+else
+  module reset
+  ml hsi/5.0.2.p5
+  ml gcc/9.3.0
+  ml openmpi/4.0.4
+  ml DefApps
+  ml cmake/3.22.2
+  ml git-lfs/2.11.0
+  ml miniforge3/23.11.0-0
+  ml libfabric/1.14.0
+  ml git-lfs
+fi
 
 # ============================================================
 # Installation root
 # ============================================================
 banner "Set Base Installation Directory"
-INSTALL_ROOT="${INSTALL_ROOT:-${PWD}/HydraGNN-Installation-Frontier}"
+INSTALL_ROOT="${PWD}/HydraGNN-Installation-Andes"
 mkdir -p "$INSTALL_ROOT"
 echo "All installation components will be contained in: $INSTALL_ROOT"
 cd "$INSTALL_ROOT"
@@ -78,7 +86,8 @@ cd "$INSTALL_ROOT"
 # Env vars & Conda env creation
 # ============================================================
 banner "Create and Activate Conda Environment"
-export LD_LIBRARY_PATH="${CRAY_LD_LIBRARY_PATH:-}:${LD_LIBRARY_PATH:-}"
+# Andes is not Cray; no CRAY_LD_LIBRARY_PATH reference here
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
 
 VENV_PATH="${VENV_PATH:-${INSTALL_ROOT}/hydragnn_venv}"
 echo "Virtual environment path: $VENV_PATH"
@@ -189,64 +198,40 @@ pip_retry vesin==0.4.2
 # mpi4py
 # ============================================================
 banner "mpi4py (v4.1.1)"
-MPI4PY_FRONTIER="${INSTALL_ROOT}/MPI4PY-Frontier"
-export MPI4PY_FRONTIER
-mkdir -p "$MPI4PY_FRONTIER"
-cd "$MPI4PY_FRONTIER"
+MPI4PY_ANDES="${INSTALL_ROOT}/MPI4PY-Andes"
+export MPI4PY_ANDES
+mkdir -p "$MPI4PY_ANDES"
+cd "$MPI4PY_ANDES"
 
 git clone -b 4.1.1 https://github.com/mpi4py/mpi4py.git || true
 pushd mpi4py >/dev/null
 rm -rf build
-CC=cc MPICC=cc pip_retry . --verbose
+CC=mpicc MPICC=mpicc pip_retry . --verbose
 popd >/dev/null
 
 # ============================================================
-# ROCm detection + ROCm-aware PyTorch
+# PyTorch (CPU-only) + torchvision
 # ============================================================
-banner "ROCm Detection and ROCm-aware PyTorch Install (Before PyG)"
-detect_rocm_mm() {
-  local v=""
-  if command -v module >/dev/null 2>&1; then
-    local mlist
-    mlist="$(module -t list 2>&1 || true)"
-    v="$(grep -Eo 'rocm/[0-9]+\.[0-9]+' <<<"$mlist" | head -n1 | sed 's#rocm/##')"
-  fi
-  if [[ -z "$v" ]] && command -v hipcc >/dev/null 2>&1; then
-    v="$(hipcc --version 2>&1 | grep -Eo 'HIP version:\s*[0-9]+\.[0-9]+' | grep -Eo '[0-9]+\.[0-9]+' | head -n1 || true)"
-  fi
-  echo "$v"
-}
-
-ROCM_MM="${ROCM_MM:-$(detect_rocm_mm)}"
-if [[ -z "$ROCM_MM" ]]; then
-  echo "❌ Could not detect ROCm version. Ensure the rocm module is loaded."
-  exit 1
-fi
-echo "Detected ROCm: $ROCM_MM"
-if [[ "$ROCM_MM" != "$EXPECTED_ROCM_MM" ]]; then
-  echo "❌ ROCm version mismatch. Detected $ROCM_MM but expecting rocm${EXPECTED_ROCM_MM}."
-  exit 1
-fi
-
-subbanner "Install ROCm PyTorch from ${PYTORCH_ROCM_INDEX_URL}"
-pip_retry --index-url "${PYTORCH_ROCM_INDEX_URL}" torch torchvision
+banner "Install CPU-only PyTorch"
+PYTORCH_CPU_INDEX_URL="https://download.pytorch.org/whl/cpu"
+pip_retry --index-url "${PYTORCH_CPU_INDEX_URL}" torch torchvision
 assert_numpy_1264
 
-python - <<PY
+python - <<'PY'
 import torch
 print("torch.__version__ =", torch.__version__)
-print("torch.version.hip =", torch.version.hip)
+print("CUDA available?    =", torch.cuda.is_available())
 PY
 
 # ============================================================
-# PyTorch-Geometric stack
+# PyTorch-Geometric stack (CPU build)
 # ============================================================
-banner "PyTorch-Geometric Stack (ROCm ${ROCM_MM})"
-PYG_DIR_NAME="PyTorch-Geometric-${ROCM_MM}"
-PYG_FRONTIER="${INSTALL_ROOT}/${PYG_DIR_NAME}"
-export PYG_FRONTIER
-mkdir -p "$PYG_FRONTIER"
-cd "$PYG_FRONTIER"
+banner "PyTorch-Geometric Stack (CPU)"
+PYG_DIR_NAME="PyTorch-Geometric-CPU"
+PYG_ANDES="${INSTALL_ROOT}/${PYG_DIR_NAME}"
+export PYG_ANDES
+mkdir -p "$PYG_ANDES"
+cd "$PYG_ANDES"
 
 subbanner "pytorch_geometric (official)"
 if [[ ! -d pytorch_geometric/.git ]]; then
@@ -258,25 +243,20 @@ pip_retry . --verbose
 assert_numpy_1264
 popd >/dev/null
 
-# --- pytorch_scatter (ROCm fork pinned) ---
+# --- pytorch_scatter (official repo & stable ref for CPU) ---
 build_pytorch_scatter() {
-  subbanner "pytorch_scatter (ROCm fork pinned to ${PYTORCH_SCATTER_ROCM_COMMIT}; temporary until upstream merges)"
+  subbanner "pytorch_scatter (official @ 2.1.2-9-g7cabb53)"
   if [[ ! -d pytorch_scatter/.git ]]; then
-    # Official upstream (kept for reference; will switch back after merge):
-    # git clone --recursive git@github.com:rusty1s/pytorch_scatter.git
-    # Temporary ROCm fork (use until fixes merge upstream):
-    git clone --recursive "${PYTORCH_SCATTER_ROCM_REPO}" pytorch_scatter
+    git clone --recursive git@github.com:rusty1s/pytorch_scatter.git
   fi
   pushd pytorch_scatter >/dev/null
   git fetch --all
-  git checkout "${PYTORCH_SCATTER_ROCM_COMMIT}"
+  git checkout 2.1.2-9-g7cabb53
   git submodule update --init --recursive
   rm -rf build
-  # If needed: export PYTORCH_ROCM_ARCH=gfx90a
-  CC=gcc CXX=g++ python setup.py build
-  CC=gcc CXX=g++ python setup.py install
+  CC=mpicc CXX=mpicxx python setup.py build
+  CC=mpicc CXX=mpicxx python setup.py install
   assert_numpy_1264
-  echo "pytorch_scatter pinned to commit: $(git rev-parse --short HEAD)"
   popd >/dev/null
 }
 
@@ -284,19 +264,15 @@ build_pytorch_scatter() {
 build_pytorch_sparse() {
   subbanner "pytorch_sparse (official @ 0.6.18-8-gcdbf561)"
   if [[ ! -d pytorch_sparse/.git ]]; then
-    # Official upstream (kept for reference; will switch back after merge):
-    # git clone --recursive git@github.com:rusty1s/pytorch_sparse.git
-    # Temporary ROCm fork (use until fixes merge upstream):
-    git clone --recursive "${PYTORCH_SPARSE_ROCM_REPO}" pytorch_sparse
+    git clone --recursive git@github.com:rusty1s/pytorch_sparse.git
   fi
   pushd pytorch_sparse >/dev/null
   git fetch --all
-  git checkout "${PYTORCH_SPARSE_ROCM_COMMIT}"
+  git checkout 0.6.18-8-gcdbf561
   rm -rf build
-  CC=gcc CXX=g++ python setup.py build
-  CC=gcc CXX=g++ python setup.py install
+  CC=mpicc CXX=mpicxx python setup.py build
+  CC=mpicc CXX=mpicxx python setup.py install
   assert_numpy_1264
-  echo "pytorch_sparse pinned to commit: $(git rev-parse --short HEAD)"
   popd >/dev/null
 }
 
@@ -310,8 +286,8 @@ build_pytorch_cluster() {
   git fetch --all
   git checkout 1.6.3-11-g4126a52
   rm -rf build
-  CC=gcc CXX=g++ python setup.py build
-  CC=gcc CXX=g++ python setup.py install
+  CC=mpicc CXX=mpicxx python setup.py build
+  CC=mpicc CXX=mpicxx python setup.py install
   assert_numpy_1264
   popd >/dev/null
 }
@@ -326,8 +302,8 @@ build_pytorch_spline_conv() {
   git fetch --all
   git checkout 1.2.2-9-ga6d1020
   rm -rf build
-  CC=gcc CXX=g++ python setup.py build
-  CC=gcc CXX=g++ python setup.py install
+  CC=mpicc CXX=mpicxx python setup.py build
+  CC=mpicc CXX=mpicxx python setup.py install
   assert_numpy_1264
   popd >/dev/null
 }
@@ -354,12 +330,12 @@ assert_numpy_1264
 # ============================================================
 # ADIOS2
 # ============================================================
-ADIOS2_FRONTIER="${INSTALL_ROOT}/ADIOS2-Frontier"
-export ADIOS2_FRONTIER
+ADIOS2_ANDES="${INSTALL_ROOT}/ADIOS2-Andes"
+export ADIOS2_ANDES
 build_adios() {
   banner "ADIOS2 (v2.10.2)"
-  mkdir -p "$ADIOS2_FRONTIER"
-  cd "$ADIOS2_FRONTIER"
+  mkdir -p "$ADIOS2_ANDES"
+  cd "$ADIOS2_ANDES"
 
   if [[ ! -d ADIOS2/.git ]]; then
     git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git
@@ -367,52 +343,52 @@ build_adios() {
 
   mkdir -p adios2-build
 
-  CC=cc CXX=CC FC=ftn \
+  CC=mpicc CXX=mpicxx FC=mpifort \
   cmake -DCMAKE_INSTALL_PREFIX=$VENV_PATH \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_TESTING=OFF \
-      -DADIOS2_USE_MPI=ON \
-      -DADIOS2_USE_Fortran=OFF \
-      -DADIOS2_BUILD_EXAMPLES_EXPERIMENTAL=OFF \
-      -DADIOS2_BUILD_TESTING=OFF \
-      -DADIOS2_USE_HDF5=OFF \
-      -DADIOS2_USE_SST=OFF \
-      -DADIOS2_USE_BZip2=OFF \
-      -DADIOS2_USE_PNG=OFF \
-      -DADIOS2_USE_DataSpaces=OFF \
-      -DADIOS2_USE_Python=ON \
-      -DPython_EXECUTABLE=$(which python) \
-      -B adios2-build -S ADIOS2
+        -DCMAKE_BUILD_TYPE=Release \
+        -DBUILD_TESTING=OFF \
+        -DADIOS2_USE_MPI=ON \
+        -DADIOS2_USE_Fortran=OFF \
+        -DADIOS2_BUILD_EXAMPLES_EXPERIMENTAL=OFF \
+        -DADIOS2_BUILD_TESTING=OFF \
+        -DADIOS2_USE_HDF5=OFF \
+        -DADIOS2_USE_SST=OFF \
+        -DADIOS2_USE_BZip2=OFF \
+        -DADIOS2_USE_PNG=OFF \
+        -DADIOS2_USE_DataSpaces=OFF \
+        -DADIOS2_USE_Python=ON \
+        -DPython_EXECUTABLE=$(which python) \
+        -B adios2-build -S ADIOS2
 
-  cmake --build adios2-build -j32
-  cmake --install adios2_build 2>/dev/null || cmake --install adios2-build
+  cmake --build adios2-build -j$(nproc || echo 16)
+  cmake --install adios2-build
 }
 
 # ============================================================
 # DDStore
 # ============================================================
-DDSTORE_FRONTIER="${INSTALL_ROOT}/DDStore-Frontier"
-export DDSTORE_FRONTIER
+DDSTORE_ANDES="${INSTALL_ROOT}/DDStore-Andes"
+export DDSTORE_ANDES
 build_ddstore() {
   banner "DDStore"
-  mkdir -p "$DDSTORE_FRONTIER"
-  cd "$DDSTORE_FRONTIER"
+  mkdir -p "$DDSTORE_ANDES"
+  cd "$DDSTORE_ANDES"
 
   git clone git@github.com:ORNL/DDStore.git || true
   pushd DDStore >/dev/null
-  CC=cc CXX=CC pip_retry . --no-build-isolation --verbose
+  CC=mpicc CXX=mpicxx pip_retry . --no-build-isolation --verbose
   popd >/dev/null
 }
 
 # ============================================================
 # DeepHyper
 # ============================================================
-DEEPHYPER_FRONTIER="${INSTALL_ROOT}/DeepHyperFrontier"
-export DEEPHYPER_FRONTIER
+DEEPHYPER_ANDES="${INSTALL_ROOT}/DeepHyper-Andes"
+export DEEPHYPER_ANDES
 build_deephyper() {
   banner "DeepHyper (develop branch)"
-  mkdir -p "$DEEPHYPER_FRONTIER"
-  cd "$DEEPHYPER_FRONTIER"
+  mkdir -p "$DEEPHYPER_ANDES"
+  cd "$DEEPHYPER_ANDES"
 
   git clone https://github.com/deephyper/deephyper.git || true
   cd deephyper
@@ -423,33 +399,34 @@ build_deephyper() {
 # ============================================================
 # GPTL
 # ============================================================
-GPTL_FRONTIER="${INSTALL_ROOT}/GPTLFrontier"
-export GPTL_FRONTIER
+GPTL_ANDES="${INSTALL_ROOT}/GPTL-Andes"
+export GPTL_ANDES
 build_gptl() {
   banner "GPTL"
-  mkdir -p "$GPTL_FRONTIER"
-  cd "$GPTL_FRONTIER"
+  mkdir -p "$GPTL_ANDES"
+  cd "$GPTL_ANDES"
 
   wget https://github.com/jmrosinski/GPTL/releases/download/v8.1.1/gptl-8.1.1.tar.gz
   tar xvf gptl-8.1.1.tar.gz
   pushd gptl-8.1.1 >/dev/null
-  ./configure --prefix=$VENV_PATH --disable-libunwind CC=cc CXX=CC FC=ftn
+  ./configure --prefix=$VENV_PATH --disable-libunwind CC=mpicc CXX=mpicxx FC=mpifort
   make install
   popd >/dev/null
 
   git clone https://github.com/jychoi-hpc/gptl4py.git || true
   pushd gptl4py >/dev/null
-  GPTL_DIR=$VENV_PATH CC=cc CXX=CC pip_retry . --no-build-isolation --verbose
+  GPTL_DIR=$VENV_PATH CC=mpicc CXX=mpicxx pip_retry . --no-build-isolation --verbose
   popd >/dev/null
 }
 
 ## parallel build
 cd "$INSTALL_ROOT"
-banner "Adios, DDStore, DeepHyper, and GPTL build (in parallel)"
+banner "Adios, DDStore and DeepHyper build (in parallel)"
 timeit build_adios > build_adios.log & pid1=$!
 timeit build_ddstore > build_ddstore.log & pid2=$!
 timeit build_deephyper > build_deephyper.log & pid3=$!
 timeit build_gptl > build_gptl.log & pid4=$!
+
 for pid in $pid1 $pid2 $pid3 $pid4; do
     progress $pid &
 done
@@ -458,22 +435,37 @@ wait
 # ============================================================
 # Final Summary
 # ============================================================
-banner "Final Summary"
+banner "Final Summary (Andes)"
 cat <<EOF
 Base install:        $INSTALL_ROOT
 Virtual environment: $VENV_PATH
-PyTorch-Geometric:   $PYG_FRONTIER
-  - pytorch_scatter fork: ${PYTORCH_SCATTER_ROCM_REPO} @ ${PYTORCH_SCATTER_ROCM_COMMIT} (temporary)
-  - pytorch_sparse:       0.6.18-8-gcdbf561
-  - pytorch_cluster:      1.6.3-11-g4126a52
-  - pytorch_spline_conv:  1.2.2-9-ga6d1020
-MPI4PY:              $MPI4PY_FRONTIER
-ADIOS2:              $ADIOS2_FRONTIER
-DDStore:             $DDSTORE_FRONTIER
-DeepHyper:           $DEEPHYPER_FRONTIER
+
+PyTorch (CPU-only):  from ${PYTORCH_CPU_INDEX_URL}
+PyTorch-Geometric:   $PYG_ANDES
+  - pytorch_scatter:     2.1.2-9-g7cabb53 (official)
+  - pytorch_sparse:      0.6.18-8-gcdbf561 (official)
+  - pytorch_cluster:     1.6.3-11-g4126a52 (official)
+  - pytorch_spline_conv: 1.2.2-9-ga6d1020 (official)
+
+MPI4PY:              $MPI4PY_ANDES
+ADIOS2:              $ADIOS2_ANDES
+DDStore:             $DDSTORE_ANDES
+DeepHyper:           $DEEPHYPER_ANDES
 EOF
 
-echo "✅ HydraGNN-Installation-Frontier environment setup complete!"
+echo "✅ HydraGNN-Installation-Andes environment setup complete!"
+
 echo ""
-print_frontier_activation_instructions "${FRONTIER_ROCM_MODULE_VERSION}" "${FRONTIER_AMD_MIXED_MODULE_VERSION}" "${VENV_PATH}"
+echo "Use the following commands to activate the new HydraGNN python environment:"
+echo "  module reset"
+echo "  ml hsi/5.0.2.p5"
+echo "  ml gcc/9.3.0"
+echo "  ml openmpi/4.0.4"
+echo "  ml DefApps"
+echo "  ml cmake/3.22.2"
+echo "  ml git-lfs/2.11.0"
+echo "  ml miniforge3/23.11.0-0"
+echo "  ml libfabric/1.14.0"
+echo ""
+echo "  source activate ${VENV_PATH}"
 

--- a/scripts/hpc/olcf/andes/installation/install.sh
+++ b/scripts/hpc/olcf/andes/installation/install.sh
@@ -11,37 +11,6 @@ hr() { printf '%*s\n' "${COLUMNS:-80}" '' | tr ' ' '='; }
 banner() { hr; echo ">>> $1"; hr; }
 subbanner() { echo "-- $1"; }
 
-timeit() {
-  SECONDS=0
-  local start_time=$(date +"%T")
-  echo "[$start_time] Starting: $*" >&2
-  "$@"
-  local status=$?
-  local end_time=$(date +"%T")
-  echo "[$end_time] Finished: $* (Elapsed: ${SECONDS}s, Status: $status)" >&2
-  return $status
-}
-
-# Spinner function
-progress() {
-  local pid=$1
-  local delay=0.1
-
-  spinstr[0]="-"
-  spinstr[1]="\\"
-  spinstr[2]="|"
-  spinstr[3]="/"
-
-  echo -n "${spinstr[0]}"
-  while kill -0 $pid 2>/dev/null; do
-    for c in "${spinstr[@]}"; do
-      echo -ne "\b$c"
-      sleep $delay
-    done
-  done
-  echo -ne "\b"
-}
-
 banner "Starting HydraGNN environment setup on ANDES ($(date))"
 
 # ============================================================
@@ -191,23 +160,7 @@ pip_retry mendeleev==0.16.0
 pip_retry lmdb
 pip_retry h5py==3.14.0 
 pip_retry tensorflow
-pip_retry tensorflow_datasets
 pip_retry vesin==0.4.2
-
-# ============================================================
-# mpi4py
-# ============================================================
-banner "mpi4py (v4.1.1)"
-MPI4PY_ANDES="${INSTALL_ROOT}/MPI4PY-Andes"
-export MPI4PY_ANDES
-mkdir -p "$MPI4PY_ANDES"
-cd "$MPI4PY_ANDES"
-
-git clone -b 4.1.1 https://github.com/mpi4py/mpi4py.git || true
-pushd mpi4py >/dev/null
-rm -rf build
-CC=mpicc MPICC=mpicc pip_retry . --verbose
-popd >/dev/null
 
 # ============================================================
 # PyTorch (CPU-only) + torchvision
@@ -244,193 +197,164 @@ assert_numpy_1264
 popd >/dev/null
 
 # --- pytorch_scatter (official repo & stable ref for CPU) ---
-build_pytorch_scatter() {
-  subbanner "pytorch_scatter (official @ 2.1.2-9-g7cabb53)"
-  if [[ ! -d pytorch_scatter/.git ]]; then
-    git clone --recursive git@github.com:rusty1s/pytorch_scatter.git
-  fi
-  pushd pytorch_scatter >/dev/null
-  git fetch --all
-  git checkout 2.1.2-9-g7cabb53
-  git submodule update --init --recursive
-  rm -rf build
-  CC=mpicc CXX=mpicxx python setup.py build
-  CC=mpicc CXX=mpicxx python setup.py install
-  assert_numpy_1264
-  popd >/dev/null
-}
+subbanner "pytorch_scatter (official @ 2.1.2-9-g7cabb53)"
+if [[ ! -d pytorch_scatter/.git ]]; then
+  git clone --recursive git@github.com:rusty1s/pytorch_scatter.git
+fi
+pushd pytorch_scatter >/dev/null
+git fetch --all
+git checkout 2.1.2-9-g7cabb53
+git submodule update --init --recursive
+rm -rf build
+CC=mpicc CXX=mpicxx python setup.py build
+CC=mpicc CXX=mpicxx python setup.py install
+assert_numpy_1264
+popd >/dev/null
 
 # --- pytorch_sparse (official pinned) ---
-build_pytorch_sparse() {
-  subbanner "pytorch_sparse (official @ 0.6.18-8-gcdbf561)"
-  if [[ ! -d pytorch_sparse/.git ]]; then
-    git clone --recursive git@github.com:rusty1s/pytorch_sparse.git
-  fi
-  pushd pytorch_sparse >/dev/null
-  git fetch --all
-  git checkout 0.6.18-8-gcdbf561
-  rm -rf build
-  CC=mpicc CXX=mpicxx python setup.py build
-  CC=mpicc CXX=mpicxx python setup.py install
-  assert_numpy_1264
-  popd >/dev/null
-}
+subbanner "pytorch_sparse (official @ 0.6.18-8-gcdbf561)"
+if [[ ! -d pytorch_sparse/.git ]]; then
+  git clone --recursive git@github.com:rusty1s/pytorch_sparse.git
+fi
+pushd pytorch_sparse >/dev/null
+git fetch --all
+git checkout 0.6.18-8-gcdbf561
+rm -rf build
+CC=mpicc CXX=mpicxx python setup.py build
+CC=mpicc CXX=mpicxx python setup.py install
+assert_numpy_1264
+popd >/dev/null
 
 # --- pytorch_cluster (official pinned) ---
-build_pytorch_cluster() {
-  subbanner "pytorch_cluster (official @ 1.6.3-11-g4126a52)"
-  if [[ ! -d pytorch_cluster/.git ]]; then
-    git clone --recursive git@github.com:rusty1s/pytorch_cluster.git
-  fi
-  pushd pytorch_cluster >/dev/null
-  git fetch --all
-  git checkout 1.6.3-11-g4126a52
-  rm -rf build
-  CC=mpicc CXX=mpicxx python setup.py build
-  CC=mpicc CXX=mpicxx python setup.py install
-  assert_numpy_1264
-  popd >/dev/null
-}
+subbanner "pytorch_cluster (official @ 1.6.3-11-g4126a52)"
+if [[ ! -d pytorch_cluster/.git ]]; then
+  git clone --recursive git@github.com:rusty1s/pytorch_cluster.git
+fi
+pushd pytorch_cluster >/dev/null
+git fetch --all
+git checkout 1.6.3-11-g4126a52
+rm -rf build
+CC=mpicc CXX=mpicxx python setup.py build
+CC=mpicc CXX=mpicxx python setup.py install
+assert_numpy_1264
+popd >/dev/null
 
 # --- pytorch_spline_conv (official pinned) ---
-build_pytorch_spline_conv() {
-  subbanner "pytorch_spline_conv (official @ 1.2.2-9-ga6d1020)"
-  if [[ ! -d pytorch_spline_conv/.git ]]; then
-    git clone --recursive git@github.com:rusty1s/pytorch_spline_conv.git
-  fi
-  pushd pytorch_spline_conv >/dev/null
-  git fetch --all
-  git checkout 1.2.2-9-ga6d1020
-  rm -rf build
-  CC=mpicc CXX=mpicxx python setup.py build
-  CC=mpicc CXX=mpicxx python setup.py install
-  assert_numpy_1264
-  popd >/dev/null
-}
+subbanner "pytorch_spline_conv (official @ 1.2.2-9-ga6d1020)"
+if [[ ! -d pytorch_spline_conv/.git ]]; then
+  git clone --recursive git@github.com:rusty1s/pytorch_spline_conv.git
+fi
+pushd pytorch_spline_conv >/dev/null
+git fetch --all
+git checkout 1.2.2-9-ga6d1020
+rm -rf build
+CC=mpicc CXX=mpicxx python setup.py build
+CC=mpicc CXX=mpicxx python setup.py install
+assert_numpy_1264
+popd >/dev/null
 
-## parallel build
-banner "pytorch geometric dependencies build (in parallel)"
-timeit build_pytorch_scatter > build_pytorch_scatter.log & pid1=$!
-timeit build_pytorch_sparse > build_pytorch_sparse.log & pid2=$!
-timeit build_pytorch_cluster > build_pytorch_cluster.log & pid3=$!
-timeit build_pytorch_spline_conv > build_pytorch_spline_conv.log & pid4=$!
-
-for pid in $pid1 $pid2 $pid3 $pid4; do
-    progress $pid &
-done
-wait
-
-# ============================================================
-# e3nn and openequivariance
-# ============================================================
-banner "Install e3nn and openequivariance"
+subbanner "Install e3nn and openequivariance"
 pip_retry e3nn openequivariance --verbose
 assert_numpy_1264
 
 # ============================================================
+# mpi4py
+# ============================================================
+banner "mpi4py (v4.1.1)"
+MPI4PY_ANDES="${INSTALL_ROOT}/MPI4PY-Andes"
+export MPI4PY_ANDES
+mkdir -p "$MPI4PY_ANDES"
+cd "$MPI4PY_ANDES"
+
+git clone -b 4.1.1 https://github.com/mpi4py/mpi4py.git || true
+pushd mpi4py >/dev/null
+rm -rf build
+CC=mpicc MPICC=mpicc pip_retry . --verbose
+popd >/dev/null
+
+# ============================================================
 # ADIOS2
 # ============================================================
+banner "ADIOS2 (v2.10.2)"
 ADIOS2_ANDES="${INSTALL_ROOT}/ADIOS2-Andes"
 export ADIOS2_ANDES
-build_adios() {
-  banner "ADIOS2 (v2.10.2)"
-  mkdir -p "$ADIOS2_ANDES"
-  cd "$ADIOS2_ANDES"
+mkdir -p "$ADIOS2_ANDES"
+cd "$ADIOS2_ANDES"
 
-  if [[ ! -d ADIOS2/.git ]]; then
-    git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git
-  fi
+if [[ ! -d ADIOS2/.git ]]; then
+  git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git
+fi
 
-  mkdir -p adios2-build
+mkdir -p adios2-build
 
-  CC=mpicc CXX=mpicxx FC=mpifort \
-  cmake -DCMAKE_INSTALL_PREFIX=$VENV_PATH \
-        -DCMAKE_BUILD_TYPE=Release \
-        -DBUILD_TESTING=OFF \
-        -DADIOS2_USE_MPI=ON \
-        -DADIOS2_USE_Fortran=OFF \
-        -DADIOS2_BUILD_EXAMPLES_EXPERIMENTAL=OFF \
-        -DADIOS2_BUILD_TESTING=OFF \
-        -DADIOS2_USE_HDF5=OFF \
-        -DADIOS2_USE_SST=OFF \
-        -DADIOS2_USE_BZip2=OFF \
-        -DADIOS2_USE_PNG=OFF \
-        -DADIOS2_USE_DataSpaces=OFF \
-        -DADIOS2_USE_Python=ON \
-        -DPython_EXECUTABLE=$(which python) \
-        -B adios2-build -S ADIOS2
+CC=mpicc CXX=mpicxx FC=mpifort \
+cmake -DCMAKE_INSTALL_PREFIX=$VENV_PATH \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING=OFF \
+      -DADIOS2_USE_MPI=ON \
+      -DADIOS2_USE_Fortran=OFF \
+      -DADIOS2_BUILD_EXAMPLES_EXPERIMENTAL=OFF \
+      -DADIOS2_BUILD_TESTING=OFF \
+      -DADIOS2_USE_HDF5=OFF \
+      -DADIOS2_USE_SST=OFF \
+      -DADIOS2_USE_BZip2=OFF \
+      -DADIOS2_USE_PNG=OFF \
+      -DADIOS2_USE_DataSpaces=OFF \
+      -DADIOS2_USE_Python=ON \
+      -DPython_EXECUTABLE=$(which python) \
+      -B adios2-build -S ADIOS2
 
-  cmake --build adios2-build -j$(nproc || echo 16)
-  cmake --install adios2-build
-}
+cmake --build adios2-build -j$(nproc || echo 16)
+cmake --install adios2-build
 
 # ============================================================
 # DDStore
 # ============================================================
+banner "DDStore"
 DDSTORE_ANDES="${INSTALL_ROOT}/DDStore-Andes"
 export DDSTORE_ANDES
-build_ddstore() {
-  banner "DDStore"
-  mkdir -p "$DDSTORE_ANDES"
-  cd "$DDSTORE_ANDES"
+mkdir -p "$DDSTORE_ANDES"
+cd "$DDSTORE_ANDES"
 
-  git clone git@github.com:ORNL/DDStore.git || true
-  pushd DDStore >/dev/null
-  CC=mpicc CXX=mpicxx pip_retry . --no-build-isolation --verbose
-  popd >/dev/null
-}
+git clone git@github.com:ORNL/DDStore.git || true
+pushd DDStore >/dev/null
+CC=mpicc CXX=mpicxx pip_retry . --no-build-isolation --verbose
+popd >/dev/null
 
 # ============================================================
 # DeepHyper
 # ============================================================
+banner "DeepHyper (develop branch)"
 DEEPHYPER_ANDES="${INSTALL_ROOT}/DeepHyper-Andes"
 export DEEPHYPER_ANDES
-build_deephyper() {
-  banner "DeepHyper (develop branch)"
-  mkdir -p "$DEEPHYPER_ANDES"
-  cd "$DEEPHYPER_ANDES"
+mkdir -p "$DEEPHYPER_ANDES"
+cd "$DEEPHYPER_ANDES"
 
-  git clone https://github.com/deephyper/deephyper.git || true
-  cd deephyper
-  pip_retry -e . --verbose
-  assert_numpy_1264
-}
+git clone https://github.com/deephyper/deephyper.git || true
+cd deephyper
+pip_retry -e . --verbose
+assert_numpy_1264
 
 # ============================================================
 # GPTL
 # ============================================================
+banner "GPTL"
 GPTL_ANDES="${INSTALL_ROOT}/GPTL-Andes"
 export GPTL_ANDES
-build_gptl() {
-  banner "GPTL"
-  mkdir -p "$GPTL_ANDES"
-  cd "$GPTL_ANDES"
+mkdir -p "$GPTL_ANDES"
+cd "$GPTL_ANDES"
 
-  wget https://github.com/jmrosinski/GPTL/releases/download/v8.1.1/gptl-8.1.1.tar.gz
-  tar xvf gptl-8.1.1.tar.gz
-  pushd gptl-8.1.1 >/dev/null
-  ./configure --prefix=$VENV_PATH --disable-libunwind CC=mpicc CXX=mpicxx FC=mpifort
-  make install
-  popd >/dev/null
+wget https://github.com/jmrosinski/GPTL/releases/download/v8.1.1/gptl-8.1.1.tar.gz
+tar xvf gptl-8.1.1.tar.gz
+pushd gptl-8.1.1 >/dev/null
+./configure --prefix=$VENV_PATH --disable-libunwind CC=mpicc CXX=mpicxx FC=mpifort
+make install
+popd >/dev/null
 
-  git clone https://github.com/jychoi-hpc/gptl4py.git || true
-  pushd gptl4py >/dev/null
-  GPTL_DIR=$VENV_PATH CC=mpicc CXX=mpicxx pip_retry . --no-build-isolation --verbose
-  popd >/dev/null
-}
-
-## parallel build
-cd "$INSTALL_ROOT"
-banner "Adios, DDStore and DeepHyper build (in parallel)"
-timeit build_adios > build_adios.log & pid1=$!
-timeit build_ddstore > build_ddstore.log & pid2=$!
-timeit build_deephyper > build_deephyper.log & pid3=$!
-timeit build_gptl > build_gptl.log & pid4=$!
-
-for pid in $pid1 $pid2 $pid3 $pid4; do
-    progress $pid &
-done
-wait
+git clone https://github.com/jychoi-hpc/gptl4py.git || true
+pushd gptl4py >/dev/null
+GPTL_DIR=$VENV_PATH CC=mpicc CXX=mpicxx pip_retry . --no-build-isolation --verbose
+popd >/dev/null
 
 # ============================================================
 # Final Summary
@@ -468,5 +392,4 @@ echo "  ml miniforge3/23.11.0-0"
 echo "  ml libfabric/1.14.0"
 echo ""
 echo "  source activate ${VENV_PATH}"
-
 

--- a/scripts/hpc/olcf/frontier/environments/interactive-rocm713.sh
+++ b/scripts/hpc/olcf/frontier/environments/interactive-rocm713.sh
@@ -1,6 +1,6 @@
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "${script_dir}/../../../../.." && pwd)
-source "${repo_root}/installation_DOE_supercomputers/olcf_proxy_env.sh"
+source "${repo_root}/scripts/hpc/olcf/proxy-env.sh"
 
 function cmd() {
     echo "$@"
@@ -12,7 +12,7 @@ function cmd() {
 # HSA_STATUS_ERROR_ILLEGAL_INSTRUCTION MI250X collective crash seen on the old
 # ROCm 7.1.x / 6.4 RCCL) plus the validated lumina-sdk RCCL runtime config.
 HYDRAGNN_ROOT="${HYDRAGNN_ROOT:-/lustre/orion/lrn070/world-shared/mlupopa/HydraGNN}"
-VENV_PATH="${VENV_PATH:-/lustre/orion/lrn070/world-shared/mlupopa/HydraGNN/installation_DOE_supercomputers/HydraGNN-Installation-Frontier-ROCm713/hydragnn_venv_rocm713}"
+VENV_PATH="${VENV_PATH:-/lustre/orion/lrn070/world-shared/mlupopa/HydraGNN/HydraGNN-Installation-Frontier-ROCm713/hydragnn_venv_rocm713}"
 
 # Load ROCm 7.13 module stack + conda environment
 source /lustre/orion/lrn070/world-shared/mlupopa/module-to-load-frontier-rocm713.sh

--- a/scripts/hpc/olcf/frontier/environments/interactive.sh
+++ b/scripts/hpc/olcf/frontier/environments/interactive.sh
@@ -1,6 +1,6 @@
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "${script_dir}/../../../../.." && pwd)
-source "${repo_root}/installation_DOE_supercomputers/olcf_proxy_env.sh"
+source "${repo_root}/scripts/hpc/olcf/proxy-env.sh"
 
 function cmd() {
     echo "$@"

--- a/scripts/hpc/olcf/frontier/environments/mptrj-interactive.sh
+++ b/scripts/hpc/olcf/frontier/environments/mptrj-interactive.sh
@@ -1,6 +1,6 @@
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 repo_root=$(cd "${script_dir}/../../../../.." && pwd)
-source "${repo_root}/installation_DOE_supercomputers/olcf_proxy_env.sh"
+source "${repo_root}/scripts/hpc/olcf/proxy-env.sh"
 
 function cmd() {
     echo "$@"

--- a/scripts/hpc/olcf/frontier/installation/install-parallel-rocm64.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-parallel-rocm64.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # setup_env.sh
 # Complete automated setup for HydraGNN environment and dependencies on Frontier.
-# Updated to ROCm 7.1 (module rocm/7.1.1) and PyTorch wheels from https://download.pytorch.org/whl/rocm7.1
 
 set -Eeuo pipefail
 
@@ -15,14 +14,45 @@ subbanner() { echo "-- $1"; }
 # =========================
 # Config (env-overridable)
 # =========================
-FRONTIER_ROCM_MODULE_VERSION="${FRONTIER_ROCM_MODULE_VERSION:-7.1.1}"
-FRONTIER_AMD_MIXED_MODULE_VERSION="${FRONTIER_AMD_MIXED_MODULE_VERSION:-7.1.1}"
-EXPECTED_ROCM_MM="${EXPECTED_ROCM_MM:-7.1}"
+FRONTIER_ROCM_MODULE_VERSION="${FRONTIER_ROCM_MODULE_VERSION:-6.4.0}"
+FRONTIER_AMD_MIXED_MODULE_VERSION="${FRONTIER_AMD_MIXED_MODULE_VERSION:-6.4.0}"
+EXPECTED_ROCM_MM="${EXPECTED_ROCM_MM:-6.4}"
 PYTORCH_ROCM_INDEX_URL="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm${EXPECTED_ROCM_MM}}"
 PYTORCH_SCATTER_ROCM_REPO="${PYTORCH_SCATTER_ROCM_REPO:-https://github.com/Looong01/pytorch_scatter-rocm.git}"
 PYTORCH_SCATTER_ROCM_COMMIT="${PYTORCH_SCATTER_ROCM_COMMIT:-9799c51}"
 PYTORCH_SPARSE_ROCM_REPO="${PYTORCH_SPARSE_ROCM_REPO:-https://github.com/Looong01/pytorch_sparse-rocm.git}"
 PYTORCH_SPARSE_ROCM_COMMIT="${PYTORCH_SPARSE_ROCM_COMMIT:-2340737}"
+
+timeit() {
+  SECONDS=0
+  local start_time=$(date +"%T")
+  echo "[$start_time] Starting: $*" >&2
+  "$@"
+  local status=$?
+  local end_time=$(date +"%T")
+  echo "[$end_time] Finished: $* (Elapsed: ${SECONDS}s, Status: $status)" >&2
+  return $status
+}
+
+# Spinner function
+progress() {
+  local pid=$1
+  local delay=0.1
+
+  spinstr[0]="-"
+  spinstr[1]="\\"
+  spinstr[2]="|"
+  spinstr[3]="/"
+
+  echo -n "${spinstr[0]}"
+  while kill -0 $pid 2>/dev/null; do
+    for c in "${spinstr[@]}"; do
+      echo -ne "\b$c"
+      sleep $delay
+    done
+  done
+  echo -ne "\b"
+}
 
 banner "Starting HydraGNN environment setup ($(date))"
 
@@ -32,7 +62,7 @@ banner "Starting HydraGNN environment setup ($(date))"
 banner "Configure Frontier Modules"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
-source "${SCRIPT_DIR}/module_loads_frontier.sh"
+source "${SCRIPT_DIR}/module-loads.sh"
 load_frontier_modules "${FRONTIER_ROCM_MODULE_VERSION}" "${FRONTIER_AMD_MIXED_MODULE_VERSION}"
 
 # ============================================================
@@ -56,19 +86,25 @@ echo "Virtual environment path: $VENV_PATH"
 PYTHON_VERSION="${PYTHON_VERSION:-3.11}"
 echo "Python version: ${PYTHON_VERSION}"
 
+RECREATE_ENV="${RECREATE_ENV:-0}"
+
 if ! command -v conda >/dev/null 2>&1; then
   echo "❌ Conda command not found. Ensure miniforge3 is properly loaded."
   exit 1
 fi
 
-if [[ -d "$VENV_PATH" ]]; then
+if [[ -d "$VENV_PATH" && "$RECREATE_ENV" -eq 1 ]]; then
   echo "Removing existing conda environment at: $VENV_PATH"
   source deactivate >/dev/null 2>&1 || true
   conda env remove -p "$VENV_PATH" -y || rm -rf "$VENV_PATH"
 fi
 
-echo "Creating conda environment at $VENV_PATH with Python $PYTHON_VERSION"
-conda create -y -p "$VENV_PATH" python="$PYTHON_VERSION"
+if [[ -d "$VENV_PATH" ]]; then
+  echo "Conda environment already exists at $VENV_PATH"
+else
+  echo "Creating conda environment at $VENV_PATH with Python $PYTHON_VERSION"
+  conda create -y -p "$VENV_PATH" python="$PYTHON_VERSION"
+fi
 
 # shellcheck disable=SC1091
 source activate "$VENV_PATH"
@@ -114,23 +150,23 @@ assert_numpy_1264
 banner "Install Core Python Packages"
 
 pip_retry ninja
-pip_retry astunparse
-pip_retry expecttest
-pip_retry hypothesis
-pip_retry numpy==1.26.4
-pip_retry psutil==7.1.0
-pip_retry pyyaml
-pip_retry requests
-pip_retry setuptools
-pip_retry typing-extensions
-pip_retry sympy==1.14.0
-pip_retry filelock
-pip_retry networkx
-pip_retry jinja2
+pip_retry astunparse 
+pip_retry expecttest 
+pip_retry hypothesis 
+pip_retry numpy==1.26.4 
+pip_retry psutil==7.1.0 
+pip_retry pyyaml 
+pip_retry requests 
+pip_retry setuptools 
+pip_retry typing-extensions 
+pip_retry sympy==1.14.0 
+pip_retry filelock 
+pip_retry networkx 
+pip_retry jinja2 
 pip_retry tqdm==4.67.1
 pip_retry types-dataclasses
-pip_retry scipy==1.14.1
-pip_retry pyparsing
+pip_retry scipy==1.14.1 
+pip_retry pyparsing 
 pip_retry build
 pip_retry Cython
 pip_retry tensorboard==2.20.0
@@ -144,10 +180,25 @@ pip_retry pymatgen
 pip_retry igraph
 pip_retry mendeleev==0.16.0
 pip_retry lmdb
-pip_retry h5py==3.14.0
+pip_retry h5py==3.14.0 
 pip_retry tensorflow
 pip_retry tensorflow_datasets
 pip_retry vesin==0.4.2
+
+# ============================================================
+# mpi4py
+# ============================================================
+banner "mpi4py (v4.1.1)"
+MPI4PY_FRONTIER="${INSTALL_ROOT}/MPI4PY-Frontier"
+export MPI4PY_FRONTIER
+mkdir -p "$MPI4PY_FRONTIER"
+cd "$MPI4PY_FRONTIER"
+
+git clone -b 4.1.1 https://github.com/mpi4py/mpi4py.git || true
+pushd mpi4py >/dev/null
+rm -rf build
+CC=cc MPICC=cc pip_retry . --verbose
+popd >/dev/null
 
 # ============================================================
 # ROCm detection + ROCm-aware PyTorch
@@ -181,24 +232,16 @@ subbanner "Install ROCm PyTorch from ${PYTORCH_ROCM_INDEX_URL}"
 pip_retry --index-url "${PYTORCH_ROCM_INDEX_URL}" torch torchvision
 assert_numpy_1264
 
-python - <<'PY'
+python - <<PY
 import torch
 print("torch.__version__ =", torch.__version__)
 print("torch.version.hip =", torch.version.hip)
-print("torch.cuda.is_available() =", torch.cuda.is_available())  # ROCm uses torch.cuda API
-print("torch.cuda.device_count() =", torch.cuda.device_count())
-if torch.cuda.device_count() > 0:
-    print("GPU[0] =", torch.cuda.get_device_name(0))
 PY
 
 # ============================================================
 # PyTorch-Geometric stack
 # ============================================================
 banner "PyTorch-Geometric Stack (ROCm ${ROCM_MM})"
-
-# Recommended for MI250X builds
-export PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH:-gfx90a}"
-
 PYG_DIR_NAME="PyTorch-Geometric-${ROCM_MM}"
 PYG_FRONTIER="${INSTALL_ROOT}/${PYG_DIR_NAME}"
 export PYG_FRONTIER
@@ -216,177 +259,201 @@ assert_numpy_1264
 popd >/dev/null
 
 # --- pytorch_scatter (ROCm fork pinned) ---
-subbanner "pytorch_scatter (ROCm fork pinned to ${PYTORCH_SCATTER_ROCM_COMMIT}; temporary until upstream merges)"
-if [[ ! -d pytorch_scatter/.git ]]; then
-  # Official upstream (kept for reference; will switch back after merge):
-  # git clone --recursive git@github.com:rusty1s/pytorch_scatter.git
-  # Temporary ROCm fork (use until fixes merge upstream):
-  git clone --recursive "${PYTORCH_SCATTER_ROCM_REPO}" pytorch_scatter
-fi
-pushd pytorch_scatter >/dev/null
-git fetch --all
-git checkout "${PYTORCH_SCATTER_ROCM_COMMIT}"
-git submodule update --init --recursive
-rm -rf build
-CC=gcc CXX=g++ python setup.py build
-CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
-echo "pytorch_scatter pinned to commit: $(git rev-parse --short HEAD)"
-popd >/dev/null
+build_pytorch_scatter() {
+  subbanner "pytorch_scatter (ROCm fork pinned to ${PYTORCH_SCATTER_ROCM_COMMIT}; temporary until upstream merges)"
+  if [[ ! -d pytorch_scatter/.git ]]; then
+    # Official upstream (kept for reference; will switch back after merge):
+    # git clone --recursive git@github.com:rusty1s/pytorch_scatter.git
+    # Temporary ROCm fork (use until fixes merge upstream):
+    git clone --recursive "${PYTORCH_SCATTER_ROCM_REPO}" pytorch_scatter
+  fi
+  pushd pytorch_scatter >/dev/null
+  git fetch --all
+  git checkout "${PYTORCH_SCATTER_ROCM_COMMIT}"
+  git submodule update --init --recursive
+  rm -rf build
+  # If needed: export PYTORCH_ROCM_ARCH=gfx90a
+  CC=gcc CXX=g++ python setup.py build
+  CC=gcc CXX=g++ python setup.py install
+  assert_numpy_1264
+  echo "pytorch_scatter pinned to commit: $(git rev-parse --short HEAD)"
+  popd >/dev/null
+}
 
-# --- pytorch_sparse (ROCm fork pinned) ---
-subbanner "pytorch_sparse (ROCm fork pinned to ${PYTORCH_SPARSE_ROCM_COMMIT}; temporary until upstream merges)"
-if [[ ! -d pytorch_sparse/.git ]]; then
-  # Official upstream (kept for reference; will switch back after merge):
-  # git clone --recursive git@github.com:rusty1s/pytorch_sparse.git
-  # Temporary ROCm fork (use until fixes merge upstream):
-  git clone --recursive "${PYTORCH_SPARSE_ROCM_REPO}" pytorch_sparse
-fi
-pushd pytorch_sparse >/dev/null
-git fetch --all
-git checkout "${PYTORCH_SPARSE_ROCM_COMMIT}"
-rm -rf build
-CC=gcc CXX=g++ python setup.py build
-CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
-echo "pytorch_sparse pinned to commit: $(git rev-parse --short HEAD)"
-popd >/dev/null
+# --- pytorch_sparse (official pinned) ---
+build_pytorch_sparse() {
+  subbanner "pytorch_sparse (official @ 0.6.18-8-gcdbf561)"
+  if [[ ! -d pytorch_sparse/.git ]]; then
+    # Official upstream (kept for reference; will switch back after merge):
+    # git clone --recursive git@github.com:rusty1s/pytorch_sparse.git
+    # Temporary ROCm fork (use until fixes merge upstream):
+    git clone --recursive "${PYTORCH_SPARSE_ROCM_REPO}" pytorch_sparse
+  fi
+  pushd pytorch_sparse >/dev/null
+  git fetch --all
+  git checkout "${PYTORCH_SPARSE_ROCM_COMMIT}"
+  rm -rf build
+  CC=gcc CXX=g++ python setup.py build
+  CC=gcc CXX=g++ python setup.py install
+  assert_numpy_1264
+  echo "pytorch_sparse pinned to commit: $(git rev-parse --short HEAD)"
+  popd >/dev/null
+}
 
 # --- pytorch_cluster (official pinned) ---
-subbanner "pytorch_cluster (official @ 1.6.3-11-g4126a52)"
-if [[ ! -d pytorch_cluster/.git ]]; then
-  git clone --recursive git@github.com:rusty1s/pytorch_cluster.git
-fi
-pushd pytorch_cluster >/dev/null
-git fetch --all
-git checkout 1.6.3-11-g4126a52
-rm -rf build
-CC=gcc CXX=g++ python setup.py build
-CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
-popd >/dev/null
+build_pytorch_cluster() {
+  subbanner "pytorch_cluster (official @ 1.6.3-11-g4126a52)"
+  if [[ ! -d pytorch_cluster/.git ]]; then
+    git clone --recursive git@github.com:rusty1s/pytorch_cluster.git
+  fi
+  pushd pytorch_cluster >/dev/null
+  git fetch --all
+  git checkout 1.6.3-11-g4126a52
+  rm -rf build
+  CC=gcc CXX=g++ python setup.py build
+  CC=gcc CXX=g++ python setup.py install
+  assert_numpy_1264
+  popd >/dev/null
+}
 
 # --- pytorch_spline_conv (official pinned) ---
-subbanner "pytorch_spline_conv (official @ 1.2.2-9-ga6d1020)"
-if [[ ! -d pytorch_spline_conv/.git ]]; then
-  git clone --recursive git@github.com:rusty1s/pytorch_spline_conv.git
-fi
-pushd pytorch_spline_conv >/dev/null
-git fetch --all
-git checkout 1.2.2-9-ga6d1020
-rm -rf build
-CC=gcc CXX=g++ python setup.py build
-CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
-popd >/dev/null
+build_pytorch_spline_conv() {
+  subbanner "pytorch_spline_conv (official @ 1.2.2-9-ga6d1020)"
+  if [[ ! -d pytorch_spline_conv/.git ]]; then
+    git clone --recursive git@github.com:rusty1s/pytorch_spline_conv.git
+  fi
+  pushd pytorch_spline_conv >/dev/null
+  git fetch --all
+  git checkout 1.2.2-9-ga6d1020
+  rm -rf build
+  CC=gcc CXX=g++ python setup.py build
+  CC=gcc CXX=g++ python setup.py install
+  assert_numpy_1264
+  popd >/dev/null
+}
 
-subbanner "Install e3nn"
-pip_retry e3nn --verbose
-assert_numpy_1264
+## parallel build
+banner "pytorch geometric dependencies build (in parallel)"
+timeit build_pytorch_scatter > build_pytorch_scatter.log & pid1=$!
+timeit build_pytorch_sparse > build_pytorch_sparse.log & pid2=$!
+timeit build_pytorch_cluster > build_pytorch_cluster.log & pid3=$!
+timeit build_pytorch_spline_conv > build_pytorch_spline_conv.log & pid4=$!
 
-# NOTE: unload ROCm for mpi4py build
-module unload craype-accel-amd-gfx90a
-module unload rocm
-#######
+for pid in $pid1 $pid2 $pid3 $pid4; do
+    progress $pid &
+done
+wait
 
 # ============================================================
-# mpi4py
+# e3nn and openequivariance
 # ============================================================
-banner "mpi4py (v4.1.1)"
-MPI4PY_FRONTIER="${INSTALL_ROOT}/MPI4PY-Frontier"
-export MPI4PY_FRONTIER
-mkdir -p "$MPI4PY_FRONTIER"
-cd "$MPI4PY_FRONTIER"
-
-git clone -b 4.1.1 https://github.com/mpi4py/mpi4py.git || true
-pushd mpi4py >/dev/null
-rm -rf build
-CC=cc MPICC=cc pip_retry . --verbose
-popd >/dev/null
+banner "Install e3nn and openequivariance"
+pip_retry e3nn openequivariance --verbose
+assert_numpy_1264
 
 # ============================================================
 # ADIOS2
 # ============================================================
-banner "ADIOS2 (v2.10.2)"
 ADIOS2_FRONTIER="${INSTALL_ROOT}/ADIOS2-Frontier"
 export ADIOS2_FRONTIER
-mkdir -p "$ADIOS2_FRONTIER"
-cd "$ADIOS2_FRONTIER"
+build_adios() {
+  banner "ADIOS2 (v2.10.2)"
+  mkdir -p "$ADIOS2_FRONTIER"
+  cd "$ADIOS2_FRONTIER"
 
-if [[ ! -d ADIOS2/.git ]]; then
-  git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git
-fi
+  if [[ ! -d ADIOS2/.git ]]; then
+    git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git
+  fi
 
-mkdir -p adios2-build
+  mkdir -p adios2-build
 
-CC=cc CXX=CC FC=ftn \
-cmake -DCMAKE_INSTALL_PREFIX=$VENV_PATH \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_TESTING=OFF \
-    -DADIOS2_USE_MPI=ON \
-    -DADIOS2_USE_Fortran=OFF \
-    -DADIOS2_BUILD_EXAMPLES_EXPERIMENTAL=OFF \
-    -DADIOS2_BUILD_TESTING=OFF \
-    -DADIOS2_USE_HDF5=OFF \
-    -DADIOS2_USE_SST=OFF \
-    -DADIOS2_USE_BZip2=OFF \
-    -DADIOS2_USE_PNG=OFF \
-    -DADIOS2_USE_DataSpaces=OFF \
-    -DADIOS2_USE_Python=ON \
-    -DPython_EXECUTABLE=$(which python) \
-    -B adios2-build -S ADIOS2
+  CC=cc CXX=CC FC=ftn \
+  cmake -DCMAKE_INSTALL_PREFIX=$VENV_PATH \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_TESTING=OFF \
+      -DADIOS2_USE_MPI=ON \
+      -DADIOS2_USE_Fortran=OFF \
+      -DADIOS2_BUILD_EXAMPLES_EXPERIMENTAL=OFF \
+      -DADIOS2_BUILD_TESTING=OFF \
+      -DADIOS2_USE_HDF5=OFF \
+      -DADIOS2_USE_SST=OFF \
+      -DADIOS2_USE_BZip2=OFF \
+      -DADIOS2_USE_PNG=OFF \
+      -DADIOS2_USE_DataSpaces=OFF \
+      -DADIOS2_USE_Python=ON \
+      -DPython_EXECUTABLE=$(which python) \
+      -B adios2-build -S ADIOS2
 
-cmake --build adios2-build -j32
-cmake --install adios2_build 2>/dev/null || cmake --install adios2-build
+  cmake --build adios2-build -j32
+  cmake --install adios2_build 2>/dev/null || cmake --install adios2-build
+}
 
 # ============================================================
 # DDStore
 # ============================================================
-banner "DDStore"
 DDSTORE_FRONTIER="${INSTALL_ROOT}/DDStore-Frontier"
 export DDSTORE_FRONTIER
-mkdir -p "$DDSTORE_FRONTIER"
-cd "$DDSTORE_FRONTIER"
+build_ddstore() {
+  banner "DDStore"
+  mkdir -p "$DDSTORE_FRONTIER"
+  cd "$DDSTORE_FRONTIER"
 
-git clone git@github.com:ORNL/DDStore.git || true
-pushd DDStore >/dev/null
-CC=cc CXX=CC pip_retry . --no-build-isolation --verbose
-popd >/dev/null
+  git clone git@github.com:ORNL/DDStore.git || true
+  pushd DDStore >/dev/null
+  CC=cc CXX=CC pip_retry . --no-build-isolation --verbose
+  popd >/dev/null
+}
 
 # ============================================================
 # DeepHyper
 # ============================================================
-banner "DeepHyper (develop branch)"
 DEEPHYPER_FRONTIER="${INSTALL_ROOT}/DeepHyperFrontier"
 export DEEPHYPER_FRONTIER
-mkdir -p "$DEEPHYPER_FRONTIER"
-cd "$DEEPHYPER_FRONTIER"
+build_deephyper() {
+  banner "DeepHyper (develop branch)"
+  mkdir -p "$DEEPHYPER_FRONTIER"
+  cd "$DEEPHYPER_FRONTIER"
 
-git clone https://github.com/deephyper/deephyper.git || true
-cd deephyper
-pip_retry . --verbose
-assert_numpy_1264
+  git clone https://github.com/deephyper/deephyper.git || true
+  cd deephyper
+  pip_retry -e . --verbose
+  assert_numpy_1264
+}
 
 # ============================================================
 # GPTL
 # ============================================================
-banner "GPTL"
 GPTL_FRONTIER="${INSTALL_ROOT}/GPTLFrontier"
 export GPTL_FRONTIER
-mkdir -p "$GPTL_FRONTIER"
-cd "$GPTL_FRONTIER"
+build_gptl() {
+  banner "GPTL"
+  mkdir -p "$GPTL_FRONTIER"
+  cd "$GPTL_FRONTIER"
 
-wget https://github.com/jmrosinski/GPTL/releases/download/v8.1.1/gptl-8.1.1.tar.gz
-tar xvf gptl-8.1.1.tar.gz
-pushd gptl-8.1.1 >/dev/null
-./configure --prefix=$VENV_PATH --disable-libunwind CC=cc CXX=CC FC=ftn
-make install
-popd >/dev/null
+  wget https://github.com/jmrosinski/GPTL/releases/download/v8.1.1/gptl-8.1.1.tar.gz
+  tar xvf gptl-8.1.1.tar.gz
+  pushd gptl-8.1.1 >/dev/null
+  ./configure --prefix=$VENV_PATH --disable-libunwind CC=cc CXX=CC FC=ftn
+  make install
+  popd >/dev/null
 
-git clone https://github.com/jychoi-hpc/gptl4py.git || true
-pushd gptl4py >/dev/null
-GPTL_DIR=$VENV_PATH CC=cc CXX=CC pip_retry . --no-build-isolation --verbose
-popd >/dev/null
+  git clone https://github.com/jychoi-hpc/gptl4py.git || true
+  pushd gptl4py >/dev/null
+  GPTL_DIR=$VENV_PATH CC=cc CXX=CC pip_retry . --no-build-isolation --verbose
+  popd >/dev/null
+}
+
+## parallel build
+cd "$INSTALL_ROOT"
+banner "Adios, DDStore, DeepHyper, and GPTL build (in parallel)"
+timeit build_adios > build_adios.log & pid1=$!
+timeit build_ddstore > build_ddstore.log & pid2=$!
+timeit build_deephyper > build_deephyper.log & pid3=$!
+timeit build_gptl > build_gptl.log & pid4=$!
+for pid in $pid1 $pid2 $pid3 $pid4; do
+    progress $pid &
+done
+wait
 
 # ============================================================
 # Final Summary
@@ -397,7 +464,7 @@ Base install:        $INSTALL_ROOT
 Virtual environment: $VENV_PATH
 PyTorch-Geometric:   $PYG_FRONTIER
   - pytorch_scatter fork: ${PYTORCH_SCATTER_ROCM_REPO} @ ${PYTORCH_SCATTER_ROCM_COMMIT} (temporary)
-  - pytorch_sparse fork:  ${PYTORCH_SPARSE_ROCM_REPO} @ ${PYTORCH_SPARSE_ROCM_COMMIT} (temporary)
+  - pytorch_sparse:       0.6.18-8-gcdbf561
   - pytorch_cluster:      1.6.3-11-g4126a52
   - pytorch_spline_conv:  1.2.2-9-ga6d1020
 MPI4PY:              $MPI4PY_FRONTIER

--- a/scripts/hpc/olcf/frontier/installation/install-rocm64.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm64.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
-# setup_env_andes.sh
-# Complete automated setup for HydraGNN environment and dependencies on Andes (CPU-only).
+# setup_env.sh
+# Complete automated setup for HydraGNN environment and dependencies on Frontier.
 
 set -Eeuo pipefail
 
@@ -11,42 +11,34 @@ hr() { printf '%*s\n' "${COLUMNS:-80}" '' | tr ' ' '='; }
 banner() { hr; echo ">>> $1"; hr; }
 subbanner() { echo "-- $1"; }
 
-banner "Starting HydraGNN environment setup on ANDES ($(date))"
+# =========================
+# Config (env-overridable)
+# =========================
+FRONTIER_ROCM_MODULE_VERSION="${FRONTIER_ROCM_MODULE_VERSION:-6.4.0}"
+FRONTIER_AMD_MIXED_MODULE_VERSION="${FRONTIER_AMD_MIXED_MODULE_VERSION:-6.4.0}"
+EXPECTED_ROCM_MM="${EXPECTED_ROCM_MM:-6.4}"
+PYTORCH_ROCM_INDEX_URL="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm${EXPECTED_ROCM_MM}}"
+PYTORCH_SCATTER_ROCM_REPO="${PYTORCH_SCATTER_ROCM_REPO:-https://github.com/Looong01/pytorch_scatter-rocm.git}"
+PYTORCH_SCATTER_ROCM_COMMIT="${PYTORCH_SCATTER_ROCM_COMMIT:-9799c51}"
+PYTORCH_SPARSE_ROCM_REPO="${PYTORCH_SPARSE_ROCM_REPO:-https://github.com/Looong01/pytorch_sparse-rocm.git}"
+PYTORCH_SPARSE_ROCM_COMMIT="${PYTORCH_SPARSE_ROCM_COMMIT:-2340737}"
+
+banner "Starting HydraGNN environment setup ($(date))"
 
 # ============================================================
-# Module initialization & Andes stack
+# Module initialization & Frontier stack
 # ============================================================
-banner "Configure Andes Modules"
-if ! command -v module >/dev/null 2>&1; then
-  if [[ -f /etc/profile.d/modules.sh ]]; then
-    source /etc/profile.d/modules.sh
-  elif [[ -f /usr/share/lmod/lmod/init/bash ]]; then
-    source /usr/share/lmod/lmod/init/bash
-  elif [[ -f /usr/share/Modules/init/bash ]]; then
-    source /usr/share/Modules/init/bash
-  fi
-fi
-
-if ! command -v module >/dev/null 2>&1; then
-  echo "⚠️  'module' command not found. Ensure you're running on Andes."
-else
-  module reset
-  ml hsi/5.0.2.p5
-  ml gcc/9.3.0
-  ml openmpi/4.0.4
-  ml DefApps
-  ml cmake/3.22.2
-  ml git-lfs/2.11.0
-  ml miniforge3/23.11.0-0
-  ml libfabric/1.14.0
-  ml git-lfs
-fi
+banner "Configure Frontier Modules"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/module-loads.sh"
+load_frontier_modules "${FRONTIER_ROCM_MODULE_VERSION}" "${FRONTIER_AMD_MIXED_MODULE_VERSION}"
 
 # ============================================================
 # Installation root
 # ============================================================
 banner "Set Base Installation Directory"
-INSTALL_ROOT="${PWD}/HydraGNN-Installation-Andes"
+INSTALL_ROOT="${INSTALL_ROOT:-${PWD}/HydraGNN-Installation-Frontier}"
 mkdir -p "$INSTALL_ROOT"
 echo "All installation components will be contained in: $INSTALL_ROOT"
 cd "$INSTALL_ROOT"
@@ -55,8 +47,7 @@ cd "$INSTALL_ROOT"
 # Env vars & Conda env creation
 # ============================================================
 banner "Create and Activate Conda Environment"
-# Andes is not Cray; no CRAY_LD_LIBRARY_PATH reference here
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+export LD_LIBRARY_PATH="${CRAY_LD_LIBRARY_PATH:-}:${LD_LIBRARY_PATH:-}"
 
 VENV_PATH="${VENV_PATH:-${INSTALL_ROOT}/hydragnn_venv}"
 echo "Virtual environment path: $VENV_PATH"
@@ -64,25 +55,19 @@ echo "Virtual environment path: $VENV_PATH"
 PYTHON_VERSION="${PYTHON_VERSION:-3.11}"
 echo "Python version: ${PYTHON_VERSION}"
 
-RECREATE_ENV="${RECREATE_ENV:-0}"
-
 if ! command -v conda >/dev/null 2>&1; then
   echo "❌ Conda command not found. Ensure miniforge3 is properly loaded."
   exit 1
 fi
 
-if [[ -d "$VENV_PATH" && "$RECREATE_ENV" -eq 1 ]]; then
+if [[ -d "$VENV_PATH" ]]; then
   echo "Removing existing conda environment at: $VENV_PATH"
   source deactivate >/dev/null 2>&1 || true
   conda env remove -p "$VENV_PATH" -y || rm -rf "$VENV_PATH"
 fi
 
-if [[ -d "$VENV_PATH" ]]; then
-  echo "Conda environment already exists at $VENV_PATH"
-else
-  echo "Creating conda environment at $VENV_PATH with Python $PYTHON_VERSION"
-  conda create -y -p "$VENV_PATH" python="$PYTHON_VERSION"
-fi
+echo "Creating conda environment at $VENV_PATH with Python $PYTHON_VERSION"
+conda create -y -p "$VENV_PATH" python="$PYTHON_VERSION"
 
 # shellcheck disable=SC1091
 source activate "$VENV_PATH"
@@ -160,31 +145,56 @@ pip_retry mendeleev==0.16.0
 pip_retry lmdb
 pip_retry h5py==3.14.0 
 pip_retry tensorflow
+pip_retry tensorflow_datasets
 pip_retry vesin==0.4.2
 
 # ============================================================
-# PyTorch (CPU-only) + torchvision
+# ROCm detection + ROCm-aware PyTorch
 # ============================================================
-banner "Install CPU-only PyTorch"
-PYTORCH_CPU_INDEX_URL="https://download.pytorch.org/whl/cpu"
-pip_retry --index-url "${PYTORCH_CPU_INDEX_URL}" torch torchvision
+banner "ROCm Detection and ROCm-aware PyTorch Install (Before PyG)"
+detect_rocm_mm() {
+  local v=""
+  if command -v module >/dev/null 2>&1; then
+    local mlist
+    mlist="$(module -t list 2>&1 || true)"
+    v="$(grep -Eo 'rocm/[0-9]+\.[0-9]+' <<<"$mlist" | head -n1 | sed 's#rocm/##')"
+  fi
+  if [[ -z "$v" ]] && command -v hipcc >/dev/null 2>&1; then
+    v="$(hipcc --version 2>&1 | grep -Eo 'HIP version:\s*[0-9]+\.[0-9]+' | grep -Eo '[0-9]+\.[0-9]+' | head -n1 || true)"
+  fi
+  echo "$v"
+}
+
+ROCM_MM="${ROCM_MM:-$(detect_rocm_mm)}"
+if [[ -z "$ROCM_MM" ]]; then
+  echo "❌ Could not detect ROCm version. Ensure the rocm module is loaded."
+  exit 1
+fi
+echo "Detected ROCm: $ROCM_MM"
+if [[ "$ROCM_MM" != "$EXPECTED_ROCM_MM" ]]; then
+  echo "❌ ROCm version mismatch. Detected $ROCM_MM but expecting rocm${EXPECTED_ROCM_MM}."
+  exit 1
+fi
+
+subbanner "Install ROCm PyTorch from ${PYTORCH_ROCM_INDEX_URL}"
+pip_retry --index-url "${PYTORCH_ROCM_INDEX_URL}" torch torchvision
 assert_numpy_1264
 
-python - <<'PY'
+python - <<PY
 import torch
 print("torch.__version__ =", torch.__version__)
-print("CUDA available?    =", torch.cuda.is_available())
+print("torch.version.hip =", torch.version.hip)
 PY
 
 # ============================================================
-# PyTorch-Geometric stack (CPU build)
+# PyTorch-Geometric stack
 # ============================================================
-banner "PyTorch-Geometric Stack (CPU)"
-PYG_DIR_NAME="PyTorch-Geometric-CPU"
-PYG_ANDES="${INSTALL_ROOT}/${PYG_DIR_NAME}"
-export PYG_ANDES
-mkdir -p "$PYG_ANDES"
-cd "$PYG_ANDES"
+banner "PyTorch-Geometric Stack (ROCm ${ROCM_MM})"
+PYG_DIR_NAME="PyTorch-Geometric-${ROCM_MM}"
+PYG_FRONTIER="${INSTALL_ROOT}/${PYG_DIR_NAME}"
+export PYG_FRONTIER
+mkdir -p "$PYG_FRONTIER"
+cd "$PYG_FRONTIER"
 
 subbanner "pytorch_geometric (official)"
 if [[ ! -d pytorch_geometric/.git ]]; then
@@ -196,33 +206,42 @@ pip_retry . --verbose
 assert_numpy_1264
 popd >/dev/null
 
-# --- pytorch_scatter (official repo & stable ref for CPU) ---
-subbanner "pytorch_scatter (official @ 2.1.2-9-g7cabb53)"
+# --- pytorch_scatter (ROCm fork pinned) ---
+subbanner "pytorch_scatter (ROCm fork pinned to ${PYTORCH_SCATTER_ROCM_COMMIT}; temporary until upstream merges)"
 if [[ ! -d pytorch_scatter/.git ]]; then
-  git clone --recursive git@github.com:rusty1s/pytorch_scatter.git
+  # Official upstream (kept for reference; will switch back after merge):
+  # git clone --recursive git@github.com:rusty1s/pytorch_scatter.git
+  # Temporary ROCm fork (use until fixes merge upstream):
+  git clone --recursive "${PYTORCH_SCATTER_ROCM_REPO}" pytorch_scatter
 fi
 pushd pytorch_scatter >/dev/null
 git fetch --all
-git checkout 2.1.2-9-g7cabb53
+git checkout "${PYTORCH_SCATTER_ROCM_COMMIT}"
 git submodule update --init --recursive
 rm -rf build
-CC=mpicc CXX=mpicxx python setup.py build
-CC=mpicc CXX=mpicxx python setup.py install
+# If needed: export PYTORCH_ROCM_ARCH=gfx90a
+CC=gcc CXX=g++ python setup.py build
+CC=gcc CXX=g++ python setup.py install
 assert_numpy_1264
+echo "pytorch_scatter pinned to commit: $(git rev-parse --short HEAD)"
 popd >/dev/null
 
 # --- pytorch_sparse (official pinned) ---
 subbanner "pytorch_sparse (official @ 0.6.18-8-gcdbf561)"
 if [[ ! -d pytorch_sparse/.git ]]; then
-  git clone --recursive git@github.com:rusty1s/pytorch_sparse.git
+  # Official upstream (kept for reference; will switch back after merge):
+  # git clone --recursive git@github.com:rusty1s/pytorch_sparse.git
+  # Temporary ROCm fork (use until fixes merge upstream):
+  git clone --recursive "${PYTORCH_SPARSE_ROCM_REPO}" pytorch_sparse
 fi
 pushd pytorch_sparse >/dev/null
 git fetch --all
-git checkout 0.6.18-8-gcdbf561
+git checkout "${PYTORCH_SPARSE_ROCM_COMMIT}"
 rm -rf build
-CC=mpicc CXX=mpicxx python setup.py build
-CC=mpicc CXX=mpicxx python setup.py install
+CC=gcc CXX=g++ python setup.py build
+CC=gcc CXX=g++ python setup.py install
 assert_numpy_1264
+echo "pytorch_sparse pinned to commit: $(git rev-parse --short HEAD)"
 popd >/dev/null
 
 # --- pytorch_cluster (official pinned) ---
@@ -234,8 +253,8 @@ pushd pytorch_cluster >/dev/null
 git fetch --all
 git checkout 1.6.3-11-g4126a52
 rm -rf build
-CC=mpicc CXX=mpicxx python setup.py build
-CC=mpicc CXX=mpicxx python setup.py install
+CC=gcc CXX=g++ python setup.py build
+CC=gcc CXX=g++ python setup.py install
 assert_numpy_1264
 popd >/dev/null
 
@@ -248,38 +267,38 @@ pushd pytorch_spline_conv >/dev/null
 git fetch --all
 git checkout 1.2.2-9-ga6d1020
 rm -rf build
-CC=mpicc CXX=mpicxx python setup.py build
-CC=mpicc CXX=mpicxx python setup.py install
+CC=gcc CXX=g++ python setup.py build
+CC=gcc CXX=g++ python setup.py install
 assert_numpy_1264
 popd >/dev/null
 
 subbanner "Install e3nn and openequivariance"
-pip_retry e3nn openequivariance --verbose
+pip_retry e3nn --verbose
 assert_numpy_1264
 
 # ============================================================
 # mpi4py
 # ============================================================
 banner "mpi4py (v4.1.1)"
-MPI4PY_ANDES="${INSTALL_ROOT}/MPI4PY-Andes"
-export MPI4PY_ANDES
-mkdir -p "$MPI4PY_ANDES"
-cd "$MPI4PY_ANDES"
+MPI4PY_FRONTIER="${INSTALL_ROOT}/MPI4PY-Frontier"
+export MPI4PY_FRONTIER
+mkdir -p "$MPI4PY_FRONTIER"
+cd "$MPI4PY_FRONTIER"
 
 git clone -b 4.1.1 https://github.com/mpi4py/mpi4py.git || true
 pushd mpi4py >/dev/null
 rm -rf build
-CC=mpicc MPICC=mpicc pip_retry . --verbose
+CC=cc MPICC=cc pip_retry . --verbose
 popd >/dev/null
 
 # ============================================================
 # ADIOS2
 # ============================================================
 banner "ADIOS2 (v2.10.2)"
-ADIOS2_ANDES="${INSTALL_ROOT}/ADIOS2-Andes"
-export ADIOS2_ANDES
-mkdir -p "$ADIOS2_ANDES"
-cd "$ADIOS2_ANDES"
+ADIOS2_FRONTIER="${INSTALL_ROOT}/ADIOS2-Frontier"
+export ADIOS2_FRONTIER
+mkdir -p "$ADIOS2_FRONTIER"
+cd "$ADIOS2_FRONTIER"
 
 if [[ ! -d ADIOS2/.git ]]; then
   git clone -b v2.10.2 https://github.com/ornladios/ADIOS2.git
@@ -287,110 +306,93 @@ fi
 
 mkdir -p adios2-build
 
-CC=mpicc CXX=mpicxx FC=mpifort \
+CC=cc CXX=CC FC=ftn \
 cmake -DCMAKE_INSTALL_PREFIX=$VENV_PATH \
-      -DCMAKE_BUILD_TYPE=Release \
-      -DBUILD_TESTING=OFF \
-      -DADIOS2_USE_MPI=ON \
-      -DADIOS2_USE_Fortran=OFF \
-      -DADIOS2_BUILD_EXAMPLES_EXPERIMENTAL=OFF \
-      -DADIOS2_BUILD_TESTING=OFF \
-      -DADIOS2_USE_HDF5=OFF \
-      -DADIOS2_USE_SST=OFF \
-      -DADIOS2_USE_BZip2=OFF \
-      -DADIOS2_USE_PNG=OFF \
-      -DADIOS2_USE_DataSpaces=OFF \
-      -DADIOS2_USE_Python=ON \
-      -DPython_EXECUTABLE=$(which python) \
-      -B adios2-build -S ADIOS2
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBUILD_TESTING=OFF \
+    -DADIOS2_USE_MPI=ON \
+    -DADIOS2_USE_Fortran=OFF \
+    -DADIOS2_BUILD_EXAMPLES_EXPERIMENTAL=OFF \
+    -DADIOS2_BUILD_TESTING=OFF \
+    -DADIOS2_USE_HDF5=OFF \
+    -DADIOS2_USE_SST=OFF \
+    -DADIOS2_USE_BZip2=OFF \
+    -DADIOS2_USE_PNG=OFF \
+    -DADIOS2_USE_DataSpaces=OFF \
+    -DADIOS2_USE_Python=ON \
+    -DPython_EXECUTABLE=$(which python) \
+    -B adios2-build -S ADIOS2
 
-cmake --build adios2-build -j$(nproc || echo 16)
-cmake --install adios2-build
+cmake --build adios2-build -j32
+cmake --install adios2_build 2>/dev/null || cmake --install adios2-build
 
 # ============================================================
 # DDStore
 # ============================================================
 banner "DDStore"
-DDSTORE_ANDES="${INSTALL_ROOT}/DDStore-Andes"
-export DDSTORE_ANDES
-mkdir -p "$DDSTORE_ANDES"
-cd "$DDSTORE_ANDES"
+DDSTORE_FRONTIER="${INSTALL_ROOT}/DDStore-Frontier"
+export DDSTORE_FRONTIER
+mkdir -p "$DDSTORE_FRONTIER"
+cd "$DDSTORE_FRONTIER"
 
 git clone git@github.com:ORNL/DDStore.git || true
 pushd DDStore >/dev/null
-CC=mpicc CXX=mpicxx pip_retry . --no-build-isolation --verbose
+CC=cc CXX=CC pip_retry . --no-build-isolation --verbose
 popd >/dev/null
 
 # ============================================================
 # DeepHyper
 # ============================================================
 banner "DeepHyper (develop branch)"
-DEEPHYPER_ANDES="${INSTALL_ROOT}/DeepHyper-Andes"
-export DEEPHYPER_ANDES
-mkdir -p "$DEEPHYPER_ANDES"
-cd "$DEEPHYPER_ANDES"
+DEEPHYPER_FRONTIER="${INSTALL_ROOT}/DeepHyperFrontier"
+export DEEPHYPER_FRONTIER
+mkdir -p "$DEEPHYPER_FRONTIER"
+cd "$DEEPHYPER_FRONTIER"
 
 git clone https://github.com/deephyper/deephyper.git || true
 cd deephyper
-pip_retry -e . --verbose
+pip_retry . --verbose
 assert_numpy_1264
 
 # ============================================================
 # GPTL
 # ============================================================
 banner "GPTL"
-GPTL_ANDES="${INSTALL_ROOT}/GPTL-Andes"
-export GPTL_ANDES
-mkdir -p "$GPTL_ANDES"
-cd "$GPTL_ANDES"
+GPTL_FRONTIER="${INSTALL_ROOT}/GPTLFrontier"
+export GPTL_FRONTIER
+mkdir -p "$GPTL_FRONTIER"
+cd "$GPTL_FRONTIER"
 
 wget https://github.com/jmrosinski/GPTL/releases/download/v8.1.1/gptl-8.1.1.tar.gz
 tar xvf gptl-8.1.1.tar.gz
 pushd gptl-8.1.1 >/dev/null
-./configure --prefix=$VENV_PATH --disable-libunwind CC=mpicc CXX=mpicxx FC=mpifort
+./configure --prefix=$VENV_PATH --disable-libunwind CC=cc CXX=CC FC=ftn
 make install
 popd >/dev/null
 
 git clone https://github.com/jychoi-hpc/gptl4py.git || true
 pushd gptl4py >/dev/null
-GPTL_DIR=$VENV_PATH CC=mpicc CXX=mpicxx pip_retry . --no-build-isolation --verbose
+GPTL_DIR=$VENV_PATH CC=cc CXX=CC pip_retry . --no-build-isolation --verbose
 popd >/dev/null
 
 # ============================================================
 # Final Summary
 # ============================================================
-banner "Final Summary (Andes)"
+banner "Final Summary"
 cat <<EOF
 Base install:        $INSTALL_ROOT
 Virtual environment: $VENV_PATH
-
-PyTorch (CPU-only):  from ${PYTORCH_CPU_INDEX_URL}
-PyTorch-Geometric:   $PYG_ANDES
-  - pytorch_scatter:     2.1.2-9-g7cabb53 (official)
-  - pytorch_sparse:      0.6.18-8-gcdbf561 (official)
-  - pytorch_cluster:     1.6.3-11-g4126a52 (official)
-  - pytorch_spline_conv: 1.2.2-9-ga6d1020 (official)
-
-MPI4PY:              $MPI4PY_ANDES
-ADIOS2:              $ADIOS2_ANDES
-DDStore:             $DDSTORE_ANDES
-DeepHyper:           $DEEPHYPER_ANDES
+PyTorch-Geometric:   $PYG_FRONTIER
+  - pytorch_scatter fork: ${PYTORCH_SCATTER_ROCM_REPO} @ ${PYTORCH_SCATTER_ROCM_COMMIT} (temporary)
+  - pytorch_sparse:       0.6.18-8-gcdbf561
+  - pytorch_cluster:      1.6.3-11-g4126a52
+  - pytorch_spline_conv:  1.2.2-9-ga6d1020
+MPI4PY:              $MPI4PY_FRONTIER
+ADIOS2:              $ADIOS2_FRONTIER
+DDStore:             $DDSTORE_FRONTIER
+DeepHyper:           $DEEPHYPER_FRONTIER
 EOF
 
-echo "✅ HydraGNN-Installation-Andes environment setup complete!"
-
+echo "✅ HydraGNN-Installation-Frontier environment setup complete!"
 echo ""
-echo "Use the following commands to activate the new HydraGNN python environment:"
-echo "  module reset"
-echo "  ml hsi/5.0.2.p5"
-echo "  ml gcc/9.3.0"
-echo "  ml openmpi/4.0.4"
-echo "  ml DefApps"
-echo "  ml cmake/3.22.2"
-echo "  ml git-lfs/2.11.0"
-echo "  ml miniforge3/23.11.0-0"
-echo "  ml libfabric/1.14.0"
-echo ""
-echo "  source activate ${VENV_PATH}"
-
-
+print_frontier_activation_instructions "${FRONTIER_ROCM_MODULE_VERSION}" "${FRONTIER_AMD_MIXED_MODULE_VERSION}" "${VENV_PATH}"

--- a/scripts/hpc/olcf/frontier/installation/install-rocm71.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm71.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # setup_env.sh
 # Complete automated setup for HydraGNN environment and dependencies on Frontier.
+# Updated to ROCm 7.1 (module rocm/7.1.1) and PyTorch wheels from https://download.pytorch.org/whl/rocm7.1
 
 set -Eeuo pipefail
 
@@ -14,9 +15,9 @@ subbanner() { echo "-- $1"; }
 # =========================
 # Config (env-overridable)
 # =========================
-FRONTIER_ROCM_MODULE_VERSION="${FRONTIER_ROCM_MODULE_VERSION:-6.4.0}"
-FRONTIER_AMD_MIXED_MODULE_VERSION="${FRONTIER_AMD_MIXED_MODULE_VERSION:-6.4.0}"
-EXPECTED_ROCM_MM="${EXPECTED_ROCM_MM:-6.4}"
+FRONTIER_ROCM_MODULE_VERSION="${FRONTIER_ROCM_MODULE_VERSION:-7.1.1}"
+FRONTIER_AMD_MIXED_MODULE_VERSION="${FRONTIER_AMD_MIXED_MODULE_VERSION:-7.1.1}"
+EXPECTED_ROCM_MM="${EXPECTED_ROCM_MM:-7.1}"
 PYTORCH_ROCM_INDEX_URL="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm${EXPECTED_ROCM_MM}}"
 PYTORCH_SCATTER_ROCM_REPO="${PYTORCH_SCATTER_ROCM_REPO:-https://github.com/Looong01/pytorch_scatter-rocm.git}"
 PYTORCH_SCATTER_ROCM_COMMIT="${PYTORCH_SCATTER_ROCM_COMMIT:-9799c51}"
@@ -31,7 +32,7 @@ banner "Starting HydraGNN environment setup ($(date))"
 banner "Configure Frontier Modules"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
-source "${SCRIPT_DIR}/module_loads_frontier.sh"
+source "${SCRIPT_DIR}/module-loads.sh"
 load_frontier_modules "${FRONTIER_ROCM_MODULE_VERSION}" "${FRONTIER_AMD_MIXED_MODULE_VERSION}"
 
 # ============================================================
@@ -113,23 +114,23 @@ assert_numpy_1264
 banner "Install Core Python Packages"
 
 pip_retry ninja
-pip_retry astunparse 
-pip_retry expecttest 
-pip_retry hypothesis 
-pip_retry numpy==1.26.4 
-pip_retry psutil==7.1.0 
-pip_retry pyyaml 
-pip_retry requests 
-pip_retry setuptools 
-pip_retry typing-extensions 
-pip_retry sympy==1.14.0 
-pip_retry filelock 
-pip_retry networkx 
-pip_retry jinja2 
+pip_retry astunparse
+pip_retry expecttest
+pip_retry hypothesis
+pip_retry numpy==1.26.4
+pip_retry psutil==7.1.0
+pip_retry pyyaml
+pip_retry requests
+pip_retry setuptools
+pip_retry typing-extensions
+pip_retry sympy==1.14.0
+pip_retry filelock
+pip_retry networkx
+pip_retry jinja2
 pip_retry tqdm==4.67.1
 pip_retry types-dataclasses
-pip_retry scipy==1.14.1 
-pip_retry pyparsing 
+pip_retry scipy==1.14.1
+pip_retry pyparsing
 pip_retry build
 pip_retry Cython
 pip_retry tensorboard==2.20.0
@@ -143,7 +144,7 @@ pip_retry pymatgen
 pip_retry igraph
 pip_retry mendeleev==0.16.0
 pip_retry lmdb
-pip_retry h5py==3.14.0 
+pip_retry h5py==3.14.0
 pip_retry tensorflow
 pip_retry tensorflow_datasets
 pip_retry vesin==0.4.2
@@ -180,16 +181,24 @@ subbanner "Install ROCm PyTorch from ${PYTORCH_ROCM_INDEX_URL}"
 pip_retry --index-url "${PYTORCH_ROCM_INDEX_URL}" torch torchvision
 assert_numpy_1264
 
-python - <<PY
+python - <<'PY'
 import torch
 print("torch.__version__ =", torch.__version__)
 print("torch.version.hip =", torch.version.hip)
+print("torch.cuda.is_available() =", torch.cuda.is_available())  # ROCm uses torch.cuda API
+print("torch.cuda.device_count() =", torch.cuda.device_count())
+if torch.cuda.device_count() > 0:
+    print("GPU[0] =", torch.cuda.get_device_name(0))
 PY
 
 # ============================================================
 # PyTorch-Geometric stack
 # ============================================================
 banner "PyTorch-Geometric Stack (ROCm ${ROCM_MM})"
+
+# Recommended for MI250X builds
+export PYTORCH_ROCM_ARCH="${PYTORCH_ROCM_ARCH:-gfx90a}"
+
 PYG_DIR_NAME="PyTorch-Geometric-${ROCM_MM}"
 PYG_FRONTIER="${INSTALL_ROOT}/${PYG_DIR_NAME}"
 export PYG_FRONTIER
@@ -219,15 +228,14 @@ git fetch --all
 git checkout "${PYTORCH_SCATTER_ROCM_COMMIT}"
 git submodule update --init --recursive
 rm -rf build
-# If needed: export PYTORCH_ROCM_ARCH=gfx90a
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
 assert_numpy_1264
 echo "pytorch_scatter pinned to commit: $(git rev-parse --short HEAD)"
 popd >/dev/null
 
-# --- pytorch_sparse (official pinned) ---
-subbanner "pytorch_sparse (official @ 0.6.18-8-gcdbf561)"
+# --- pytorch_sparse (ROCm fork pinned) ---
+subbanner "pytorch_sparse (ROCm fork pinned to ${PYTORCH_SPARSE_ROCM_COMMIT}; temporary until upstream merges)"
 if [[ ! -d pytorch_sparse/.git ]]; then
   # Official upstream (kept for reference; will switch back after merge):
   # git clone --recursive git@github.com:rusty1s/pytorch_sparse.git
@@ -272,9 +280,14 @@ CC=gcc CXX=g++ python setup.py install
 assert_numpy_1264
 popd >/dev/null
 
-subbanner "Install e3nn and openequivariance"
+subbanner "Install e3nn"
 pip_retry e3nn --verbose
 assert_numpy_1264
+
+# NOTE: unload ROCm for mpi4py build
+module unload craype-accel-amd-gfx90a
+module unload rocm
+#######
 
 # ============================================================
 # mpi4py
@@ -384,7 +397,7 @@ Base install:        $INSTALL_ROOT
 Virtual environment: $VENV_PATH
 PyTorch-Geometric:   $PYG_FRONTIER
   - pytorch_scatter fork: ${PYTORCH_SCATTER_ROCM_REPO} @ ${PYTORCH_SCATTER_ROCM_COMMIT} (temporary)
-  - pytorch_sparse:       0.6.18-8-gcdbf561
+  - pytorch_sparse fork:  ${PYTORCH_SPARSE_ROCM_REPO} @ ${PYTORCH_SPARSE_ROCM_COMMIT} (temporary)
   - pytorch_cluster:      1.6.3-11-g4126a52
   - pytorch_spline_conv:  1.2.2-9-ga6d1020
 MPI4PY:              $MPI4PY_FRONTIER
@@ -396,4 +409,3 @@ EOF
 echo "✅ HydraGNN-Installation-Frontier environment setup complete!"
 echo ""
 print_frontier_activation_instructions "${FRONTIER_ROCM_MODULE_VERSION}" "${FRONTIER_AMD_MIXED_MODULE_VERSION}" "${VENV_PATH}"
-

--- a/scripts/hpc/olcf/frontier/installation/install-rocm713.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm713.sh
@@ -5,7 +5,7 @@
 # wheels for AMD Instinct MI250X (gfx90a), per:
 #   https://rocm.docs.amd.com/en/7.13.0-preview/frameworks/pytorch/install.html
 #
-# Derived from hydragnn_installation_bash_script_frontier-rocm72.sh.
+# Derived from install-rocm72.sh.
 # Key changes vs ROCm 7.2:
 #   - Module stack:  rocm/7.13.0  amd-mixed/7.13.0
 #   - EXPECTED_ROCM_MM="7.13"
@@ -23,7 +23,7 @@
 #           ${VLLM_SRC_DIR} (must be cloned before running on a compute node).
 #
 # Usage:
-#   bash hydragnn_installation_bash_script_frontier-rocm713.sh
+#   bash scripts/hpc/olcf/frontier/installation/install-rocm713.sh
 #
 # Override variables:
 #   VENV_PATH             Override conda env path

--- a/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
@@ -3,7 +3,7 @@
 # Complete automated setup for HydraGNN environment and dependencies on Frontier.
 # Updated to ROCm 7.2 (module rocm/7.2.0) and PyTorch wheels from https://download.pytorch.org/whl/rocm7.2
 #
-# Derived from hydragnn_installation_bash_script_frontier-rocm71.sh.
+# Derived from install-rocm71.sh.
 # Key changes vs ROCm 7.1:
 #   - Module stack:  rocm/7.2.0  amd-mixed/7.2.0
 #   - EXPECTED_ROCM_MM="7.2"
@@ -14,7 +14,7 @@
 #           ${VLLM_SRC_DIR} (must be cloned before running on a compute node).
 #
 # Usage:
-#   bash hydragnn_installation_bash_script_frontier-rocm72.sh
+#   bash scripts/hpc/olcf/frontier/installation/install-rocm72.sh
 #
 # Override variables:
 #   VENV_PATH        Override conda env path

--- a/scripts/hpc/olcf/frontier/installation/module-loads.sh
+++ b/scripts/hpc/olcf/frontier/installation/module-loads.sh
@@ -2,7 +2,7 @@
 
 # Shared module loader for Frontier installation scripts.
 # Usage:
-#   source ".../module_loads_frontier.sh"
+#   source ".../module-loads.sh"
 #   load_frontier_modules "7.1.1" "7.1.1"
 
 # Paths are declared as env-overridable variables so callers can adjust

--- a/scripts/hpc/olcf/proxy-env.sh
+++ b/scripts/hpc/olcf/proxy-env.sh
@@ -11,7 +11,7 @@
 # Source this optional helper before downloading datasets from an OLCF system
 # whose compute nodes require the CCS proxy:
 #
-#   source installation_DOE_supercomputers/olcf_proxy_env.sh
+#   source scripts/hpc/olcf/proxy-env.sh
 
 export all_proxy="socks://proxy.ccs.ornl.gov:3128/"
 export ftp_proxy="ftp://proxy.ccs.ornl.gov:3128/"


### PR DESCRIPTION
## Summary

- organize installation scripts under `scripts/hpc/<facility>/<system>/installation`
- place the shared OLCF proxy helper at `scripts/hpc/olcf/proxy-env.sh`
- give installation and module-loading scripts concise names within their system-specific directories
- update environment scripts, job scripts, and documentation for the new locations

## Layout

- `scripts/hpc/alcf/aurora/installation`
- `scripts/hpc/nersc/perlmutter/installation`
- `scripts/hpc/olcf/andes/installation`
- `scripts/hpc/olcf/frontier/installation`

## Scope

The installation logic and configurable installation destinations are preserved. Paths to repository-managed scripts and the default example environment locations were updated to remove the obsolete `installation_DOE_supercomputers` directory.

## Validation

- ran `bash -n` on every relocated installation and module-loading script
- ran `bash -n` on all environment and job scripts whose paths changed
- verified sibling `module-loads.sh` files resolve for Frontier and Perlmutter installers
- verified no references to `installation_DOE_supercomputers` or the former module filenames remain
- preserved original executable modes
- ran `git diff --check`
