### PR TITLE
Document current HydraGNN structure and Python support

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ["3.11", "3.12", "3.14"]
+        python: ["3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - name: Setup Python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Contributing to HydraGNN is easy: just open a [pull
 request](https://help.github.com/articles/using-pull-requests/). Make
-`master` the destination branch on the [HydraGNN
+`main` the destination branch on the [HydraGNN
 repository](https://github.com/ORNL/HydraGNN) and allow edits from
 maintainers in the pull request.
 
@@ -35,3 +35,18 @@ directory.
 
 HydraGNN uses `pytest` to test. You can run `python -m pytest` from the top level
 directory.
+
+Pytest follows its standard discovery convention in this repository: test files
+are named `test_*.py`, test functions are named `test_*`, and test classes are
+named `Test*`. Name reusable helpers `check_*` or `_helper_*` so pytest does not
+collect them as tests.
+
+Before submitting a pull request, verify both discovery and execution:
+
+```bash
+python -m pytest tests --collect-only -q
+python -m pytest tests
+```
+
+The collection check is important: a valid-looking function with the wrong name
+otherwise receives no test coverage.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ To install required packages with only basic capability (`torch`,
 `torch_geometric`, and related packages)
 and to serialize+store the processed data for later sessions (`pickle5`):
 
-> **Python version:** Installation via `install_dependencies.sh` is currently tested and supported for **Python 3.10, 3.11, and 3.12** only.
+> **Python versions:** HydraGNN is tested and supported on **Python 3.11,
+> 3.12, and 3.14**. Other Python versions, including Python 3.13, are not
+> supported. Facility installation scripts default to Python 3.11 unless
+> documented otherwise for that system.
 
 **Recommended approach - standard installation:**
 ```bash

--- a/README.md
+++ b/README.md
@@ -32,9 +32,8 @@ To install required packages with only basic capability (`torch`,
 `torch_geometric`, and related packages)
 and to serialize+store the processed data for later sessions (`pickle5`):
 
-> **Python versions:** HydraGNN is tested and supported on **Python 3.11,
-> 3.12, and 3.14**. Other Python versions, including Python 3.13, are not
-> supported. Facility installation scripts default to Python 3.11 unless
+> **Python versions:** HydraGNN is tested and supported on **Python 3.11
+> through 3.14**. Facility installation scripts default to Python 3.11 unless
 > documented otherwise for that system.
 
 **Recommended approach - standard installation:**

--- a/README.md
+++ b/README.md
@@ -172,13 +172,13 @@ Additionally, many important arguments fall within the `["NeuralNetwork"]` secti
 - `["NeuralNetwork"]`
   - `["Architecture"]`
     - `["mpnn_type"]`  
-      Accepted types: `CGCNN`, `DimeNet`, `EGNN`, `GAT`, `GIN`, `MACE`, `MFC`, `PAINN`, `PNAEq`, `PNAPlus`, `PNA`, `SAGE`, `SchNet` (str)
+      Accepted types: `AllScAIP`, `CGCNN`, `DimeNet`, `EGNN`, `GAT`, `GIN`, `MACE`, `MFC`, `PAINN`, `PNAEq`, `PNAPlus`, `PNA`, `SAGE`, `SchNet`, `UMA` (str)
     - `["num_conv_layers"]`  
       Examples: `1`, `2`, `3`, `4` ... (int)
     - `["output_heads"]`  
       Task types: `node`, `graph` (int)
     - `["global_attn_engine"]`
-      Accepted types: `GPS`, `None`
+      Accepted types: `EquivariantTransformer`, `GPS`, `None`
     - `["global_attn_type"]`
       Accepted types: `multihead`, `performer`
     - `["pe_dim"]`
@@ -223,6 +223,16 @@ training batch more than once. For example:
 When GPS wraps an equivariant HydraGNN model, global attention operates only
 on invariant node channels. Equivariant channels are updated by the local MPNN
 and propagated alongside the globally attended invariant representation.
+
+### Feature guides
+
+- [GraphGPS and Performer configuration](#configurable-settings)
+- [Equivariant all-to-all graph Transformer](docs/equivariant_graph_transformer.md)
+- [UMA and AllScAIP integration](docs/uma_allscaip.md)
+- [Cost-aware graph batching](docs/cost_aware_batching.md)
+- [Reusable dataset downloads](docs/dataset_downloads.md)
+- [Materials preprocessing](docs/materials_preprocessing.md)
+- [HPC facility assets](scripts/hpc/README.md)
 
   - `["Variables of Interest"]`
     - `["input_node_features"]`  

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -42,7 +42,10 @@ HydraGNN is a distributed PyTorch implementation of multi-headed graph convoluti
 
 HydraGNN uses a modular requirements system for flexible and reproducible installation. The recommended way to install all necessary dependencies is to use the provided installation script:
 
-> **Python version:** Installation via `install_dependencies.sh` is currently tested and supported for **Python 3.10, 3.11, and 3.12** only.
+> **Python versions:** HydraGNN is tested and supported on **Python 3.11,
+> 3.12, and 3.14**. Other Python versions, including Python 3.13, are not
+> supported. Facility installation scripts default to Python 3.11 unless
+> documented otherwise for that system.
 
 #### Recommended: Automated Installation
 ```bash

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -1061,7 +1061,7 @@ class MyCustomLoader(RawDatasetLoader):
 #SBATCH --gpu-bind=closest
 
 # Load modules and environment
-module load python/3.9
+module load python/3.11
 source hydragnn_env/bin/activate
 
 # Set environment variables
@@ -1366,4 +1366,4 @@ HydraGNN continues to evolve with new features and optimizations. Stay updated w
 ---
 
 *Last updated: April 2026*
-*Version: Compatible with HydraGNN v4.0*
+*Version: Compatible with HydraGNN v5.0*

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -127,6 +127,20 @@ Tested installation scripts are organized by facility and system under
 
 HydraGNN supports multiple data formats and provides comprehensive preprocessing capabilities.
 
+Dataset creation and application-specific preprocessing are caller
+responsibilities. HydraGNN training consumes prepared PyG graph samples; the
+legacy `run_training`, `run_prediction`, and `SerializedDataLoader`
+orchestration APIs have been removed. Prepared pickle, per-sample `.pt`, ADIOS,
+and DDStore-backed datasets remain available through their current loaders.
+Loading an already prepared dataset does not silently reconstruct, renormalize,
+or otherwise mutate its stored features. Rebuild the dataset explicitly when
+its preprocessing contract changes.
+
+Reusable data utilities are documented in
+[dataset downloads](docs/dataset_downloads.md) and
+[materials preprocessing](docs/materials_preprocessing.md). Variable-size graph
+training can use [cost-aware batching](docs/cost_aware_batching.md).
+
 ### Supported Data Formats
 
 #### 1. Raw Data Formats

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -42,9 +42,8 @@ HydraGNN is a distributed PyTorch implementation of multi-headed graph convoluti
 
 HydraGNN uses a modular requirements system for flexible and reproducible installation. The recommended way to install all necessary dependencies is to use the provided installation script:
 
-> **Python versions:** HydraGNN is tested and supported on **Python 3.11,
-> 3.12, and 3.14**. Other Python versions, including Python 3.13, are not
-> supported. Facility installation scripts default to Python 3.11 unless
+> **Python versions:** HydraGNN is tested and supported on **Python 3.11
+> through 3.14**. Facility installation scripts default to Python 3.11 unless
 > documented otherwise for that system.
 
 #### Recommended: Automated Installation

--- a/docs/equivariant_graph_transformer.md
+++ b/docs/equivariant_graph_transformer.md
@@ -3,7 +3,7 @@
 ## Scope
 
 HydraGNN's `GPS` global-attention engine applies scalar attention to invariant
-node channels. The proposed `EquivariantTransformer` engine is an alternative
+node channels. The `EquivariantTransformer` engine is an alternative
 GraphGPS-style hybrid: every layer combines a local equivariant MPNN update
 with an explicitly SE(3)-equivariant, all-to-all attention update.
 
@@ -124,9 +124,9 @@ selected. For SchNet it also rejects coordinate-update mode
 (`Architecture.equivariance=true`) because raw coordinates are not
 translation-invariant latent tensor features.
 
-## Required tests
+## Verification coverage
 
-The engine is not complete until tests cover:
+The regression suite verifies:
 
 1. rotation equivariance for every output irrep;
 2. translation invariance;

--- a/docs/uma_allscaip.md
+++ b/docs/uma_allscaip.md
@@ -1,0 +1,73 @@
+# UMA and AllScAIP integration
+
+HydraGNN provides `UMA` and `AllScAIP` as monolithic atomistic backbones. They
+run their own complete block stacks inside HydraGNN and then expose node
+representations to HydraGNN's task heads; they are not ordinary local MPNN
+layers combined with the `GPS` engine.
+
+## Input data contract
+
+Both backbones require `data.pos` with shape `[num_nodes, 3]`. Prefer an integer
+`data.atomic_numbers` tensor with one value per node. For compatibility, the
+current integration falls back to `data.x[:, 0]` when `atomic_numbers` is not
+present. Periodic samples may provide `data.cell` and `data.pbc`; non-periodic
+samples default to a zero cell with periodicity disabled. Optional `charge` and
+`spin` values are graph-level scalars.
+
+Set `enable_interatomic_potential` to `true` when training an energy-conserving
+potential. HydraGNN then obtains conservative forces by differentiating the
+predicted invariant energy with respect to `data.pos`.
+
+## UMA
+
+Select UMA with `"mpnn_type": "UMA"` and set `"equivariance": true`. UMA
+maintains SO(3) irreducible features internally and is genuinely equivariant.
+The default HydraGNN decoder reads its invariant L=0 channels. Set
+`uma_equivariant_vector_head` to expose an L=1 per-node vector head and use
+`uma_vector_head_index` when more than one node head could match.
+
+Standard HydraGNN keys configure the cutoff, neighbor cap, width, depth, radial
+basis size, and periodic behavior. UMA-specific controls include `uma_variant`
+(`S`, `M`, or `L`), `uma_mmax`, `uma_grid_resolution`, `uma_edge_channels`,
+`uma_hidden_channels`, `uma_norm_type`, `uma_ff_type`, `uma_use_chg_spin`,
+`uma_num_experts`, `uma_moe_dropout`, and `uma_use_composition_embedding`.
+
+HydraGNN vendors the required FAIR-Chem UMA implementation and its preserved
+MIT notice, so normal UMA execution does not import the external
+`fairchem-core` package. HydraGNN does not yet provide FAIR-Chem's graph-parallel
+UMA runtime; large-graph support therefore does not imply distributed graph
+partitioning parity.
+
+## AllScAIP
+
+Select AllScAIP with `"mpnn_type": "AllScAIP"`. It constructs its own
+differentiable radius/kNN graph and uses scalar hidden representations. Its
+energy prediction is invariant and its energy-gradient forces are equivariant,
+but its latent representation is not an e3nn-style equivariant tensor field.
+
+The standard `radius`, `max_neighbours`, `hidden_dim`, and `num_conv_layers`
+keys configure its principal dimensions. AllScAIP-specific controls include
+`allscaip_num_heads`, `allscaip_freq_list`, `allscaip_atten_name`,
+`allscaip_use_node_path`, `allscaip_use_sincx_mask`,
+`allscaip_use_freq_mask`, `allscaip_max_num_elements`, `allscaip_knn_soft`,
+`allscaip_distance_function`, normalization and dropout settings, stress
+regression, and dataset routing.
+
+For large graphs, `allscaip_use_chunked_graph` bounds graph-construction memory
+by processing target nodes in chunks of `allscaip_graph_chunk_size` while
+retaining the same graph semantics. `allscaip_knn_use_low_mem` selects the
+lower-memory kNN implementation.
+
+Keep `allscaip_knn_soft` enabled for energy-gradient force training. The hard
+neighbor selection is not differentiable at membership changes. The `math`
+attention backend is the safe default when double backward is required.
+
+## Dependency and provenance
+
+Vendored source retains its upstream MIT notices; HydraGNN additions remain
+under the repository's BSD-3-Clause terms. `requirements-specific-models.txt`
+provides auxiliary dependencies required by the vendored UMA backbone, while
+`requirements-dev.txt` freezes `fairchem-core==2.22.0` for native parity tests.
+The native test dependency is distinct from the vendored runtime used by
+HydraGNN's adapters. See the stack module docstrings and vendoring provenance
+files for the complete key mapping and upstream revision details.

--- a/hydragnn/_version.py
+++ b/hydragnn/_version.py
@@ -8,10 +8,5 @@
 #                                                                            #
 # SPDX-License-Identifier: BSD-3-Clause                                      #
 ##############################################################################
-from . import preprocess, models, train, postprocess, utils
-from ._version import __version__
 
-# ``utils`` is a namespace package, so importing it alone does not expose its
-# children as attributes. Keep the long-standing public access pattern used by
-# examples (``hydragnn.utils.input_config_parsing``) deterministic.
-from .utils import input_config_parsing
+__version__ = "5.0"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -7,10 +7,10 @@ set -e  # Exit on any error
 
 PYTHON_MINOR_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 case "${PYTHON_MINOR_VERSION}" in
-    3.11|3.12|3.14)
+    3.11|3.12|3.13|3.14)
         ;;
     *)
-        echo "Unsupported Python ${PYTHON_MINOR_VERSION}. HydraGNN supports Python 3.11, 3.12, and 3.14." >&2
+        echo "Unsupported Python ${PYTHON_MINOR_VERSION}. HydraGNN supports Python 3.11 through 3.14." >&2
         exit 1
         ;;
 esac

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -5,6 +5,16 @@
 
 set -e  # Exit on any error
 
+PYTHON_MINOR_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+case "${PYTHON_MINOR_VERSION}" in
+    3.11|3.12|3.14)
+        ;;
+    *)
+        echo "Unsupported Python ${PYTHON_MINOR_VERSION}. HydraGNN supports Python 3.11, 3.12, and 3.14." >&2
+        exit 1
+        ;;
+esac
+
 echo "Installing HydraGNN dependencies with consistent settings..."
 
 # Install base dependencies

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -19,34 +19,34 @@ echo "Installing HydraGNN dependencies with consistent settings..."
 
 # Install base dependencies
 echo "Installing base dependencies..."
-pip install --no-build-isolation -v -r requirements-base.txt 
+python -m pip install --no-build-isolation -v -r requirements-base.txt
 
 # Install PyTorch dependencies
 echo "Installing PyTorch dependencies..."
-pip install --no-build-isolation -v -r requirements-torch.txt 
+python -m pip install --no-build-isolation -v -r requirements-torch.txt
 
 # Install PyTorch Geometric dependencies
 echo "Installing PyTorch Geometric dependencies..."
-pip install --no-build-isolation -v -r requirements-pyg.txt 
+python -m pip install --no-build-isolation -v -r requirements-pyg.txt
 
 # Install development dependencies (optional)
 if [ "$1" == "dev" ]; then
     echo "Installing development dependencies..."
-    pip install --no-build-isolation -v -r requirements-dev.txt
+    python -m pip install --no-build-isolation -v -r requirements-dev.txt
 fi
 
 # Install model-specific backbone dependencies (e.g. FAIRChem UMA).
 # NOTE: build isolation is intentionally ENABLED here (no --no-build-isolation)
 # so omegaconf's sdist-only antlr4-python3-runtime dependency can build.
 echo "Installing model-specific backbone dependencies..."
-pip install -v -r requirements-specific-models.txt
+python -m pip install -v -r requirements-specific-models.txt
 
 # Install optional dependencies (optional)
 if [ "$1" == "all" ] || [ "$2" == "optional" ]; then
     echo "Installing optional dependencies..."
-    pip install --no-build-isolation -v -r requirements-optional.txt
+    python -m pip install --no-build-isolation -v -r requirements-optional.txt
 fi
 
 echo "Installation complete!"
 echo "Installed package versions:"
-pip list | grep -E "(numpy|scipy|torch|scikit-learn|matplotlib|ase)"
+python -m pip list | grep -E "(numpy|scipy|torch|scikit-learn|matplotlib|ase)"

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -48,5 +48,6 @@ if [ "$1" == "all" ] || [ "$2" == "optional" ]; then
 fi
 
 echo "Installation complete!"
+echo "HydraGNN source version: $(python setup.py --version)"
 echo "Installed package versions:"
 python -m pip list | grep -E "(numpy|scipy|torch|scikit-learn|matplotlib|ase)"

--- a/setup.py
+++ b/setup.py
@@ -59,11 +59,12 @@ test_requires = parse_requirements("requirements-dev.txt")
 setup(
     name="HydraGNN",
     version="4.0rc1",
-    python_requires=">=3.11,<3.15,!=3.13.*",
+    python_requires=">=3.11,<3.15",
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: 3.14",
     ],
     package_dir={"hydragnn": "hydragnn"},

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,13 @@ test_requires = parse_requirements("requirements-dev.txt")
 setup(
     name="HydraGNN",
     version="4.0rc1",
+    python_requires=">=3.11,<3.15,!=3.13.*",
+    classifiers=[
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.14",
+    ],
     package_dir={"hydragnn": "hydragnn"},
     packages=find_namespace_packages(include=["hydragnn", "hydragnn.*"]),
     # Vendored FairChem UMA backbone ships non-Python resources (spherical

--- a/setup.py
+++ b/setup.py
@@ -55,10 +55,13 @@ def get_install_requires():
 
 install_requires = get_install_requires()
 test_requires = parse_requirements("requirements-dev.txt")
+version_namespace = {}
+with open(os.path.join(os.path.dirname(__file__), "hydragnn", "_version.py")) as f:
+    exec(f.read(), version_namespace)
 
 setup(
     name="HydraGNN",
-    version="4.0rc1",
+    version=version_namespace["__version__"],
     python_requires=">=3.11,<3.15",
     classifiers=[
         "Programming Language :: Python :: 3 :: Only",


### PR DESCRIPTION
## Summary
- define Python 3.11 through 3.14 as the supported range in CI, packaging, installer checks, README, and user manual
- add Python 3.13 to the CI matrix so every supported minor version is exercised
- make HydraGNN v5.0 the single package version source and expose `hydragnn.__version__`
- use `python -m pip` consistently and report the source version during dependency installation
- document standard pytest discovery and correct the contributor target branch to `main`
- update architecture documentation for UMA, AllScAIP, and EquivariantTransformer
- add a feature-guide index and dedicated UMA/AllScAIP guide
- describe prepared-dataset ownership after removal of legacy orchestration APIs

## Validation
- verified package metadata and `hydragnn.__version__` both report `5.0`
- verified the package version specifier accepts Python 3.11 through 3.14 and rejects versions outside that range
- `bash -n install_dependencies.sh`
- `python setup.py --version`
- `black --check setup.py hydragnn/__init__.py hydragnn/_version.py`
- `git diff --check`