### PR TITLE
Add smooth buffered neighbor-list support

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,40 @@ Additionally, many important arguments fall within the `["NeuralNetwork"]` secti
       Accepted types: `GPS`, `None`
     - `["global_attn_type"]`
       Accepted types: `multihead`, `performer`
+
+#### Smooth physical cutoffs and buffered neighbor lists
+
+HydraGNN can separate a model's physical interaction radius from the radius
+used to allocate candidate edges:
+
+```json
+"Architecture": {
+  "radius": 5.0,
+  "neighbor_list_radius": 5.5,
+  "max_neighbours": 128,
+  "neighbor_overflow": "error"
+}
+```
+
+`radius` remains the physical cutoff passed to the MPNN. The optional
+`neighbor_list_radius` is the larger candidate-list radius. It must be greater
+than or equal to `radius`; using a larger value is accepted only for a model
+registered as having its own distance cutoff (`SchNet`, `DimeNet`, `PAINN`,
+`PNAEq`, `PNAPlus`, or `MACE`). This prevents buffered edges from accidentally
+becoming physical interactions in a model without a native envelope.
+
+Set `neighbor_overflow` to `"error"` for force-, stress-, or Hessian-sensitive
+work. HydraGNN then detects when a node has more candidates than
+`max_neighbours` and fails instead of silently performing a discontinuous hard
+top-k truncation. `"truncate"` preserves the historical behavior and remains
+the default for existing configurations.
+
+Model implementations that need a C3 switching function can use
+`hydragnn.utils.model.SepticCutoff`. It is one below an onset radius, follows
+`1 - 35t^4 + 84t^5 - 70t^6 + 20t^7` through the switching interval, and is
+zero at the physical cutoff. HydraGNN does not automatically multiply this
+function into native model envelopes: doing so would double-taper interactions
+and alter reference architectures.
     - `["pe_dim"]`
       Dimension of positional encodings (int)
     - `["global_attn_heads"]`

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -331,6 +331,50 @@ HydraGNN provides extensive configuration options for building graph neural netw
 
 ### Output Head Configuration
 
+### Buffered neighbor lists and smooth cutoffs
+
+For atomistic models, the physical interaction cutoff and candidate graph can
+be configured independently:
+
+```json
+"Architecture": {
+    "radius": 5.0,
+    "neighbor_list_radius": 5.5,
+    "max_neighbours": 128,
+    "neighbor_overflow": "error"
+}
+```
+
+- `radius` is the physical cutoff understood by the model.
+- `neighbor_list_radius` is the candidate-list radius and defaults to
+  `radius`.
+- `max_neighbours` is candidate storage capacity, not a smooth physical
+  top-k definition.
+- `neighbor_overflow: "error"` rejects a sample if that capacity would remove
+  an edge. `"truncate"` explicitly selects the historical hard truncation.
+
+A buffered radius is valid only for a stack with a native distance envelope:
+SchNet, DimeNet, PAINN, PNAEq, PNAPlus, or MACE. The native envelope makes
+edges between `radius` and `neighbor_list_radius` carry zero physical weight;
+the larger graph merely delays discrete edge deletion until after the
+interaction has vanished. This does not solve hard top-k truncation, which is
+why overflow detection is a separate requirement.
+
+HydraGNN also exports an opt-in septic cutoff:
+
+```python
+from hydragnn.utils.model import SepticCutoff
+
+cutoff = SepticCutoff(onset=4.0, cutoff=5.0)
+edge_weight = cutoff(edge_distance)
+```
+
+For `t = (r - onset) / (cutoff - onset)`, its transition polynomial is
+`1 - 35*t**4 + 84*t**5 - 70*t**6 + 20*t**7`. Its first three derivatives
+match zero at both transition boundaries. Model authors must apply the
+envelope to every geometry-dependent interaction path to claim the resulting
+smoothness. Native envelopes are not modified automatically.
+
 #### Multi-Task Learning Setup
 
 ```json

--- a/hydragnn/models/SCFStack.py
+++ b/hydragnn/models/SCFStack.py
@@ -304,7 +304,11 @@ class CFConv(MessagePassing):
         edge_rbf: Tensor,
         edge_attr: OptTensor = None,
     ) -> Tensor:
-        C = 0.5 * (torch.cos(edge_weight * PI / self.cutoff) + 1.0)
+        C = torch.where(
+            edge_weight < self.cutoff,
+            0.5 * (torch.cos(edge_weight * PI / self.cutoff) + 1.0),
+            torch.zeros_like(edge_weight),
+        )
         if edge_attr is None:
             W = self.nn(edge_rbf) * C.view(-1, 1)
         else:

--- a/hydragnn/preprocess/graph_dataset.py
+++ b/hydragnn/preprocess/graph_dataset.py
@@ -29,6 +29,9 @@ from hydragnn.preprocess.graph_samples_checks_and_updates import (
     update_predicted_values,
 )
 from hydragnn.utils.distributed import get_device
+from hydragnn.utils.input_config_parsing.config_utils import (
+    validate_neighbor_list_config,
+)
 from hydragnn.utils.print.print_utils import iterate_tqdm, print_distributed
 
 
@@ -40,15 +43,23 @@ def load_pickled_graphs(dataset_path):
         return pickle.load(stream)
 
 
-def _build_edges(data, radius, max_neighbours, periodic):
+def _build_edges(data, radius, max_neighbours, periodic, overflow="truncate"):
     if periodic:
         data.pbc = [True, True, True]
         if not hasattr(data, "cell") or data.cell is None:
             raise ValueError("Periodic graph samples require data.cell")
-        return get_radius_graph_pbc(radius, loop=False, max_neighbours=max_neighbours)(
-            data
-        )
-    data = get_radius_graph(radius, loop=False, max_neighbours=max_neighbours)(data)
+        return get_radius_graph_pbc(
+            radius,
+            loop=False,
+            max_neighbours=max_neighbours,
+            overflow=overflow,
+        )(data)
+    data = get_radius_graph(
+        radius,
+        loop=False,
+        max_neighbours=max_neighbours,
+        overflow=overflow,
+    )(data)
     return Distance(norm=False, cat=True)(data)
 
 
@@ -70,6 +81,7 @@ def _stratified_sample(dataset, percentage, verbosity):
 def prepare_graph_dataset(dataset, config, dist=False):
     """Prepare an explicit graph collection according to per-sample geometry."""
     architecture = config["NeuralNetwork"]["Architecture"]
+    validate_neighbor_list_config(architecture)
     dataset_config = config["Dataset"]
     variables = config["NeuralNetwork"]["Variables_of_interest"]
     verbosity = config["Verbosity"]["level"]
@@ -96,9 +108,10 @@ def prepare_graph_dataset(dataset, config, dist=False):
     dataset = [
         _build_edges(
             data,
-            architecture["radius"],
+            architecture.get("neighbor_list_radius", architecture["radius"]),
             architecture["max_neighbours"],
             architecture["periodic_boundary_conditions"],
+            architecture.get("neighbor_overflow", "truncate"),
         )
         for data in dataset
     ]

--- a/hydragnn/preprocess/graph_samples_checks_and_updates.py
+++ b/hydragnn/preprocess/graph_samples_checks_and_updates.py
@@ -109,35 +109,79 @@ def check_data_samples_equivalence(data1, data2, tol):
     return x_bool and pos_bool and y_bool and edge_bool
 
 
-def get_radius_graph(radius, max_neighbours, loop=False):
-    return RadiusGraph(
+class RadiusGraphWithOverflow(RadiusGraph):
+    """Radius graph that can reject silent hard neighbor truncation."""
+
+    def __init__(self, *args, overflow="truncate", **kwargs):
+        if overflow not in {"error", "truncate"}:
+            raise ValueError("neighbor_overflow must be 'error' or 'truncate'")
+        self.overflow = overflow
+        requested_max = kwargs["max_num_neighbors"]
+        self.requested_max_num_neighbors = requested_max
+        if overflow == "error":
+            kwargs["max_num_neighbors"] = requested_max + 1
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, data):
+        data = super().__call__(data)
+        if self.overflow == "error" and data.edge_index.numel():
+            counts = torch.bincount(data.edge_index[1], minlength=int(data.num_nodes))
+            saturated = torch.nonzero(
+                counts > self.requested_max_num_neighbors, as_tuple=False
+            ).flatten()
+            if saturated.numel():
+                raise RuntimeError(
+                    "Candidate neighbor list exceeds max_neighbours="
+                    f"{self.requested_max_num_neighbors} for "
+                    f"{saturated.numel()} node(s). Increase max_neighbours; "
+                    "silent truncation would break smoothness."
+                )
+        return data
+
+
+def get_radius_graph(radius, max_neighbours, loop=False, overflow="truncate"):
+    return RadiusGraphWithOverflow(
         r=radius,
         loop=loop,
         max_num_neighbors=max_neighbours,
+        overflow=overflow,
     )
 
 
-def get_radius_graph_pbc(radius, max_neighbours, loop=False):
+def get_radius_graph_pbc(radius, max_neighbours, loop=False, overflow="truncate"):
     return RadiusGraphPBC(
         r=radius,
         loop=loop,
         max_num_neighbors=max_neighbours,
+        overflow=overflow,
     )
 
 
 def get_radius_graph_config(config, loop=False):
-    return RadiusGraph(
-        r=config["radius"],
+    from hydragnn.utils.input_config_parsing.config_utils import (
+        validate_neighbor_list_config,
+    )
+
+    validate_neighbor_list_config(config)
+    return get_radius_graph(
+        config.get("neighbor_list_radius", config["radius"]),
+        config["max_neighbours"],
         loop=loop,
-        max_num_neighbors=config["max_neighbours"],
+        overflow=config.get("neighbor_overflow", "truncate"),
     )
 
 
 def get_radius_graph_pbc_config(config, loop=False):
-    return RadiusGraphPBC(
-        r=config["radius"],
+    from hydragnn.utils.input_config_parsing.config_utils import (
+        validate_neighbor_list_config,
+    )
+
+    validate_neighbor_list_config(config)
+    return get_radius_graph_pbc(
+        config.get("neighbor_list_radius", config["radius"]),
+        config["max_neighbours"],
         loop=loop,
-        max_num_neighbors=config["max_neighbours"],
+        overflow=config.get("neighbor_overflow", "truncate"),
     )
 
 
@@ -145,6 +189,12 @@ class RadiusGraphPBC(RadiusGraph):
     r"""Creates edges based on node positions :obj:`pos` to all points within a
     given distance, including periodic images. Uses vesin for fast neighbor search.
     """
+
+    def __init__(self, *args, overflow="truncate", **kwargs):
+        if overflow not in {"error", "truncate"}:
+            raise ValueError("neighbor_overflow must be 'error' or 'truncate'")
+        self.overflow = overflow
+        super().__init__(*args, **kwargs)
 
     def __call__(self, data):
         data, device, dtype = self._check_and_standardize_data(data)
@@ -192,6 +242,17 @@ class RadiusGraphPBC(RadiusGraph):
                 ) = self._remove_true_self_loops(
                     edge_src, edge_dst, edge_length, edge_cell_shifts
                 )
+
+            if self.overflow == "error":
+                counts = np.bincount(edge_dst, minlength=data.num_nodes)
+                saturated = np.flatnonzero(counts > self.max_num_neighbors)
+                if saturated.size:
+                    raise RuntimeError(
+                        "Candidate periodic neighbor list exceeds max_neighbours="
+                        f"{self.max_num_neighbors} for {saturated.size} node(s). "
+                        "Increase max_neighbours; silent truncation would break "
+                        "smoothness."
+                    )
 
             # Limit neighbors per node (vectorized)
             edge_src, edge_dst, edge_length, edge_cell_shifts = self._limit_neighbors(

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -22,6 +22,39 @@ import warnings
 import json
 import torch
 
+_NATIVE_DISTANCE_CUTOFF_MODELS = {
+    "DimeNet",
+    "MACE",
+    "PAINN",
+    "PNAEq",
+    "PNAPlus",
+    "SchNet",
+}
+
+
+def validate_neighbor_list_config(architecture):
+    """Validate separation of physical and candidate-list cutoffs."""
+    radius = architecture.get("radius")
+    list_radius = architecture.get("neighbor_list_radius", radius)
+    overflow = architecture.get("neighbor_overflow", "truncate")
+
+    if overflow not in {"error", "truncate"}:
+        raise ValueError("neighbor_overflow must be 'error' or 'truncate'")
+    if list_radius is not None and list_radius <= 0:
+        raise ValueError("neighbor_list_radius must be positive")
+    if radius is not None and list_radius is not None and list_radius < radius:
+        raise ValueError("neighbor_list_radius must be greater than or equal to radius")
+    if (
+        radius is not None
+        and list_radius is not None
+        and list_radius > radius
+        and architecture.get("mpnn_type") not in _NATIVE_DISTANCE_CUTOFF_MODELS
+    ):
+        raise ValueError(
+            "A buffered neighbor list requires a model with a native physical "
+            f"cutoff; {architecture.get('mpnn_type')!r} is not registered as one"
+        )
+
 
 def update_config(config, train_loader, val_loader, test_loader):
     """check if config input consistent and update config with model and datasets"""
@@ -115,6 +148,13 @@ def update_config(config, train_loader, val_loader, test_loader):
 
     if "radius" not in config["NeuralNetwork"]["Architecture"]:
         config["NeuralNetwork"]["Architecture"]["radius"] = None
+    if "neighbor_list_radius" not in config["NeuralNetwork"]["Architecture"]:
+        config["NeuralNetwork"]["Architecture"]["neighbor_list_radius"] = config[
+            "NeuralNetwork"
+        ]["Architecture"]["radius"]
+    if "neighbor_overflow" not in config["NeuralNetwork"]["Architecture"]:
+        config["NeuralNetwork"]["Architecture"]["neighbor_overflow"] = "truncate"
+    validate_neighbor_list_config(config["NeuralNetwork"]["Architecture"])
     if "radial_type" not in config["NeuralNetwork"]["Architecture"]:
         config["NeuralNetwork"]["Architecture"]["radial_type"] = None
     if "distance_transform" not in config["NeuralNetwork"]["Architecture"]:

--- a/hydragnn/utils/model/__init__.py
+++ b/hydragnn/utils/model/__init__.py
@@ -22,3 +22,4 @@ from .model import (
     print_optimizer,
     update_multibranch_heads,
 )
+from .cutoffs import SepticCutoff, septic_cutoff

--- a/hydragnn/utils/model/cutoffs.py
+++ b/hydragnn/utils/model/cutoffs.py
@@ -1,0 +1,46 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+"""Reusable smooth cutoff functions for geometry-dependent interactions."""
+
+import torch
+from torch import nn
+
+
+def septic_cutoff(distance: torch.Tensor, onset: float, cutoff: float) -> torch.Tensor:
+    """Return a C3 septic switch from one at ``onset`` to zero at ``cutoff``.
+
+    This function supplies an opt-in primitive for model implementations. It
+    does not automatically multiply native model envelopes, which would alter
+    their reference architectures through double tapering.
+    """
+    if not 0 <= onset < cutoff:
+        raise ValueError("cutoff radii must satisfy 0 <= onset < cutoff")
+    t = ((distance - onset) / (cutoff - onset)).clamp(0.0, 1.0)
+    switch = 1 + t**4 * (-35 + t * (84 + t * (-70 + 20 * t)))
+    return torch.where(
+        distance <= onset,
+        torch.ones_like(distance),
+        torch.where(distance < cutoff, switch, torch.zeros_like(distance)),
+    )
+
+
+class SepticCutoff(nn.Module):
+    """Module wrapper around :func:`septic_cutoff`."""
+
+    def __init__(self, onset: float, cutoff: float):
+        super().__init__()
+        if not 0 <= onset < cutoff:
+            raise ValueError("cutoff radii must satisfy 0 <= onset < cutoff")
+        self.onset = float(onset)
+        self.cutoff = float(cutoff)
+
+    def forward(self, distance: torch.Tensor) -> torch.Tensor:
+        return septic_cutoff(distance, self.onset, self.cutoff)

--- a/tests/test_smooth_cutoffs.py
+++ b/tests/test_smooth_cutoffs.py
@@ -1,0 +1,90 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import pytest
+import torch
+from torch_geometric.data import Data
+
+from hydragnn.preprocess.graph_samples_checks_and_updates import (
+    get_radius_graph,
+    get_radius_graph_config,
+)
+from hydragnn.utils.input_config_parsing.config_utils import (
+    validate_neighbor_list_config,
+)
+from hydragnn.utils.model.cutoffs import septic_cutoff
+
+
+@pytest.mark.parametrize("boundary", [1.0, 2.0])
+def pytest_septic_cutoff_matches_through_third_derivative(boundary):
+    direction = 1.0 if boundary == 1.0 else -1.0
+    distance = torch.tensor(
+        boundary + direction * 1.0e-8, dtype=torch.float64, requires_grad=True
+    )
+    value = septic_cutoff(distance, onset=1.0, cutoff=2.0)
+    derivatives = []
+    current = value
+    for _ in range(3):
+        (current,) = torch.autograd.grad(current, distance, create_graph=True)
+        derivatives.append(current)
+
+    expected_value = 1.0 if boundary == 1.0 else 0.0
+    assert value.item() == pytest.approx(expected_value, abs=1.0e-12)
+    assert all(abs(item.item()) < 1.0e-4 for item in derivatives)
+
+
+def pytest_radius_graph_rejects_neighbor_overflow():
+    data = Data(
+        pos=torch.tensor(
+            [[0.0, 0.0, 0.0], [0.1, 0.0, 0.0], [0.2, 0.0, 0.0], [0.3, 0.0, 0.0]]
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="silent truncation would break smoothness"):
+        get_radius_graph(1.0, max_neighbours=2, overflow="error")(data)
+
+
+def pytest_buffered_radius_requires_native_cutoff_model():
+    with pytest.raises(ValueError, match="native physical cutoff"):
+        validate_neighbor_list_config(
+            {
+                "mpnn_type": "SAGE",
+                "radius": 4.0,
+                "neighbor_list_radius": 4.5,
+                "neighbor_overflow": "error",
+            }
+        )
+
+
+def pytest_buffered_radius_accepts_native_cutoff_model():
+    validate_neighbor_list_config(
+        {
+            "mpnn_type": "MACE",
+            "radius": 4.0,
+            "neighbor_list_radius": 4.5,
+            "neighbor_overflow": "error",
+        }
+    )
+
+
+def pytest_buffered_radius_builds_candidates_beyond_physical_cutoff():
+    data = Data(pos=torch.tensor([[0.0, 0.0, 0.0], [1.2, 0.0, 0.0]]))
+    graph = get_radius_graph_config(
+        {
+            "mpnn_type": "MACE",
+            "radius": 1.0,
+            "neighbor_list_radius": 1.5,
+            "max_neighbours": 4,
+            "neighbor_overflow": "error",
+        }
+    )(data)
+
+    assert graph.edge_index.shape[1] == 2


### PR DESCRIPTION
## Summary

- separate the physical model cutoff (`radius`) from an optional buffered candidate-list radius (`neighbor_list_radius`)
- add explicit neighbor-cap overflow handling so force/Hessian-sensitive workflows can reject silent hard top-k truncation
- provide a reusable C3 septic cutoff without automatically double-tapering native model envelopes
- validate buffered lists against models registered with native physical cutoffs
- make SchNet interactions exactly zero outside their physical cutoff
- document configuration semantics, native-envelope boundaries, and Hessian considerations

## Design

Buffered edges are permitted only for SchNet, DimeNet, PAINN, PNAEq, PNAPlus, and MACE on current upstream main. Native envelopes remain authoritative. UMA and AllScAIP should be registered after their integrations reach main and this branch is rebased.

`neighbor_overflow: "error"` is recommended for differentiable atomistic workflows. The historical `"truncate"` behavior remains the default for existing configurations.

## Validation

- 11 focused cutoff, graph-construction, periodic-boundary, and dataset tests passed
- 6 septic/buffer-specific tests passed independently
- Black passed for all HydraGNN Python sources
- Python compilation and `git diff --check` passed

The radial-transform training tests were also attempted locally; they reached a pre-existing local-fixture issue where generated `.pt` files were interpreted as LSMS text, unrelated to this patch.