### PR TITLE
Preserve pytest default directory exclusions

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,17 @@
 [pytest]
-norecursedirs = dataset .venv .uv-cache build dist
+norecursedirs =
+    .*
+    __pycache__
+    build
+    dist
+    CVS
+    _darcs
+    {arch}
+    *.egg
+    venv
+    dataset
+    .venv
+    .uv-cache
 python_classes = Test*
 python_functions = test_*
 filterwarnings =


### PR DESCRIPTION
## Summary
- restore pytest's standard recursive-collection exclusions after defining `norecursedirs`
- explicitly exclude `__pycache__`
- retain HydraGNN-specific exclusions for datasets, local environments, caches, and build artifacts

Defining `norecursedirs` replaces pytest's defaults, so this prevents collection from traversing dot directories and other irrelevant trees.

## Validation
- `python -m pytest tests --collect-only -q`: 585 tests collected successfully
- `git diff --check` passes