### PR TITLE
Adopt standard pytest test naming

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,7 @@
-# Using "pytest*" due to the prevalence of existing "test" functions (test/train)
 [pytest]
-norecursedirs = dataset
-python_classes = Pytest
-python_functions = pytest_
+norecursedirs = dataset .venv .uv-cache build dist
+python_classes = Test*
+python_functions = test_*
 filterwarnings =
     ignore::DeprecationWarning
     ignore::FutureWarning

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -9,7 +9,7 @@
 # SPDX-License-Identifier: BSD-3-Clause                                      #
 ##############################################################################
 from .deterministic_graph_data import deterministic_graph_data
-from .test_config import pytest_config
+from .test_config import test_config
 from .test_graphs import unittest_train_model
 from .test_enthalpy import unittest_formation_enthalpy
-from .test_atomicdescriptors import pytest_atomicdescriptors
+from .test_atomicdescriptors import test_atomicdescriptors

--- a/tests/test_atomicdescriptors.py
+++ b/tests/test_atomicdescriptors.py
@@ -16,7 +16,7 @@ import subprocess
 
 
 @pytest.mark.mpi_skip()
-def pytest_atomicdescriptors():
+def test_atomicdescriptors():
     file_path = os.path.join(
         os.path.dirname(__file__),
         "..",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,13 +15,13 @@ import pytest
 import hydragnn
 
 
-def pytest_input_config_parsing_is_exposed_through_utils():
+def test_input_config_parsing_is_exposed_through_utils():
     assert hydragnn.utils.input_config_parsing.update_config is not None
 
 
 @pytest.mark.parametrize("config_file", ["lsms/lsms.json"])
 @pytest.mark.mpi_skip()
-def pytest_config(config_file):
+def test_config(config_file):
 
     config_file = os.path.join("examples", config_file)
     with open(config_file, "r") as f:

--- a/tests/test_cost_aware_batch_sampler.py
+++ b/tests/test_cost_aware_batch_sampler.py
@@ -26,7 +26,7 @@ def _dataset(costs):
     return [Data(x=torch.zeros(cost, 2)) for cost in costs]
 
 
-def pytest_cost_sampler_respects_node_and_graph_budgets():
+def test_cost_sampler_respects_node_and_graph_budgets():
     sampler = CostAwareBatchSampler(
         _dataset([2, 3, 4, 1, 2]),
         max_cost=6,
@@ -40,7 +40,7 @@ def pytest_cost_sampler_respects_node_and_graph_budgets():
     assert all(len(batch) <= 2 for batch in batches)
 
 
-def pytest_cost_sampler_shuffle_is_deterministic_per_epoch():
+def test_cost_sampler_shuffle_is_deterministic_per_epoch():
     dataset = _dataset([1] * 12)
     first = CostAwareBatchSampler(dataset, 3, seed=17)
     second = CostAwareBatchSampler(dataset, 3, seed=17)
@@ -52,7 +52,7 @@ def pytest_cost_sampler_shuffle_is_deterministic_per_epoch():
     assert list(first) != list(CostAwareBatchSampler(dataset, 3, seed=17))
 
 
-def pytest_cost_sampler_caches_batches_until_epoch_changes(monkeypatch):
+def test_cost_sampler_caches_batches_until_epoch_changes(monkeypatch):
     sampler = CostAwareBatchSampler(_dataset([1] * 8), 3, seed=17)
     calls = 0
     original = sampler._ordered_indices
@@ -73,7 +73,7 @@ def pytest_cost_sampler_caches_batches_until_epoch_changes(monkeypatch):
     assert calls == 2
 
 
-def pytest_drop_last_considers_graph_limit():
+def test_drop_last_considers_graph_limit():
     sampler = CostAwareBatchSampler(
         _dataset([1] * 5),
         max_cost=10,
@@ -85,7 +85,7 @@ def pytest_drop_last_considers_graph_limit():
 
 
 @pytest.mark.parametrize("policy", ["error", "single", "skip"])
-def pytest_cost_sampler_has_explicit_oversized_policy(policy):
+def test_cost_sampler_has_explicit_oversized_policy(policy):
     sampler = CostAwareBatchSampler(
         _dataset([2, 8, 3]), 5, shuffle=False, oversized_sample=policy
     )
@@ -99,7 +99,7 @@ def pytest_cost_sampler_has_explicit_oversized_policy(policy):
         assert sampler.statistics().skipped_samples == 1
 
 
-def pytest_cost_sampler_uses_precomputed_costs_without_loading_dataset():
+def test_cost_sampler_uses_precomputed_costs_without_loading_dataset():
     class MetadataOnlyDataset:
         def __len__(self):
             return 3
@@ -114,7 +114,7 @@ def pytest_cost_sampler_uses_precomputed_costs_without_loading_dataset():
     assert list(sampler) == [[0, 1], [2]]
 
 
-def pytest_cost_sampler_reads_ddstore_style_shape_metadata_without_samples():
+def test_cost_sampler_reads_ddstore_style_shape_metadata_without_samples():
     class MetadataOnlyDataset:
         variable_count = {"x": [2, 4, 3], "edge_index": [5, 9, 7]}
         variable_dim = {"x": 0, "edge_index": 1}
@@ -129,7 +129,7 @@ def pytest_cost_sampler_reads_ddstore_style_shape_metadata_without_samples():
     assert list(sampler) == [[0, 1], [2]]
 
 
-def pytest_node_budget_configuration_builds_variable_graph_batches():
+def test_node_budget_configuration_builds_variable_graph_batches():
     dataset = _dataset([2, 3, 4, 1])
     loaders = create_dataloaders(
         dataset,
@@ -148,7 +148,7 @@ def pytest_node_budget_configuration_builds_variable_graph_batches():
     ]
 
 
-def pytest_node_budget_preserves_custom_distributed_loader_settings(monkeypatch):
+def test_node_budget_preserves_custom_distributed_loader_settings(monkeypatch):
     calls = []
 
     class RecordingLoader:
@@ -178,7 +178,7 @@ def pytest_node_budget_preserves_custom_distributed_loader_settings(monkeypatch)
     assert all(call["persistent_workers"] is False for call in calls)
 
 
-def pytest_distributed_sampler_has_equal_steps_and_complete_step_assignment():
+def test_distributed_sampler_has_equal_steps_and_complete_step_assignment():
     dataset = _dataset([1, 2, 3, 4, 5, 6, 7, 8, 9])
     samplers = [
         DistributedCostAwareBatchSampler(
@@ -198,7 +198,7 @@ def pytest_distributed_sampler_has_equal_steps_and_complete_step_assignment():
         assert len({tuple(batch) for batch in step_batches}) == 3
 
 
-def pytest_distributed_sampler_groups_similar_costs_per_step():
+def test_distributed_sampler_groups_similar_costs_per_step():
     dataset = _dataset([1, 2, 3, 4, 5, 6, 7, 8])
     samplers = [
         DistributedCostAwareBatchSampler(
@@ -218,7 +218,7 @@ def pytest_distributed_sampler_groups_similar_costs_per_step():
         assert abs(left_cost - right_cost) <= 2
 
 
-def pytest_distributed_sampler_epoch_shuffle_is_reproducible():
+def test_distributed_sampler_epoch_shuffle_is_reproducible():
     dataset = _dataset([1] * 20)
     first = DistributedCostAwareBatchSampler(dataset, 3, num_replicas=2, rank=0, seed=9)
     second = DistributedCostAwareBatchSampler(

--- a/tests/test_dataset_download.py
+++ b/tests/test_dataset_download.py
@@ -31,7 +31,7 @@ class _Response(io.BytesIO):
         self.close()
 
 
-def pytest_download_file_resumes_partial_content(monkeypatch, tmp_path):
+def test_download_file_resumes_partial_content(monkeypatch, tmp_path):
     payload = b"complete dataset contents"
     destination = tmp_path / "dataset.bin"
     partial = tmp_path / "dataset.bin.part"
@@ -52,7 +52,7 @@ def pytest_download_file_resumes_partial_content(monkeypatch, tmp_path):
     assert not partial.exists()
 
 
-def pytest_download_file_restarts_if_server_ignores_range(monkeypatch, tmp_path):
+def test_download_file_restarts_if_server_ignores_range(monkeypatch, tmp_path):
     destination = tmp_path / "dataset.bin"
     (tmp_path / "dataset.bin.part").write_bytes(b"partial")
     payload = b"replacement"
@@ -65,7 +65,7 @@ def pytest_download_file_restarts_if_server_ignores_range(monkeypatch, tmp_path)
     assert destination.read_bytes() == payload
 
 
-def pytest_download_file_reuses_verified_destination(monkeypatch, tmp_path):
+def test_download_file_reuses_verified_destination(monkeypatch, tmp_path):
     destination = tmp_path / "dataset.bin"
     destination.write_bytes(b"already complete")
     monkeypatch.setattr(
@@ -83,7 +83,7 @@ def pytest_download_file_reuses_verified_destination(monkeypatch, tmp_path):
     )
 
 
-def pytest_download_file_rejects_existing_directory(monkeypatch, tmp_path):
+def test_download_file_rejects_existing_directory(monkeypatch, tmp_path):
     destination = tmp_path / "dataset.bin"
     destination.mkdir()
     monkeypatch.setattr(
@@ -95,7 +95,7 @@ def pytest_download_file_rejects_existing_directory(monkeypatch, tmp_path):
         download_file("https://example.invalid/dataset.bin", destination)
 
 
-def pytest_download_file_removes_partial_after_checksum_mismatch(monkeypatch, tmp_path):
+def test_download_file_removes_partial_after_checksum_mismatch(monkeypatch, tmp_path):
     destination = tmp_path / "dataset.bin"
     partial = tmp_path / "dataset.bin.part"
     monkeypatch.setattr(
@@ -121,7 +121,7 @@ def _write_tar(path: Path, member_name: str, data: bytes = b"data"):
         tar.addfile(info, io.BytesIO(data))
 
 
-def pytest_safe_extract_tar_streams_regular_files(monkeypatch, tmp_path):
+def test_safe_extract_tar_streams_regular_files(monkeypatch, tmp_path):
     archive = tmp_path / "dataset.tar.gz"
     _write_tar(archive, "split/sample.txt")
     monkeypatch.setattr(
@@ -134,7 +134,7 @@ def pytest_safe_extract_tar_streams_regular_files(monkeypatch, tmp_path):
     assert (destination / "split/sample.txt").read_bytes() == b"data"
 
 
-def pytest_safe_extract_tar_rejects_path_traversal(tmp_path):
+def test_safe_extract_tar_rejects_path_traversal(tmp_path):
     archive = tmp_path / "unsafe.tar.gz"
     _write_tar(archive, "../outside.txt")
 
@@ -150,7 +150,7 @@ def pytest_safe_extract_tar_rejects_path_traversal(tmp_path):
         (tarfile.CHRTYPE, "unsupported archive entry"),
     ],
 )
-def pytest_safe_extract_tar_rejects_links_and_special_entries(
+def test_safe_extract_tar_rejects_links_and_special_entries(
     tmp_path, member_type, message
 ):
     archive = tmp_path / "unsafe.tar.gz"

--- a/tests/test_dataset_download_integration.py
+++ b/tests/test_dataset_download_integration.py
@@ -29,7 +29,7 @@ def _archive_payload():
     return payload.getvalue()
 
 
-def pytest_downloader_cli_resumes_redirect_and_extracts(tmp_path):
+def test_downloader_cli_resumes_redirect_and_extracts(tmp_path):
     payload = _archive_payload()
 
     class Handler(BaseHTTPRequestHandler):
@@ -95,7 +95,7 @@ def pytest_downloader_cli_resumes_redirect_and_extracts(tmp_path):
     assert not archive.exists()
 
 
-def pytest_materials_download_entry_points_use_shared_transport():
+def test_materials_download_entry_points_use_shared_transport():
     repository = Path(__file__).parents[1]
     shell_consumers = {
         "examples/mptrj/download_data_andes.sh": "MPtrj_2022.9_full.json",

--- a/tests/test_dataset_download_network.py
+++ b/tests/test_dataset_download_network.py
@@ -38,7 +38,7 @@ ENDPOINTS = {
 
 
 @pytest.mark.parametrize(("dataset", "url"), ENDPOINTS.items())
-def pytest_live_dataset_endpoint_supports_bounded_probe(dataset, url):
+def test_live_dataset_endpoint_supports_bounded_probe(dataset, url):
     request = Request(
         url,
         headers={"Range": "bytes=0-65535", "User-Agent": "HydraGNN-CI/1.0"},

--- a/tests/test_datasetclass_inheritance.py
+++ b/tests/test_datasetclass_inheritance.py
@@ -212,7 +212,7 @@ def unittest_train_model_dataset_class_inheritance(
 ## FIXME: this is temporarily disabled to avoid multiple instantiations of DDP
 @pytest.mark.parametrize("model_type", ["PNA"])
 @pytest.mark.skip()
-def pytest_train_model_vectoroutput(model_type, overwrite_data=False):
+def test_train_model_vectoroutput(model_type, overwrite_data=False):
     unittest_train_model_dataset_class_inheritance(
         model_type, "ci_vectoroutput.json", True, overwrite_data
     )

--- a/tests/test_deepspeed.py
+++ b/tests/test_deepspeed.py
@@ -27,7 +27,7 @@ except Exception:
 @pytest.mark.gpu
 @pytest.mark.deepspeed
 @pytest.mark.skipif(not deepspeed_available, reason="deepspeed package not installed")
-def pytest_train_model_vectoroutput_w_deepspeed(model_type, overwrite_data=False):
+def test_train_model_vectoroutput_w_deepspeed(model_type, overwrite_data=False):
     unittest_train_model(
         model_type,
         None,
@@ -50,7 +50,7 @@ def pytest_train_model_vectoroutput_w_deepspeed(model_type, overwrite_data=False
 @pytest.mark.gpu
 @pytest.mark.deepspeed
 @pytest.mark.skipif(not deepspeed_available, reason="deepspeed package not installed")
-def pytest_train_model_vectoroutput_w_deepspeed_global_attention(
+def test_train_model_vectoroutput_w_deepspeed_global_attention(
     model_type, global_attn_engine, global_attn_type, overwrite_data=False
 ):
     unittest_train_model(
@@ -69,7 +69,7 @@ def pytest_train_model_vectoroutput_w_deepspeed_global_attention(
 # @pytest.mark.parametrize("model_type", ["PNA"])
 # @pytest.mark.parametrize("zero_stage", [1, 2, 3])
 # @pytest.mark.mpi
-# def pytest_train_model_vectoroutput_w_deepspeed_zero(
+# def test_train_model_vectoroutput_w_deepspeed_zero(
 #     model_type, zero_stage, overwrite_data=False
 # ):
 #     overwrite_config = {

--- a/tests/test_enthalpy.py
+++ b/tests/test_enthalpy.py
@@ -61,5 +61,5 @@ def unittest_formation_enthalpy():
 
 
 @pytest.mark.mpi_skip()
-def pytest_formation_enthalpy():
+def test_formation_enthalpy():
     unittest_formation_enthalpy()

--- a/tests/test_equivariant_attention.py
+++ b/tests/test_equivariant_attention.py
@@ -26,7 +26,7 @@ def _sample(dtype=torch.float64):
     return irreps, features, positions, batch
 
 
-def pytest_equivariant_attention_is_rotation_equivariant_and_translation_invariant():
+def test_equivariant_attention_is_rotation_equivariant_and_translation_invariant():
     torch.manual_seed(11)
     irreps, features, positions, batch = _sample()
     module = EquivariantAllToAllAttention(irreps, heads=2, lmax=1).double()
@@ -50,7 +50,7 @@ def pytest_equivariant_attention_is_rotation_equivariant_and_translation_invaria
     )
 
 
-def pytest_equivariant_attention_is_permutation_equivariant():
+def test_equivariant_attention_is_permutation_equivariant():
     torch.manual_seed(12)
     irreps, features, positions, batch = _sample()
     module = EquivariantAllToAllAttention(irreps, heads=2, lmax=1).double()
@@ -67,7 +67,7 @@ def pytest_equivariant_attention_is_permutation_equivariant():
     torch.testing.assert_close(permuted_output, output[permutation])
 
 
-def pytest_equivariant_attention_isolates_graphs_and_normalizes_each_target():
+def test_equivariant_attention_isolates_graphs_and_normalizes_each_target():
     torch.manual_seed(13)
     irreps, features, positions, batch = _sample()
     module = EquivariantAllToAllAttention(irreps, heads=3, lmax=1).double()
@@ -95,7 +95,7 @@ def pytest_equivariant_attention_isolates_graphs_and_normalizes_each_target():
         )
 
 
-def pytest_equivariant_attention_supports_backward_propagation():
+def test_equivariant_attention_supports_backward_propagation():
     torch.manual_seed(14)
     irreps, features, positions, batch = _sample()
     features.requires_grad_()
@@ -112,7 +112,7 @@ def pytest_equivariant_attention_supports_backward_propagation():
     assert all(parameter.grad is not None for parameter in module.parameters())
 
 
-def pytest_chunked_attention_matches_dense_outputs_and_gradients():
+def test_chunked_attention_matches_dense_outputs_and_gradients():
     torch.manual_seed(15)
     irreps = o3.Irreps("2x0e + 2x1o")
     dense_module = EquivariantAllToAllAttention(
@@ -152,7 +152,7 @@ def pytest_chunked_attention_matches_dense_outputs_and_gradients():
             )
 
 
-def pytest_chunked_attention_handles_interleaved_and_singleton_graphs():
+def test_chunked_attention_handles_interleaved_and_singleton_graphs():
     torch.manual_seed(16)
     irreps = o3.Irreps("1x0e + 1x1o")
     module = EquivariantAllToAllAttention(irreps, heads=1).double()

--- a/tests/test_equivariant_complete_graph.py
+++ b/tests/test_equivariant_complete_graph.py
@@ -15,7 +15,7 @@ import torch
 from hydragnn.globalAtt.complete_graph import complete_graph_edge_index
 
 
-def pytest_complete_graph_constructs_ordered_non_self_pairs():
+def test_complete_graph_constructs_ordered_non_self_pairs():
     edge_index = complete_graph_edge_index(torch.tensor([0, 0, 0]))
 
     expected = torch.tensor(
@@ -27,7 +27,7 @@ def pytest_complete_graph_constructs_ordered_non_self_pairs():
     assert torch.equal(edge_index, expected)
 
 
-def pytest_complete_graph_keeps_batched_graphs_isolated():
+def test_complete_graph_keeps_batched_graphs_isolated():
     batch = torch.tensor([3, 3, 8, 8, 8, 11])
     edge_index = complete_graph_edge_index(batch)
     source, target = edge_index
@@ -50,7 +50,7 @@ def pytest_complete_graph_keeps_batched_graphs_isolated():
     assert actual_pairs == expected_pairs
 
 
-def pytest_complete_graph_handles_empty_and_singleton_batches():
+def test_complete_graph_handles_empty_and_singleton_batches():
     empty = complete_graph_edge_index(torch.empty(0, dtype=torch.long))
     singletons = complete_graph_edge_index(torch.tensor([0, 2, 7]))
 
@@ -67,6 +67,6 @@ def pytest_complete_graph_handles_empty_and_singleton_batches():
         (torch.tensor([0, -1]), ValueError, "nonnegative"),
     ],
 )
-def pytest_complete_graph_rejects_invalid_batches(batch, error, message):
+def test_complete_graph_rejects_invalid_batches(batch, error, message):
     with pytest.raises(error, match=message):
         complete_graph_edge_index(batch)

--- a/tests/test_equivariant_features.py
+++ b/tests/test_equivariant_features.py
@@ -21,7 +21,7 @@ from hydragnn.globalAtt.equivariant_features import (
 )
 
 
-def pytest_scalar_vector_adapter_round_trip():
+def test_scalar_vector_adapter_round_trip():
     adapter = ScalarVectorIrrepsAdapter(channels=4)
     scalars = torch.randn(5, 4)
     vectors = torch.randn(5, 3, 4)
@@ -35,7 +35,7 @@ def pytest_scalar_vector_adapter_round_trip():
     assert torch.equal(decoded_vectors, vectors)
 
 
-def pytest_scalar_vector_adapter_is_rotation_equivariant():
+def test_scalar_vector_adapter_is_rotation_equivariant():
     adapter = ScalarVectorIrrepsAdapter(channels=3).double()
     scalars = torch.randn(7, 3, dtype=torch.float64)
     vectors = torch.randn(7, 3, 3, dtype=torch.float64)
@@ -65,21 +65,21 @@ def pytest_scalar_vector_adapter_is_rotation_equivariant():
         (torch.randn(2, 3), torch.randn(3, 3, 3), "equiv_node_feat"),
     ],
 )
-def pytest_scalar_vector_adapter_rejects_invalid_shapes(scalars, vectors, message):
+def test_scalar_vector_adapter_rejects_invalid_shapes(scalars, vectors, message):
     adapter = ScalarVectorIrrepsAdapter(channels=3)
 
     with pytest.raises(ValueError, match=message):
         adapter(scalars, vectors)
 
 
-def pytest_scalar_vector_adapter_rejects_mixed_dtypes():
+def test_scalar_vector_adapter_rejects_mixed_dtypes():
     adapter = ScalarVectorIrrepsAdapter(channels=3)
 
     with pytest.raises(ValueError, match="same dtype"):
         adapter(torch.randn(2, 3), torch.randn(2, 3, 3, dtype=torch.float64))
 
 
-def pytest_scalar_vector_adapter_rejects_invalid_encoded_width():
+def test_scalar_vector_adapter_rejects_invalid_encoded_width():
     adapter = ScalarVectorIrrepsAdapter(channels=3)
 
     with pytest.raises(ValueError, match="12 entries per node"):
@@ -87,7 +87,7 @@ def pytest_scalar_vector_adapter_rejects_invalid_encoded_width():
 
 
 @pytest.mark.parametrize("mpnn_type", ["SchNet", "DimeNet"])
-def pytest_scalar_local_models_require_explicit_limited_mode(mpnn_type):
+def test_scalar_local_models_require_explicit_limited_mode(mpnn_type):
     with pytest.raises(ValueError, match="cannot provide tensor-valued"):
         create_local_feature_adapter(mpnn_type, channels=4, allow_scalar_only=True)
 
@@ -110,7 +110,7 @@ def pytest_scalar_local_models_require_explicit_limited_mode(mpnn_type):
     assert adapter.decode(adapter(features)) is features
 
 
-def pytest_schnet_scalar_mode_rejects_coordinate_updates():
+def test_schnet_scalar_mode_rejects_coordinate_updates():
     with pytest.raises(ValueError, match="coordinate updates"):
         create_local_feature_adapter(
             "SchNet",
@@ -121,13 +121,13 @@ def pytest_schnet_scalar_mode_rejects_coordinate_updates():
         )
 
 
-def pytest_equivariant_local_models_use_scalar_vector_adapter_without_opt_in():
+def test_equivariant_local_models_use_scalar_vector_adapter_without_opt_in():
     for mpnn_type in ("PAINN", "PNAEq"):
         adapter = create_local_feature_adapter(mpnn_type, channels=4)
         assert isinstance(adapter, ScalarVectorIrrepsAdapter)
 
 
-def pytest_mace_irreps_adapter_round_trip_and_rotation():
+def test_mace_irreps_adapter_round_trip_and_rotation():
     irreps = o3.Irreps("3x0e + 3x1o + 2x2e")
     adapter = IrrepsFeatureAdapter(irreps)
     features = torch.randn(5, irreps.dim, dtype=torch.float64)
@@ -147,12 +147,12 @@ def pytest_mace_irreps_adapter_round_trip_and_rotation():
     )
 
 
-def pytest_mace_irreps_adapter_rejects_nonleading_scalars():
+def test_mace_irreps_adapter_rejects_nonleading_scalars():
     with pytest.raises(ValueError, match="precede tensor irreps"):
         IrrepsFeatureAdapter("1x1o + 1x0e")
 
 
-def pytest_mace_parallel_input_zero_initializes_absent_tensor_irreps():
+def test_mace_parallel_input_zero_initializes_absent_tensor_irreps():
     adapter = IrrepsFeatureAdapter("2x0e + 2x1o")
     scalars = torch.randn(3, 2)
     features = adapter.encode_parallel_input(scalars, torch.empty(3, 0))

--- a/tests/test_equivariant_local_global.py
+++ b/tests/test_equivariant_local_global.py
@@ -62,7 +62,7 @@ def _layer(coupling_mode):
     ("coupling_mode", "expected_scale", "expected_global_input_scale"),
     [("parallel", 5.0, 1.0), ("sequential", 6.0, 2.0)],
 )
-def pytest_equivariant_local_global_coupling_branch_isolation(
+def test_equivariant_local_global_coupling_branch_isolation(
     coupling_mode, expected_scale, expected_global_input_scale
 ):
     layer = _layer(coupling_mode)
@@ -84,7 +84,7 @@ def pytest_equivariant_local_global_coupling_branch_isolation(
 
 
 @pytest.mark.parametrize("coupling_mode", ["parallel", "sequential"])
-def pytest_equivariant_local_global_modes_preserve_se3_and_backward(coupling_mode):
+def test_equivariant_local_global_modes_preserve_se3_and_backward(coupling_mode):
     torch.manual_seed(41)
     layer = _layer(coupling_mode)
     scalars = torch.randn(4, 2, dtype=torch.float64, requires_grad=True)
@@ -119,6 +119,6 @@ def pytest_equivariant_local_global_modes_preserve_se3_and_backward(coupling_mod
     )
 
 
-def pytest_equivariant_local_global_rejects_unknown_coupling_mode():
+def test_equivariant_local_global_rejects_unknown_coupling_mode():
     with pytest.raises(ValueError, match="parallel.*sequential"):
         _layer("unknown")

--- a/tests/test_equivariant_mace_integration.py
+++ b/tests/test_equivariant_mace_integration.py
@@ -79,7 +79,7 @@ def _data(positions, edge_shifts=None):
     )
 
 
-def pytest_mace_equivariant_transformer_forward_backward_and_se3():
+def test_mace_equivariant_transformer_forward_backward_and_se3():
     torch.manual_seed(61)
     model = _create_model()
     positions = torch.tensor(
@@ -105,7 +105,7 @@ def pytest_mace_equivariant_transformer_forward_backward_and_se3():
     )
 
 
-def pytest_mace_equivariant_transformer_rejects_periodic_images():
+def test_mace_equivariant_transformer_rejects_periodic_images():
     model = _create_model()
     shifts = torch.zeros(6, 3)
     shifts[0, 0] = 3.0
@@ -114,7 +114,7 @@ def pytest_mace_equivariant_transformer_rejects_periodic_images():
         model(_data(torch.randn(3, 3), edge_shifts=shifts))
 
 
-def pytest_mace_config_requires_a_tensor_hidden_layer():
+def test_mace_config_requires_a_tensor_hidden_layer():
     config = {
         "global_attn_engine": "EquivariantTransformer",
         "mpnn_type": "MACE",

--- a/tests/test_equivariant_painn_integration.py
+++ b/tests/test_equivariant_painn_integration.py
@@ -70,7 +70,7 @@ def _data(positions, edge_shifts=None):
     )
 
 
-def pytest_painn_equivariant_transformer_forward_backward_and_rotation():
+def test_painn_equivariant_transformer_forward_backward_and_rotation():
     torch.manual_seed(31)
     model = _create_model()
     assert all(conv.coupling_mode == "parallel" for conv in model.graph_convs)
@@ -96,7 +96,7 @@ def pytest_painn_equivariant_transformer_forward_backward_and_rotation():
     )
 
 
-def pytest_painn_equivariant_transformer_rejects_periodic_images():
+def test_painn_equivariant_transformer_rejects_periodic_images():
     model = _create_model()
     positions = torch.randn(3, 3)
     shifts = torch.zeros(6, 3)
@@ -106,7 +106,7 @@ def pytest_painn_equivariant_transformer_rejects_periodic_images():
         model(_data(positions, edge_shifts=shifts))
 
 
-def pytest_equivariant_transformer_config_rejects_untested_model_integration():
+def test_equivariant_transformer_config_rejects_untested_model_integration():
     config = {
         "global_attn_engine": "EquivariantTransformer",
         "mpnn_type": "EGNN",
@@ -121,7 +121,7 @@ def pytest_equivariant_transformer_config_rejects_untested_model_integration():
         validate_equivariant_transformer_config(config)
 
 
-def pytest_equivariant_transformer_config_rejects_unknown_coupling_mode():
+def test_equivariant_transformer_config_rejects_unknown_coupling_mode():
     config = {
         "global_attn_engine": "EquivariantTransformer",
         "mpnn_type": "PAINN",

--- a/tests/test_equivariant_pnaeq_integration.py
+++ b/tests/test_equivariant_pnaeq_integration.py
@@ -68,7 +68,7 @@ def _data(positions, edge_shifts=None):
     )
 
 
-def pytest_pnaeq_equivariant_transformer_forward_backward_and_se3():
+def test_pnaeq_equivariant_transformer_forward_backward_and_se3():
     torch.manual_seed(41)
     model = _create_model()
     positions = torch.tensor(
@@ -93,7 +93,7 @@ def pytest_pnaeq_equivariant_transformer_forward_backward_and_se3():
     )
 
 
-def pytest_pnaeq_equivariant_transformer_rejects_periodic_images():
+def test_pnaeq_equivariant_transformer_rejects_periodic_images():
     model = _create_model()
     positions = torch.randn(3, 3)
     shifts = torch.zeros(6, 3)

--- a/tests/test_equivariant_scalar_mpnn_integration.py
+++ b/tests/test_equivariant_scalar_mpnn_integration.py
@@ -90,7 +90,7 @@ def _data(positions, edge_shifts=None):
 
 
 @pytest.mark.parametrize("mpnn_type", ["SchNet", "DimeNet"])
-def pytest_scalar_mpnn_equivariant_transformer_forward_backward_and_se3(mpnn_type):
+def test_scalar_mpnn_equivariant_transformer_forward_backward_and_se3(mpnn_type):
     torch.manual_seed(51)
     model = _create_model(mpnn_type)
     positions = torch.tensor(
@@ -116,7 +116,7 @@ def pytest_scalar_mpnn_equivariant_transformer_forward_backward_and_se3(mpnn_typ
 
 
 @pytest.mark.parametrize("mpnn_type", ["SchNet", "DimeNet"])
-def pytest_scalar_mpnn_equivariant_transformer_rejects_periodic_images(mpnn_type):
+def test_scalar_mpnn_equivariant_transformer_rejects_periodic_images(mpnn_type):
     model = _create_model(mpnn_type)
     shifts = torch.zeros(6, 3)
     shifts[0, 2] = 2.0
@@ -126,7 +126,7 @@ def pytest_scalar_mpnn_equivariant_transformer_rejects_periodic_images(mpnn_type
 
 
 @pytest.mark.parametrize("mpnn_type", ["SchNet", "DimeNet"])
-def pytest_scalar_mpnn_config_requires_both_safeguards(mpnn_type):
+def test_scalar_mpnn_config_requires_both_safeguards(mpnn_type):
     config = {
         "global_attn_engine": "EquivariantTransformer",
         "mpnn_type": mpnn_type,
@@ -147,7 +147,7 @@ def pytest_scalar_mpnn_config_requires_both_safeguards(mpnn_type):
         validate_equivariant_transformer_config(config)
 
 
-def pytest_schnet_config_rejects_coordinate_updates():
+def test_schnet_config_rejects_coordinate_updates():
     config = {
         "global_attn_engine": "EquivariantTransformer",
         "mpnn_type": "SchNet",

--- a/tests/test_equivariant_transformer.py
+++ b/tests/test_equivariant_transformer.py
@@ -27,7 +27,7 @@ def _sample(dtype=torch.float64):
     return irreps, features, positions, batch
 
 
-def pytest_equivariant_rms_norm_is_rotation_equivariant():
+def test_equivariant_rms_norm_is_rotation_equivariant():
     irreps, features, _, _ = _sample()
     norm = EquivariantRMSNorm(irreps).double()
     rotation = o3.rand_matrix(dtype=torch.float64)
@@ -45,7 +45,7 @@ def pytest_equivariant_rms_norm_is_rotation_equivariant():
     )
 
 
-def pytest_equivariant_transformer_layer_preserves_se3_equivariance():
+def test_equivariant_transformer_layer_preserves_se3_equivariance():
     torch.manual_seed(21)
     irreps, features, positions, batch = _sample()
     layer = EquivariantTransformerLayer(
@@ -70,7 +70,7 @@ def pytest_equivariant_transformer_layer_preserves_se3_equivariance():
     )
 
 
-def pytest_equivariant_transformer_layer_is_permutation_equivariant():
+def test_equivariant_transformer_layer_is_permutation_equivariant():
     torch.manual_seed(22)
     irreps, features, positions, batch = _sample()
     layer = EquivariantTransformerLayer(irreps, heads=2, lmax=1).double()
@@ -84,7 +84,7 @@ def pytest_equivariant_transformer_layer_is_permutation_equivariant():
     torch.testing.assert_close(permuted_output, output[permutation])
 
 
-def pytest_equivariant_transformer_layer_handles_singleton_graphs_and_backward():
+def test_equivariant_transformer_layer_handles_singleton_graphs_and_backward():
     torch.manual_seed(23)
     irreps = o3.Irreps("2x0e + 2x1o")
     features = torch.randn(2, irreps.dim, dtype=torch.float64, requires_grad=True)
@@ -109,7 +109,7 @@ def pytest_equivariant_transformer_layer_handles_singleton_graphs_and_backward()
         (torch.tensor([[0], [2]]), "cross-graph"),
     ],
 )
-def pytest_equivariant_transformer_layer_rejects_invalid_explicit_pairs(
+def test_equivariant_transformer_layer_rejects_invalid_explicit_pairs(
     edge_index, message
 ):
     irreps = o3.Irreps("1x0e + 1x1o")
@@ -122,7 +122,7 @@ def pytest_equivariant_transformer_layer_rejects_invalid_explicit_pairs(
         layer(features, positions, batch, edge_index=edge_index)
 
 
-def pytest_equivariant_transformer_rejects_tensor_coupling_without_tensor_irreps():
+def test_equivariant_transformer_rejects_tensor_coupling_without_tensor_irreps():
     with pytest.raises(ValueError, match="requires at least one non-scalar"):
         EquivariantTransformerLayer("4x0e")
 

--- a/tests/test_example_configs_uma_allscaip.py
+++ b/tests/test_example_configs_uma_allscaip.py
@@ -88,7 +88,7 @@ def _load_example_config(filename):
         ("LJ_AllScAIP.json", "AllScAIP", "AllScAIPStack"),
     ],
 )
-def pytest_example_config_builds_model(filename, expected_mpnn, expected_str):
+def test_example_config_builds_model(filename, expected_mpnn, expected_str):
     """The shipped UMA / AllScAIP example configs build a valid model."""
     os.environ["HYDRAGNN_USE_VARIABLE_GRAPH_SIZE"] = "0"
     prev_dtype = torch.get_default_dtype()
@@ -117,7 +117,7 @@ def pytest_example_config_builds_model(filename, expected_mpnn, expected_str):
 
 
 @pytest.mark.parametrize("uma_variant", ["S", "M", "L"])
-def pytest_uma_variant_config_builds_model(uma_variant):
+def test_uma_variant_config_builds_model(uma_variant):
     """The UMA example config builds for every S / M / L capacity tier."""
     os.environ["HYDRAGNN_USE_VARIABLE_GRAPH_SIZE"] = "0"
     prev_dtype = torch.get_default_dtype()
@@ -144,7 +144,7 @@ def pytest_uma_variant_config_builds_model(uma_variant):
         os.environ.pop("HYDRAGNN_USE_VARIABLE_GRAPH_SIZE", None)
 
 
-def pytest_uma_equivariant_vector_head_config_builds_model():
+def test_uma_equivariant_vector_head_config_builds_model():
     """The equivariant-vector-head example config builds and wires the head.
 
     Mirrors ``LJ_UMA_equivariant_vector.json``: an energy graph head plus a

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -39,7 +39,7 @@ import subprocess
 )
 @pytest.mark.parametrize("example", ["qm9", "md17"])
 @pytest.mark.mpi_skip()
-def pytest_examples_energy(example, mpnn_type, global_attn_engine, global_attn_type):
+def test_examples_energy(example, mpnn_type, global_attn_engine, global_attn_type):
     path = os.path.join(os.path.dirname(__file__), "..", "examples", example)
     file_path = os.path.join(path, example + ".py")
     # Add the --mpnn_type argument for the subprocess call
@@ -77,7 +77,7 @@ def pytest_examples_energy(example, mpnn_type, global_attn_engine, global_attn_t
 )
 @pytest.mark.parametrize("example", ["LennardJones"])
 @pytest.mark.mpi_skip()
-def pytest_examples_grad_forces(example, mpnn_type):
+def test_examples_grad_forces(example, mpnn_type):
     path = os.path.join(os.path.dirname(__file__), "..", "examples", example)
     file_path = os.path.join(path, example + ".py")
 

--- a/tests/test_examples_graph_attr.py
+++ b/tests/test_examples_graph_attr.py
@@ -31,7 +31,7 @@ def _load_example_module(module_path, module_name):
 @pytest.mark.parametrize("graph_attr_mode", ["concat_node", "film", "fuse_pool"])
 @pytest.mark.parametrize("example", ["qm9", "md17"])
 @pytest.mark.mpi_skip()
-def pytest_examples_graph_attr(tmp_path, example, graph_attr_mode):
+def test_examples_graph_attr(tmp_path, example, graph_attr_mode):
     examples_root = os.path.join(os.path.dirname(__file__), "..", "examples", example)
 
     if example == "qm9":

--- a/tests/test_fairchem_adapter_regressions.py
+++ b/tests/test_fairchem_adapter_regressions.py
@@ -28,24 +28,24 @@ from hydragnn.utils.model.allscaip.utils.allscaip_radius_graph import (
 )
 
 
-def pytest_allscaip_frequency_list_explicit():
+def test_allscaip_frequency_list_explicit():
     assert _resolve_frequency_list(8, [3, 2, 3], True) == [3, 2, 3]
 
 
-def pytest_allscaip_frequency_list_fairchem_default():
+def test_allscaip_frequency_list_fairchem_default():
     assert _resolve_frequency_list(64, None, True) == [20, 10, 4, 10, 20]
 
 
-def pytest_allscaip_frequency_list_invalid_sum():
+def test_allscaip_frequency_list_invalid_sum():
     with pytest.raises(ValueError, match="must sum"):
         _resolve_frequency_list(8, [4, 3], True)
 
 
-def pytest_allscaip_frequency_list_unused_without_mask():
+def test_allscaip_frequency_list_unused_without_mask():
     assert _resolve_frequency_list(17, None, False) == [17]
 
 
-def pytest_external_backbone_embedding_skips_hydragnn_activation():
+def test_external_backbone_embedding_skips_hydragnn_activation():
     model = Base.__new__(Base)
     nn.Module.__init__(model)
     model.skip_post_conv_processing = True
@@ -55,7 +55,7 @@ def pytest_external_backbone_embedding_skips_hydragnn_activation():
     assert torch.equal(delivered, embedding)
 
 
-def pytest_allscaip_embedding_applies_output_normalization():
+def test_allscaip_embedding_applies_output_normalization():
     class FakeBackbone(nn.Module):
         def forward(self, _data):
             return {"node_reps": torch.tensor([[1.0, 2.0]])}
@@ -80,7 +80,7 @@ def pytest_allscaip_embedding_applies_output_normalization():
     assert equiv.shape == (1, 0)
 
 
-def pytest_allscaip_construction_preserves_global_matmul_precision(monkeypatch):
+def test_allscaip_construction_preserves_global_matmul_precision(monkeypatch):
     # Avoid constructing the large real blocks: this regression is solely
     # about constructor ownership of process-global PyTorch state.
     monkeypatch.setattr(
@@ -108,7 +108,7 @@ def pytest_allscaip_construction_preserves_global_matmul_precision(monkeypatch):
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
 @pytest.mark.parametrize("soft", [False, True])
-def pytest_allscaip_chunked_graph_matches_dense(dtype, soft):
+def test_allscaip_chunked_graph_matches_dense(dtype, soft):
     torch.manual_seed(7)
     pos = torch.rand(8, 3, dtype=dtype)
     cell = torch.eye(3, dtype=dtype) * 20
@@ -132,7 +132,7 @@ def pytest_allscaip_chunked_graph_matches_dense(dtype, soft):
     importlib.util.find_spec("fairchem") is None,
     reason="native FAIR-Chem is optional",
 )
-def pytest_native_fairchem_available_for_parity_suite():
+def test_native_fairchem_available_for_parity_suite():
     """Compare graph preprocessing to native FAIR-Chem when it is installed."""
     native_module = importlib.import_module(
         "fairchem.core.models.allscaip.utils.allscaip_radius_graph"

--- a/tests/test_fairchem_native_parity.py
+++ b/tests/test_fairchem_native_parity.py
@@ -122,7 +122,7 @@ def _allscaip_adapter(*, batched: bool, periodic: bool) -> _FairChemAdapter:
 @pytest.mark.parametrize(
     "batched,periodic", [(False, False), (False, True), (True, False)]
 )
-def pytest_allscaip_backbone_node_representations(batched, periodic):
+def test_allscaip_backbone_node_representations(batched, periodic):
     torch.manual_seed(11)
     ours = AllScAIPBackbone(**_allscaip_config()).eval()
     native = NativeAllScAIPBackbone(**_allscaip_config()).eval()
@@ -139,7 +139,7 @@ def pytest_allscaip_backbone_node_representations(batched, periodic):
 
 
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
-def pytest_allscaip_output_normalization_matches_native(dtype):
+def test_allscaip_output_normalization_matches_native(dtype):
     torch.manual_seed(13)
     ours = get_normalization_layer(NormalizationType.RMSNorm)(64)
     native = native_get_normalization_layer(NativeNormalizationType.RMSNorm)(64)
@@ -152,7 +152,7 @@ def pytest_allscaip_output_normalization_matches_native(dtype):
 
 @pytest.mark.parametrize("periodic", [False, True])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
-def pytest_allscaip_neighbor_graph_matches_native(periodic, dtype):
+def test_allscaip_neighbor_graph_matches_native(periodic, dtype):
     ours_data = _allscaip_adapter(batched=True, periodic=periodic)
     native_data = _allscaip_adapter(batched=True, periodic=periodic)
     for data in (ours_data, native_data):
@@ -255,7 +255,7 @@ def _uma_data_dict(*, batched: bool, periodic: bool) -> _UMADataDict:
 @pytest.mark.parametrize(
     "batched,periodic", [(False, False), (False, True), (True, False)]
 )
-def pytest_uma_spherical_backbone_embeddings(batched, periodic):
+def test_uma_spherical_backbone_embeddings(batched, periodic):
     torch.manual_seed(17)
     ours = VendoredUMABackbone(**_uma_config()).eval()
     native = NativeUMABackbone(**_uma_config()).eval()
@@ -280,7 +280,7 @@ def pytest_uma_spherical_backbone_embeddings(batched, periodic):
     )
 
 
-def pytest_uma_backbone_position_gradients():
+def test_uma_backbone_position_gradients():
     torch.manual_seed(19)
     ours = VendoredUMABackbone(**_uma_config()).eval()
     native = NativeUMABackbone(**_uma_config()).eval()

--- a/tests/test_forces_equivariant.py
+++ b/tests/test_forces_equivariant.py
@@ -231,7 +231,7 @@ def compute_forces(model, data):
     return forces
 
 
-def test_head_type_equivariance(
+def check_head_type_equivariance(
     mpnn_type,
     head_type,
     num_structures=5,
@@ -415,7 +415,7 @@ def compare_energy_only_precision(precisions=("bf16", "fp32", "fp64")):
         for mpnn_type in ["EGNN", "SchNet", "DimeNet", "PAINN", "PNAEq", "MACE", "UMA"]:
             try:
                 with autocast_ctx:
-                    max_error, rel_error = test_energy_only_equivariance(
+                    max_error, rel_error = check_energy_only_equivariance(
                         mpnn_type,
                         dtype_override=dtype,
                         allow_high_precision=False,
@@ -465,7 +465,7 @@ def compare_mlp_vs_conv_heads():
         print("-" * 50)
 
         for head_type in head_types:
-            max_error, relative_error = test_head_type_equivariance(
+            max_error, relative_error = check_head_type_equivariance(
                 mpnn_type, head_type
             )
             results[mpnn_type][head_type] = {
@@ -547,7 +547,7 @@ def compare_mlp_vs_conv_heads_precision(precisions=("bf16", "fp32", "fp64")):
                 results[mpnn_type] = {}
                 for head_type in head_types:
                     with autocast_ctx:
-                        max_error, rel_error = test_head_type_equivariance(
+                        max_error, rel_error = check_head_type_equivariance(
                             mpnn_type,
                             head_type,
                             dtype_override=dtype,
@@ -563,7 +563,7 @@ def compare_mlp_vs_conv_heads_precision(precisions=("bf16", "fp32", "fp64")):
     print("\n" + "=" * 70)
 
 
-def test_energy_only_equivariance(
+def check_energy_only_equivariance(
     mpnn_type,
     num_structures=4,
     num_rotations=3,
@@ -726,7 +726,7 @@ def compare_energy_only():
 
     for mpnn_type in ["EGNN", "SchNet", "DimeNet", "PAINN", "PNAEq", "MACE", "UMA"]:
         try:
-            max_error, rel_error = test_energy_only_equivariance(mpnn_type)
+            max_error, rel_error = check_energy_only_equivariance(mpnn_type)
             status = "PRESERVED" if max_error < 1e-4 else "BROKEN"
             print(f"{mpnn_type}: energy-only head")
             print(f"  Max error:      {max_error:.2e}")

--- a/tests/test_forces_equivariant_training.py
+++ b/tests/test_forces_equivariant_training.py
@@ -24,7 +24,7 @@ import subprocess
     "mpnn_type", ["SchNet", "EGNN", "DimeNet", "PAINN", "PNAPlus", "MACE", "UMA"]
 )
 @pytest.mark.mpi_skip()
-def pytest_examples(example, mpnn_type):
+def test_examples(example, mpnn_type):
     path = os.path.join(os.path.dirname(__file__), "..", "examples", example)
     file_path = os.path.join(path, example + ".py")  # Assuming different model scripts
     python_exec = sys.executable
@@ -60,7 +60,7 @@ def pytest_examples(example, mpnn_type):
     ],
 )
 @pytest.mark.mpi_skip()
-def pytest_equivariant_heads(example, mpnn_type, head_level, head_type, graph_pooling):
+def test_equivariant_heads(example, mpnn_type, head_level, head_type, graph_pooling):
     """Test equivariant models with different head placements (node vs graph) and pooling choices."""
     path = os.path.join(os.path.dirname(__file__), "..", "examples", example)
     file_path = os.path.join(path, example + ".py")
@@ -129,7 +129,7 @@ def pytest_equivariant_heads(example, mpnn_type, head_level, head_type, graph_po
     ],
 )
 @pytest.mark.mpi_skip()
-def pytest_expanded_x_features(example, mpnn_type, head_type):
+def test_expanded_x_features(example, mpnn_type, head_type):
     """Test that MLP heads work correctly with expanded x features (including equiv_norm)."""
     path = os.path.join(os.path.dirname(__file__), "..", "examples", example)
     file_path = os.path.join(path, example + ".py")

--- a/tests/test_fsdp2_force_grad_regression.py
+++ b/tests/test_fsdp2_force_grad_regression.py
@@ -69,7 +69,7 @@ def _bf16_supported():
     "mpnn_type",
     ["EGNN", "DimeNet", "SchNet", "MACE", "PAINN", "PNAEq"],
 )
-def pytest_fsdp2_enhanced_wrapper_force_grad_regression(
+def test_fsdp2_enhanced_wrapper_force_grad_regression(
     monkeypatch, precision, mpnn_type
 ):
     has_cuda = torch.cuda.is_available()

--- a/tests/test_graph_dataset.py
+++ b/tests/test_graph_dataset.py
@@ -16,7 +16,7 @@ from torch_geometric.data import Data
 from hydragnn.preprocess import graph_dataset
 
 
-def pytest_stratified_sampling_ignores_absent_species_bins(monkeypatch):
+def test_stratified_sampling_ignores_absent_species_bins(monkeypatch):
     observed = {}
 
     class RecordingSplitter:
@@ -42,14 +42,14 @@ def pytest_stratified_sampling_ignores_absent_species_bins(monkeypatch):
     assert observed["categories"] == [201, 201]
 
 
-def pytest_periodic_edges_require_cell():
+def test_periodic_edges_require_cell():
     data = Data(pos=torch.tensor([[0.0, 0.0, 0.0]]))
 
     with pytest.raises(ValueError, match="require data.cell"):
         graph_dataset._build_edges(data, 2.0, 8, periodic=True)
 
 
-def pytest_periodic_edges_are_constructed_from_cell():
+def test_periodic_edges_are_constructed_from_cell():
     data = Data(
         pos=torch.tensor([[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]]),
         cell=5.0 * torch.eye(3),

--- a/tests/test_graphgps_pyg_parity.py
+++ b/tests/test_graphgps_pyg_parity.py
@@ -85,7 +85,7 @@ def _copy_nonlocal_state(ours: HydraGPSConv, native: PyGGPSConv) -> None:
     ],
     ids=["balanced", "uneven", "single-graph"],
 )
-def pytest_graphgps_global_branch_matches_pyg(attn_type, batch):
+def test_graphgps_global_branch_matches_pyg(attn_type, batch):
     torch.manual_seed(23)
     native = PyGGPSConv(8, conv=None, heads=2, attn_type=attn_type).eval()
     ours = HydraGPSConv(8, conv=None, heads=2, attn_type=attn_type).eval()
@@ -101,7 +101,7 @@ def pytest_graphgps_global_branch_matches_pyg(attn_type, batch):
 
 
 @pytest.mark.parametrize("attn_type", ["multihead", "performer"])
-def pytest_graphgps_local_and_global_branches_match_pyg(attn_type):
+def test_graphgps_local_and_global_branches_match_pyg(attn_type):
     torch.manual_seed(29)
     native_local = GCNConv(8, 8)
     native = PyGGPSConv(8, conv=native_local, heads=2, attn_type=attn_type).eval()
@@ -123,7 +123,7 @@ def pytest_graphgps_local_and_global_branches_match_pyg(attn_type):
 
 
 @pytest.mark.parametrize("attn_type", ["multihead", "performer"])
-def pytest_graphgps_training_dropout_matches_pyg(attn_type):
+def test_graphgps_training_dropout_matches_pyg(attn_type):
     torch.manual_seed(31)
     native = PyGGPSConv(
         8, conv=None, heads=2, dropout=0.25, attn_type=attn_type
@@ -144,7 +144,7 @@ def pytest_graphgps_training_dropout_matches_pyg(attn_type):
 
 
 @pytest.mark.parametrize("attn_type", ["multihead", "performer"])
-def pytest_graphgps_input_gradients_match_pyg(attn_type):
+def test_graphgps_input_gradients_match_pyg(attn_type):
     torch.manual_seed(41)
     native = PyGGPSConv(8, conv=None, heads=2, attn_type=attn_type).eval()
     ours = HydraGPSConv(8, conv=None, heads=2, attn_type=attn_type).eval()
@@ -166,7 +166,7 @@ def pytest_graphgps_input_gradients_match_pyg(attn_type):
             assert torch.allclose(parameter.grad, native_gradient, atol=1e-6, rtol=1e-5)
 
 
-def pytest_graphgps_performer_model_factory_forward_and_backward():
+def test_graphgps_performer_model_factory_forward_and_backward():
     model = create_model(
         mpnn_type="GIN",
         input_dim=2,
@@ -212,7 +212,7 @@ def pytest_graphgps_performer_model_factory_forward_and_backward():
     assert isinstance(model.graph_convs[0], HydraGPSConv)
 
 
-def pytest_graphgps_performer_projection_redraw_is_step_based(monkeypatch):
+def test_graphgps_performer_projection_redraw_is_step_based(monkeypatch):
     layer = HydraGPSConv(8, conv=None, heads=2, attn_type="performer").train()
     redraw_count = 0
 
@@ -233,7 +233,7 @@ def pytest_graphgps_performer_projection_redraw_is_step_based(monkeypatch):
     assert redraw_count == 1
 
 
-def pytest_graphgps_reset_restarts_performer_redraw_schedule(monkeypatch):
+def test_graphgps_reset_restarts_performer_redraw_schedule(monkeypatch):
     layer = HydraGPSConv(8, conv=None, heads=2, attn_type="performer").train()
     redraw_count = 0
 
@@ -252,7 +252,7 @@ def pytest_graphgps_reset_restarts_performer_redraw_schedule(monkeypatch):
     assert redraw_count == redraws_after_reset + 1
 
 
-def pytest_graphgps_performer_projection_redraw_handles_multiple_layers(monkeypatch):
+def test_graphgps_performer_projection_redraw_handles_multiple_layers(monkeypatch):
     layers = torch.nn.ModuleList(
         [
             HydraGPSConv(8, conv=None, heads=2, attn_type="performer"),
@@ -274,7 +274,7 @@ def pytest_graphgps_performer_projection_redraw_handles_multiple_layers(monkeypa
     assert redraw_counts == [1, 1]
 
 
-def pytest_graphgps_performer_projection_redraw_rejects_invalid_interval():
+def test_graphgps_performer_projection_redraw_rejects_invalid_interval():
     layer = HydraGPSConv(8, conv=None, heads=2, attn_type="performer").train()
 
     with pytest.raises(ValueError, match="positive or None"):

--- a/tests/test_graphs.py
+++ b/tests/test_graphs.py
@@ -243,7 +243,7 @@ def unittest_train_model(
     ],
 )
 @pytest.mark.parametrize("ci_input", ["ci.json", "ci_multihead.json"])
-def pytest_train_model(mpnn_type, ci_input, overwrite_data=False):
+def test_train_model(mpnn_type, ci_input, overwrite_data=False):
     unittest_train_model(mpnn_type, None, None, ci_input, False, overwrite_data)
 
 
@@ -252,7 +252,7 @@ def pytest_train_model(mpnn_type, ci_input, overwrite_data=False):
     "mpnn_type",
     ["GAT", "PNA", "PNAPlus", "CGCNN", "SchNet", "DimeNet", "EGNN", "PNAEq", "PAINN"],
 )
-def pytest_train_model_lengths(mpnn_type, overwrite_data=False):
+def test_train_model_lengths(mpnn_type, overwrite_data=False):
     unittest_train_model(mpnn_type, None, None, "ci.json", True, overwrite_data)
 
 
@@ -266,7 +266,7 @@ def pytest_train_model_lengths(mpnn_type, overwrite_data=False):
     "mpnn_type",
     ["GAT", "PNA", "PNAPlus", "CGCNN", "SchNet", "DimeNet", "EGNN", "PNAEq", "PAINN"],
 )
-def pytest_train_model_lengths_global_attention(
+def test_train_model_lengths_global_attention(
     mpnn_type, global_attn_engine, global_attn_type, overwrite_data=False
 ):
     unittest_train_model(
@@ -279,7 +279,7 @@ def pytest_train_model_lengths_global_attention(
     "mpnn_type",
     ["MACE"],
 )
-def pytest_train_mace_model_lengths(mpnn_type, overwrite_data=False):
+def test_train_mace_model_lengths(mpnn_type, overwrite_data=False):
     unittest_train_model(mpnn_type, None, None, "ci.json", True, overwrite_data)
 
 
@@ -287,7 +287,7 @@ def pytest_train_mace_model_lengths(mpnn_type, overwrite_data=False):
 @pytest.mark.parametrize(
     "mpnn_type", ["EGNN", "SchNet", "PNAEq", "PAINN", "MACE", "UMA"]
 )
-def pytest_train_equivariant_model(mpnn_type, overwrite_data=False):
+def test_train_equivariant_model(mpnn_type, overwrite_data=False):
     unittest_train_model(
         mpnn_type, None, None, "ci_equivariant.json", False, overwrite_data
     )
@@ -306,7 +306,7 @@ def pytest_train_equivariant_model(mpnn_type, overwrite_data=False):
         "PNAEq",
     ],
 )
-def pytest_train_model_vectoroutput(mpnn_type, overwrite_data=False):
+def test_train_model_vectoroutput(mpnn_type, overwrite_data=False):
     unittest_train_model(
         mpnn_type, None, None, "ci_vectoroutput.json", True, overwrite_data
     )
@@ -328,7 +328,7 @@ def pytest_train_model_vectoroutput(mpnn_type, overwrite_data=False):
         "PAINN",
     ],
 )
-def pytest_train_model_conv_head(mpnn_type, overwrite_data=False):
+def test_train_model_conv_head(mpnn_type, overwrite_data=False):
     unittest_train_model(
         mpnn_type, None, None, "ci_conv_head.json", False, overwrite_data
     )

--- a/tests/test_graphs_graphattr.py
+++ b/tests/test_graphs_graphattr.py
@@ -258,7 +258,7 @@ def unittest_train_model_graphattr(
     ],
 )
 @pytest.mark.parametrize("ci_input", ["ci.json", "ci_multihead.json"])
-def pytest_train_model_graphattr(
+def test_train_model_graphattr(
     mpnn_type, ci_input, graph_attr_conditioning_mode, overwrite_data=False
 ):
     unittest_train_model_graphattr(
@@ -277,7 +277,7 @@ def pytest_train_model_graphattr(
     "mpnn_type",
     ["GAT", "PNA", "PNAPlus", "CGCNN", "SchNet", "DimeNet", "EGNN", "PNAEq", "PAINN"],
 )
-def pytest_train_model_graphattr_lengths(
+def test_train_model_graphattr_lengths(
     mpnn_type, graph_attr_conditioning_mode, overwrite_data=False
 ):
     unittest_train_model_graphattr(
@@ -301,7 +301,7 @@ def pytest_train_model_graphattr_lengths(
     "mpnn_type",
     ["GAT", "PNA", "PNAPlus", "CGCNN", "SchNet", "DimeNet", "EGNN", "PNAEq", "PAINN"],
 )
-def pytest_train_model_graphattr_lengths_global_attention(
+def test_train_model_graphattr_lengths_global_attention(
     mpnn_type,
     global_attn_engine,
     global_attn_type,
@@ -324,7 +324,7 @@ def pytest_train_model_graphattr_lengths_global_attention(
     "mpnn_type",
     ["MACE"],
 )
-def pytest_train_mace_model_graphattr_lengths(
+def test_train_mace_model_graphattr_lengths(
     mpnn_type, graph_attr_conditioning_mode, overwrite_data=False
 ):
     unittest_train_model_graphattr(
@@ -340,7 +340,7 @@ def pytest_train_mace_model_graphattr_lengths(
 
 @pytest.mark.parametrize("graph_attr_conditioning_mode", CONDITIONING_MODES)
 @pytest.mark.parametrize("mpnn_type", ["EGNN", "SchNet", "PNAEq", "PAINN", "MACE"])
-def pytest_train_equivariant_model_graphattr(
+def test_train_equivariant_model_graphattr(
     mpnn_type, graph_attr_conditioning_mode, overwrite_data=False
 ):
     unittest_train_model_graphattr(
@@ -359,7 +359,7 @@ def pytest_train_equivariant_model_graphattr(
     "mpnn_type",
     ["GAT", "PNA", "PNAPlus", "SchNet", "DimeNet", "EGNN", "PNAEq"],
 )
-def pytest_train_model_graphattr_vectoroutput(
+def test_train_model_graphattr_vectoroutput(
     mpnn_type, graph_attr_conditioning_mode, overwrite_data=False
 ):
     unittest_train_model_graphattr(
@@ -390,7 +390,7 @@ def pytest_train_model_graphattr_vectoroutput(
         "PAINN",
     ],
 )
-def pytest_train_model_graphattr_conv_head(
+def test_train_model_graphattr_conv_head(
     mpnn_type, graph_attr_conditioning_mode, overwrite_data=False
 ):
     unittest_train_model_graphattr(

--- a/tests/test_interatomic_potential.py
+++ b/tests/test_interatomic_potential.py
@@ -88,7 +88,7 @@ def create_mock_molecular_data(num_atoms=10, num_graphs=2):
 
 
 @pytest.mark.mpi_skip()
-def pytest_model_creation_with_enhancement():
+def test_model_creation_with_enhancement():
     """Test creating a model with interatomic potential enhancement."""
     from hydragnn.models.create import create_model
     from hydragnn.utils.model.model import update_multibranch_heads
@@ -137,7 +137,7 @@ def pytest_model_creation_with_enhancement():
 
 
 @pytest.mark.mpi_skip()
-def pytest_forward_pass():
+def test_forward_pass():
     """Test the enhanced forward pass with molecular data."""
     from hydragnn.models.create import create_model
     from hydragnn.utils.model.model import update_multibranch_heads
@@ -192,7 +192,7 @@ def pytest_forward_pass():
 
 
 @pytest.mark.mpi_skip()
-def pytest_energy_force_consistency():
+def test_energy_force_consistency():
     """Test that forces can be computed from energy gradients."""
     from hydragnn.models.create import create_model
     from hydragnn.utils.model.model import update_multibranch_heads

--- a/tests/test_loss_and_activation_functions.py
+++ b/tests/test_loss_and_activation_functions.py
@@ -108,7 +108,7 @@ def unittest_loss_and_activation_functions(
 @pytest.mark.parametrize(
     "loss_function_type", ["mse", "mae", "rmse", "GaussianNLLLoss"]
 )
-def pytest_loss_functions(loss_function_type, ci_input="ci.json", overwrite_data=False):
+def test_loss_functions(loss_function_type, ci_input="ci.json", overwrite_data=False):
     if loss_function_type == "GaussianNLLLoss":
         ci_input = "ci_multihead.json"
     unittest_loss_and_activation_functions(
@@ -130,7 +130,7 @@ def pytest_loss_functions(loss_function_type, ci_input="ci.json", overwrite_data
         "lrelu_05",
     ],
 )
-def pytest_activation_functions_multihead(
+def test_activation_functions_multihead(
     activation_function_type, ci_input="ci_multihead.json", overwrite_data=False
 ):
     unittest_loss_and_activation_functions(
@@ -152,7 +152,7 @@ def pytest_activation_functions_multihead(
         "lrelu_05",
     ],
 )
-def pytest_activation_functions_vectoroutput(
+def test_activation_functions_vectoroutput(
     activation_function_type, ci_input="ci_vectoroutput.json", overwrite_data=False
 ):
     unittest_loss_and_activation_functions(

--- a/tests/test_materials_preprocessing.py
+++ b/tests/test_materials_preprocessing.py
@@ -32,7 +32,7 @@ def _sample(**updates):
     return Data(**values)
 
 
-def pytest_normalize_vasp_kbar_stress_and_expand_voigt():
+def test_normalize_vasp_kbar_stress_and_expand_voigt():
     stress = normalize_stress(
         [10.0, 20.0, 30.0, 4.0, 5.0, 6.0],
         source_unit="kbar",
@@ -50,7 +50,7 @@ def pytest_normalize_vasp_kbar_stress_and_expand_voigt():
     torch.testing.assert_close(stress, expected)
 
 
-def pytest_normalize_stress_preserves_ase_convention():
+def test_normalize_stress_preserves_ase_convention():
     stress = torch.tensor([[1.0, 0.2, 0.0], [0.2, 2.0, 0.3], [0.0, 0.3, 3.0]])
     output = normalize_stress(
         stress,
@@ -74,7 +74,7 @@ def pytest_normalize_stress_preserves_ase_convention():
         ),
     ],
 )
-def pytest_normalize_stress_rejects_malformed_input(stress, message):
+def test_normalize_stress_rejects_malformed_input(stress, message):
     with pytest.raises(ValueError, match=message):
         normalize_stress(
             stress,
@@ -83,7 +83,7 @@ def pytest_normalize_stress_rejects_malformed_input(stress, message):
         )
 
 
-def pytest_validate_materials_sample_accepts_consistent_data():
+def test_validate_materials_sample_accepts_consistent_data():
     sample = _sample()
     assert validate_materials_sample(sample, require_stress=True) is sample
 
@@ -97,6 +97,6 @@ def pytest_validate_materials_sample_accepts_consistent_data():
         ({"edge_index": torch.tensor([[0, 1], [0, 0]])}, "self-loops"),
     ],
 )
-def pytest_validate_materials_sample_rejects_invalid_data(updates, message):
+def test_validate_materials_sample_rejects_invalid_data(updates, message):
     with pytest.raises(ValueError, match=message):
         validate_materials_sample(_sample(**updates), require_stress=True)

--- a/tests/test_model_loadpred.py
+++ b/tests/test_model_loadpred.py
@@ -62,7 +62,7 @@ def unittest_model_prediction(config):
 
 
 # test loading and predictiong of a saved model from previous training
-def pytest_model_loadpred():
+def test_model_loadpred():
     model_type = "PNA"
     ci_input = "ci_multihead.json"
     config_file = os.path.join(os.getcwd(), "tests/inputs", ci_input)

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -108,7 +108,7 @@ def unittest_optimizers(optimizer_type, use_zero, ci_input, overwrite_data=False
     "use_zero_redundancy",
     [False, True],
 )
-def pytest_optimizers(
+def test_optimizers(
     optimizer_type, use_zero_redundancy, ci_input="ci.json", overwrite_data=False
 ):
     unittest_optimizers(optimizer_type, use_zero_redundancy, ci_input, overwrite_data)

--- a/tests/test_periodic_boundary_conditions.py
+++ b/tests/test_periodic_boundary_conditions.py
@@ -79,7 +79,7 @@ def unittest_periodic_boundary_conditions(
     assert ((dist <= config["Architecture"]["radius"]) & (dist >= 0.0)).all()
 
 
-def pytest_periodic_h2():
+def test_periodic_h2():
     config_file = "./tests/inputs/ci_periodic.json"
     with open(config_file, "r") as f:
         config = json.load(f)
@@ -98,7 +98,7 @@ def pytest_periodic_h2():
     unittest_periodic_boundary_conditions(config, data, 1, 2)
 
 
-def pytest_periodic_bcc_large():
+def test_periodic_bcc_large():
     config_file = "./tests/inputs/ci_periodic.json"
     with open(config_file, "r") as f:
         config = json.load(f)

--- a/tests/test_precision_control.py
+++ b/tests/test_precision_control.py
@@ -20,7 +20,7 @@ tvt = import_module("hydragnn.train.train_validate_test")
 pytestmark = pytest.mark.mpi_skip()
 
 
-def pytest_resolve_precision_aliases():
+def test_resolve_precision_aliases():
     prec, param_dtype, autocast_dtype = tvt.resolve_precision("bfloat16")
     assert prec == "bf16"
     assert (
@@ -39,7 +39,7 @@ def pytest_resolve_precision_aliases():
     assert autocast_dtype is None
 
 
-def pytest_move_batch_to_device_fp64(monkeypatch):
+def test_move_batch_to_device_fp64(monkeypatch):
     monkeypatch.setattr(tvt, "get_device", lambda: torch.device("cpu"))
     tensor = torch.ones(2, dtype=torch.float32)
     moved = tvt.move_batch_to_device(tensor, torch.float64)
@@ -47,7 +47,7 @@ def pytest_move_batch_to_device_fp64(monkeypatch):
     assert moved.device.type == "cpu"
 
 
-def pytest_bf16_autocast_cpu(monkeypatch):
+def test_bf16_autocast_cpu(monkeypatch):
     # Pretend only CPU is available but supports bfloat16
     monkeypatch.setattr(tvt, "get_device", lambda: torch.device("cpu"))
     monkeypatch.setattr(torch.cuda, "is_available", lambda: False)

--- a/tests/test_radial_transforms.py
+++ b/tests/test_radial_transforms.py
@@ -198,7 +198,7 @@ def unittest_train_model(
 )
 @pytest.mark.parametrize("basis_function", ["bessel", "gaussian", "chebyshev"])
 @pytest.mark.parametrize("distance_transform", ["None", "Agnesi", "Soft"])
-def pytest_train_model_transforms(
+def test_train_model_transforms(
     model_type,
     basis_function,
     distance_transform,

--- a/tests/test_rotational_invariance.py
+++ b/tests/test_rotational_invariance.py
@@ -107,7 +107,7 @@ def unittest_rotational_invariance(tol=1e-14):
 
 
 @pytest.mark.mpi_skip()
-def pytest_rotational_invariance():
+def test_rotational_invariance():
     # Test with (default) single precision
     unittest_rotational_invariance(tol=1e-4)
 

--- a/tests/test_uma_equivariant_head.py
+++ b/tests/test_uma_equivariant_head.py
@@ -31,7 +31,7 @@ def _random_node_embedding(num_nodes, lmax, channels, dtype):
 
 
 @pytest.mark.parametrize("num_vectors", [1, 3])
-def pytest_output_shape_and_gradient(num_vectors):
+def test_output_shape_and_gradient(num_vectors):
     torch.manual_seed(0)
     num_nodes, lmax, channels = 5, 2, 8
     head = _UMAEquivariantVectorHead(channels, num_vectors=num_vectors).to(
@@ -48,7 +48,7 @@ def pytest_output_shape_and_gradient(num_vectors):
     assert torch.isfinite(x.grad).all()
 
 
-def pytest_reads_only_l1_component():
+def test_reads_only_l1_component():
     """The head output must be invariant to changes in L>=2 channels and
     depend only on the L=0/L=1 block that SO3_Linear(lmax=1) consumes."""
     torch.manual_seed(1)
@@ -65,7 +65,7 @@ def pytest_reads_only_l1_component():
     assert torch.allclose(out_ref, out_perturbed, atol=1e-10)
 
 
-def pytest_equivariance_under_component_rotation():
+def test_equivariance_under_component_rotation():
     """Applying an orthogonal map R to the L=1 component axis of the input
     rotates the output vectors by the same R (equivariance)."""
     torch.manual_seed(2)
@@ -93,7 +93,7 @@ def pytest_equivariance_under_component_rotation():
     assert torch.allclose(out_rot, expected, atol=1e-9)
 
 
-def pytest_invalid_num_vectors_channel_shapes():
+def test_invalid_num_vectors_channel_shapes():
     """Constructing the head with mismatched channels still yields a valid
     module; forward with wrong channel count must raise."""
     head = _UMAEquivariantVectorHead(8, num_vectors=1).to(torch.float64)
@@ -176,7 +176,7 @@ def _make_batch(dtype):
     return Batch.from_data_list(graphs)
 
 
-def pytest_end_to_end_rotational_equivariance():
+def test_end_to_end_rotational_equivariance():
     """Through the real UMA backbone: rotating atomic positions rotates the
     equivariant vector-head output by the same rotation, while the scalar node
     head stays invariant."""
@@ -225,7 +225,7 @@ def pytest_end_to_end_rotational_equivariance():
         torch.set_default_dtype(prev_dtype)
 
 
-def pytest_uma_adapter_reads_charge_spin_from_graph_attr():
+def test_uma_adapter_reads_charge_spin_from_graph_attr():
     model = _build_uma_with_vector_head()
     batch = _make_batch(torch.get_default_dtype())
     batch.graph_attr = torch.tensor([2.0, 1.0, -1.0, 3.0])
@@ -247,7 +247,7 @@ def pytest_uma_adapter_reads_charge_spin_from_graph_attr():
         model._build_data_dict(batch)
 
 
-def pytest_uma_adapter_converts_periodic_edge_shifts():
+def test_uma_adapter_converts_periodic_edge_shifts():
     from torch_geometric.data import Batch, Data
 
     model = _build_uma_with_vector_head()
@@ -287,7 +287,7 @@ def pytest_uma_adapter_converts_periodic_edge_shifts():
     assert torch.allclose(uma_vectors, -hydragnn_vectors)
 
 
-def pytest_uma_adapter_rejects_nonperiodic_lattice_shift():
+def test_uma_adapter_rejects_nonperiodic_lattice_shift():
     model = _build_uma_with_vector_head()
     batch = _make_batch(torch.get_default_dtype())
     batch.cell = torch.eye(3).repeat(2, 1)


### PR DESCRIPTION
## Summary
- replace the HydraGNN-specific `pytest_*` function discovery convention with pytest's standard `test_*` convention
- rename all test functions and update package imports accordingly
- rename non-test equivariance helpers to `check_*` so pytest does not collect them accidentally
- exclude local virtual environments, caches, and build artifacts from recursive discovery

## Validation
- 585 tests collected successfully
- 43 focused tests passed
- `black --check .` passes
- `git diff --check` passes