### PR TITLE
Add configurable post-local SGD synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,11 @@ and propagated alongside the globally attended invariant representation.
       Training precision: `"fp32"`, `"bf16"`, `"fp64"` (str, default `"fp32"`)
     - `["conv_checkpointing"]`  
       Enable gradient checkpointing to reduce memory usage (bool, default `false`)
+    - `["LocalSGD"]`
+      Optional post-local-SGD configuration for ordinary DDP. Set `enabled`,
+      `warmup_steps`, and `synchronization_period` to replace per-step global
+      gradient averaging after warm-up with periodic model-parameter averaging.
+      Optimizer state remains rank-local; see the User Manual for constraints.
 
 
 ### Citations

--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ and propagated alongside the globally attended invariant representation.
       Optional post-local-SGD configuration for ordinary DDP. Set `enabled`,
       `warmup_steps`, and `synchronization_period` to replace per-step global
       gradient averaging after warm-up with periodic model-parameter averaging.
-      Optimizer state remains rank-local; see the User Manual for constraints.
+      `optimizer_state_policy` selects rank-local state (default) or strict
+      optimizer-aware synchronization; see the User Manual for constraints.
 
 
 ### Citations

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -812,7 +812,9 @@ frequency after a synchronized warm-up:
             "LocalSGD": {
                 "enabled": true,
                 "warmup_steps": 100,
-                "synchronization_period": 4
+                "synchronization_period": 4,
+                "optimizer_state_policy": "local",
+                "optimizer_state_bucket_bytes": 26214400
             }
         }
     }
@@ -836,10 +838,39 @@ greater than `1` provide the communication reduction.
 This option changes the optimization algorithm rather than merely optimizing
 DDP communication. Replicas intentionally diverge between parameter averages.
 PyTorch's `PostLocalSGDOptimizer` accepts standard optimizers such as SGD,
-AdamW, and RMSprop, but only model parameters are averaged. Persistent
-optimizer state—such as momentum buffers or Adam first/second moments—remains
-rank-local. Larger periods can therefore affect convergence, especially for
-adaptive optimizers or non-identically distributed data.
+AdamW, and RMSprop. `optimizer_state_policy` controls persistent state:
+
+- `"local"` (default) matches native PyTorch post-local SGD. Momentum buffers,
+  adaptive moments, and other optimizer history remain rank-local.
+- `"synchronize"` applies optimizer-specific reductions whenever model
+  parameters are averaged. This costs additional collectives and communication
+  but restarts replicas with the same model and optimizer history.
+
+HydraGNN uses the following strict synchronized-state policies:
+
+| Optimizer | State synchronization |
+| --- | --- |
+| SGD | mean `momentum_buffer` when present |
+| Adam / AdamW | mean `exp_avg` and `exp_avg_sq`; require equal `step` |
+| Adamax | mean `exp_avg`; elementwise maximum `exp_inf`; require equal `step` |
+| Adagrad | mean `sum`; require equal `step` |
+| Adadelta | mean `square_avg` and `acc_delta`; require equal `step` |
+| RMSprop | mean `square_avg` and optional `momentum_buffer`/`grad_avg`; require equal `step` |
+
+Unknown optimizers or state keys fail explicitly under `"synchronize"` rather
+than being silently ignored. FusedLAMB is currently unsupported for state
+synchronization. `optimizer_state_bucket_bytes` bounds the temporary flat
+communication buckets used to combine compatible state tensors; it must be a
+positive integer and defaults to 25 MiB. State tensors are bucketed by
+reduction, device, and dtype. State layouts and step counters are collectively
+checked before tensor reductions.
+
+The local policy communicates less. Larger periods can cause the model and
+rank-local optimizer history to become inconsistent after parameter averaging,
+especially for adaptive optimizers or non-identically distributed data. The
+synchronized policy avoids that mismatch but can substantially increase
+communication—for Adam-like methods, two additional parameter-sized moment
+buffers are transferred at every synchronization point.
 
 HydraGNN stores the model-averager step in optimizer checkpoints so resumed
 runs retain the warm-up and averaging schedule. All ranks must execute the same
@@ -849,6 +880,10 @@ data-preprocessing collectives, and checkpoint coordination are unaffected.
 If an epoch ends between scheduled averages, HydraGNN performs one conditional
 parameter average before validation/checkpointing; no extra collective is
 issued when the last optimizer step already performed the scheduled average.
+With synchronized optimizer state, a single-rank checkpoint is sufficient
+because all replicas have identical state at checkpoint time. With local state,
+the checkpoint contains the checkpoint-writing rank's optimizer history; all
+ranks load that history on resume and then diverge during later local steps.
 
 Post-local SGD currently supports ordinary PyTorch DDP only. HydraGNN rejects
 combinations with FSDP, DeepSpeed, `SyncBatchNorm`, task/model-parallel wrappers,

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -799,6 +799,69 @@ resulting engine and explicit loaders to `train_validate_test` with
 `use_deepspeed=True`. See `examples/ogb/train_gap.py` for the complete setup;
 HydraGNN no longer hides this initialization inside a convenience wrapper.
 
+### Infrequent synchronization with post-local SGD
+
+Ordinary DDP averages gradients on every backward pass. HydraGNN can instead
+use PyTorch's native post-local-SGD components to reduce global collective
+frequency after a synchronized warm-up:
+
+```json
+{
+    "NeuralNetwork": {
+        "Training": {
+            "LocalSGD": {
+                "enabled": true,
+                "warmup_steps": 100,
+                "synchronization_period": 4
+            }
+        }
+    }
+}
+```
+
+Both integer values count optimizer steps, not epochs:
+
+- `warmup_steps` must be nonnegative. Before this many steps, DDP globally
+  averages gradients after every backward pass.
+- `synchronization_period` must be positive. After warm-up, gradient
+  all-reduce is disabled and every rank applies its optimizer locally. Model
+  parameters are globally averaged at the first local step and every stated
+  number of local steps thereafter.
+
+The default is `{"enabled": false}`, which retains conventional synchronous
+DDP. A period of `1` averages parameters after every local optimizer step and
+therefore does not reduce the number of global parameter collectives; values
+greater than `1` provide the communication reduction.
+
+This option changes the optimization algorithm rather than merely optimizing
+DDP communication. Replicas intentionally diverge between parameter averages.
+PyTorch's `PostLocalSGDOptimizer` accepts standard optimizers such as SGD,
+AdamW, and RMSprop, but only model parameters are averaged. Persistent
+optimizer state—such as momentum buffers or Adam first/second moments—remains
+rank-local. Larger periods can therefore affect convergence, especially for
+adaptive optimizers or non-identically distributed data.
+
+HydraGNN stores the model-averager step in optimizer checkpoints so resumed
+runs retain the warm-up and averaging schedule. All ranks must execute the same
+number of optimizer steps. The setting only changes training-time gradient and
+parameter synchronization; validation/test reductions, metric collectives,
+data-preprocessing collectives, and checkpoint coordination are unaffected.
+If an epoch ends between scheduled averages, HydraGNN performs one conditional
+parameter average before validation/checkpointing; no extra collective is
+issued when the last optimizer step already performed the scheduled average.
+
+Post-local SGD currently supports ordinary PyTorch DDP only. HydraGNN rejects
+combinations with FSDP, DeepSpeed, `SyncBatchNorm`, task/model-parallel wrappers,
+or `ZeroRedundancyOptimizer` rather than silently applying different semantics.
+Pass the full configuration to the distributed wrapper so it can configure the
+DDP communication hook before checkpoint loading:
+
+```python
+model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
+    model, optimizer, verbosity, config=config
+)
+```
+
 ### FSDP (Fully Sharded Data Parallel) Integration
 
 Pytorch's FSDP (Fully Sharded Data Parallel) provides functionality similar to DeepSpeed ZeRO. 

--- a/examples/LennardJones/LennardJones.py
+++ b/examples/LennardJones/LennardJones.py
@@ -301,7 +301,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     hydragnn.utils.model.load_existing_model_config(

--- a/examples/alexandria/train.py
+++ b/examples/alexandria/train.py
@@ -713,7 +713,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/ani1_x/train.py
+++ b/examples/ani1_x/train.py
@@ -543,7 +543,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/ani1_x/train_mlip.py
+++ b/examples/ani1_x/train_mlip.py
@@ -534,7 +534,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/csce/train_gap.py
+++ b/examples/csce/train_gap.py
@@ -427,7 +427,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     hydragnn.utils.model.load_existing_model_config(

--- a/examples/ising_model/train_ising.py
+++ b/examples/ising_model/train_ising.py
@@ -417,7 +417,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     writer = hydragnn.utils.model.get_summary_writer(log_name)

--- a/examples/lsms/lsms.py
+++ b/examples/lsms/lsms.py
@@ -211,7 +211,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/md17/md17.py
+++ b/examples/md17/md17.py
@@ -135,7 +135,7 @@ def main(mpnn_type=None, global_attn_engine=None, global_attn_type=None):
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Run training with the given model and md17 dataset.

--- a/examples/md17/md17_mlip.py
+++ b/examples/md17/md17_mlip.py
@@ -135,7 +135,7 @@ def main(mpnn_type=None, global_attn_engine=None, global_attn_type=None):
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Run training with the given model and md17 dataset.

--- a/examples/mptrj/train.py
+++ b/examples/mptrj/train.py
@@ -572,7 +572,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/multibranch/train.py
+++ b/examples/multibranch/train.py
@@ -497,7 +497,7 @@ if __name__ == "__main__":
             optimizer, mode="min", factor=0.5, patience=5, min_lr=0.00001
         )
         model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-            model, optimizer, verbosity
+            model, optimizer, verbosity, config=config
         )
 
     # Print details of neural network architecture

--- a/examples/multidataset_hpo/gfm.py
+++ b/examples/multidataset_hpo/gfm.py
@@ -399,7 +399,7 @@ def main():
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/nabla2_dft/train.py
+++ b/examples/nabla2_dft/train.py
@@ -504,7 +504,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     hydragnn.utils.model.load_existing_model_config(

--- a/examples/ogb/train_gap.py
+++ b/examples/ogb/train_gap.py
@@ -487,7 +487,7 @@ if __name__ == "__main__":
         )
 
         model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-            model, optimizer, verbosity
+            model, optimizer, verbosity, config=config
         )
 
         # Print details of neural network architecture

--- a/examples/open_catalyst_2020/train.py
+++ b/examples/open_catalyst_2020/train.py
@@ -459,7 +459,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/open_catalyst_2022/train.py
+++ b/examples/open_catalyst_2022/train.py
@@ -661,7 +661,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/open_catalyst_2025/train.py
+++ b/examples/open_catalyst_2025/train.py
@@ -315,7 +315,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     print_model(model)

--- a/examples/open_materials_2024/train.py
+++ b/examples/open_materials_2024/train.py
@@ -350,7 +350,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/open_molecules_2025/train.py
+++ b/examples/open_molecules_2025/train.py
@@ -372,7 +372,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/open_polymers_2026/train.py
+++ b/examples/open_polymers_2026/train.py
@@ -372,7 +372,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/qcml/train.py
+++ b/examples/qcml/train.py
@@ -522,7 +522,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/qm7x/train.py
+++ b/examples/qm7x/train.py
@@ -604,7 +604,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     hydragnn.utils.model.load_existing_model_config(

--- a/examples/qm7x/train_mlip.py
+++ b/examples/qm7x/train_mlip.py
@@ -599,7 +599,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     hydragnn.utils.model.load_existing_model_config(

--- a/examples/qm9/qm9.py
+++ b/examples/qm9/qm9.py
@@ -138,7 +138,7 @@ def main(mpnn_type=None, global_attn_engine=None, global_attn_type=None):
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Run training with the given model and qm9 datasets.

--- a/examples/transition1x/train.py
+++ b/examples/transition1x/train.py
@@ -568,7 +568,7 @@ if __name__ == "__main__":
     )
 
     model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-        model, optimizer, verbosity
+        model, optimizer, verbosity, config=config
     )
 
     # Print details of neural network architecture

--- a/examples/zinc/zinc.py
+++ b/examples/zinc/zinc.py
@@ -101,7 +101,7 @@ scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
 )
 
 model, optimizer = hydragnn.utils.distributed.distributed_model_wrapper(
-    model, optimizer, verbosity
+    model, optimizer, verbosity, config=config
 )
 
 hydragnn.utils.model.model.load_existing_model_config(

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -18,7 +18,11 @@ from hydragnn.postprocess.visualizer import Visualizer
 from hydragnn.utils.print.print_utils import print_distributed, iterate_tqdm
 from hydragnn.utils.profiling_and_tracing.time_utils import Timer
 from hydragnn.utils.profiling_and_tracing.profile import Profiler
-from hydragnn.utils.distributed import get_device, check_remaining
+from hydragnn.utils.distributed import (
+    get_device,
+    check_remaining,
+    synchronize_local_sgd_parameters,
+)
 from hydragnn.utils.model.model import Checkpoint, EarlyStopping
 from hydragnn.globalAtt.gps import redraw_performer_projections
 
@@ -368,6 +372,12 @@ def train_validate_test(
             tr.disable()
             if epoch == 0:
                 tr.reset()
+
+        # Validation, checkpoints, and the model returned after the final
+        # epoch must observe one globally consistent replica. Avoid a redundant
+        # collective when the last optimizer step already performed its
+        # scheduled post-local-SGD parameter average.
+        synchronize_local_sgd_parameters(optimizer)
 
         if int(os.getenv("HYDRAGNN_VALTEST", "1")) == 0:
             continue

--- a/hydragnn/utils/distributed/__init__.py
+++ b/hydragnn/utils/distributed/__init__.py
@@ -18,6 +18,8 @@ from .distributed import (
     is_model_distributed,
     get_distributed_model,
     distributed_model_wrapper,
+    configure_local_sgd,
+    synchronize_local_sgd_parameters,
     setup_ddp,
     nsplit,
     comm_reduce,

--- a/hydragnn/utils/distributed/distributed.py
+++ b/hydragnn/utils/distributed/distributed.py
@@ -571,9 +571,9 @@ class HydraPostLocalSGDOptimizer(PostLocalSGDOptimizer):
         self.optimizer_state_policy = optimizer_state_policy
         self.optimizer_state_bucket_bytes = optimizer_state_bucket_bytes
 
-    def step(self):
+    def step(self, *args, **kwargs):
         averaging_step = self.averager.step
-        super().step()
+        loss = super().step(*args, **kwargs)
         parameters_were_averaged = (
             averaging_step >= self.averager.warmup_steps
             and (averaging_step - self.averager.warmup_steps) % self.averager.period
@@ -581,7 +581,7 @@ class HydraPostLocalSGDOptimizer(PostLocalSGDOptimizer):
         )
         if parameters_were_averaged:
             _synchronize_optimizer_state(self)
-
+        return loss
 
 def configure_local_sgd(model, optimizer, config, *, use_deepspeed=False, verbosity=0):
     """Enable PyTorch post-local SGD for an ordinary DDP model.

--- a/hydragnn/utils/distributed/distributed.py
+++ b/hydragnn/utils/distributed/distributed.py
@@ -441,7 +441,11 @@ def _optimizer_state_reductions(optimizer):
 
 
 def _reduce_optimizer_tensor_bucket(tensors, operation, process_group, bucket_bytes):
-    """Reduce state tensors in bounded flat buckets and copy results in place."""
+    """Reduce state tensors in bounded flat buckets and copy results in place.
+
+    A bucket must hold at least one tensor element, so the effective byte bound
+    is clamped to the element size when a smaller value is requested.
+    """
     if not tensors:
         return
     world_size = dist.get_world_size(process_group)
@@ -469,11 +473,12 @@ def _reduce_optimizer_tensor_bucket(tensors, operation, process_group, bucket_by
         if not tensor.is_contiguous():
             raise ValueError("optimizer state tensors must be contiguous")
         flat_tensor = tensor.view(-1)
-        max_elements = max(bucket_bytes // tensor.element_size(), 1)
+        effective_bucket_bytes = max(bucket_bytes, tensor.element_size())
+        max_elements = effective_bucket_bytes // tensor.element_size()
         for start in range(0, flat_tensor.numel(), max_elements):
             view = flat_tensor[start : start + max_elements]
             view_bytes = view.numel() * view.element_size()
-            if current and current_bytes + view_bytes > bucket_bytes:
+            if current and current_bytes + view_bytes > effective_bucket_bytes:
                 reduce_current()
             current.append(view)
             current_bytes += view_bytes

--- a/hydragnn/utils/distributed/distributed.py
+++ b/hydragnn/utils/distributed/distributed.py
@@ -398,6 +398,121 @@ def is_model_distributed(model):
     return isinstance(model, torch.nn.parallel.distributed.DistributedDataParallel)
 
 
+def _local_sgd_training_config(config):
+    """Return the Local-SGD subsection from a full or neural-network config."""
+    if config is None:
+        return {"enabled": False}
+    neural_network = config.get("NeuralNetwork", config)
+    training = neural_network.get("Training", {})
+    from hydragnn.utils.input_config_parsing.config_utils import (
+        validate_local_sgd_config,
+    )
+
+    validate_local_sgd_config(training)
+    local_sgd = training.get("LocalSGD", {})
+    return local_sgd
+
+
+def configure_local_sgd(model, optimizer, config, *, use_deepspeed=False, verbosity=0):
+    """Enable PyTorch post-local SGD for an ordinary DDP model.
+
+    During ``warmup_steps``, DDP averages gradients globally on every backward
+    pass. Afterwards, gradient all-reduce is disabled so each rank takes local
+    optimizer steps, while ``PostLocalSGDOptimizer`` averages model parameters
+    globally every ``synchronization_period`` steps. Optimizer state (for
+    example Adam moments) remains rank-local by design.
+
+    The function is deliberately restricted to ordinary DDP. FSDP, DeepSpeed,
+    model-parallel wrappers, SyncBatchNorm, and ZeroRedundancyOptimizer have
+    different collective/state semantics and must not silently enter this mode.
+    """
+    local_sgd = _local_sgd_training_config(config)
+    if not local_sgd.get("enabled", False):
+        return model, optimizer
+
+    if use_deepspeed:
+        raise ValueError("Training.LocalSGD is not supported with DeepSpeed")
+    if bool(int(os.getenv("HYDRAGNN_USE_FSDP", "0"))):
+        raise ValueError("Training.LocalSGD is not supported with FSDP")
+    if not dist.is_initialized() or dist.get_world_size() < 2:
+        raise ValueError("Training.LocalSGD requires at least two distributed ranks")
+    if not isinstance(model, DDP):
+        raise TypeError("Training.LocalSGD requires an ordinary PyTorch DDP model")
+
+    neural_network = config.get("NeuralNetwork", config)
+    if neural_network.get("Architecture", {}).get("SyncBatchNorm", False):
+        raise ValueError("Training.LocalSGD is not supported with SyncBatchNorm")
+
+    from torch.distributed.optim import (
+        PostLocalSGDOptimizer,
+        ZeroRedundancyOptimizer,
+    )
+
+    if isinstance(optimizer, ZeroRedundancyOptimizer):
+        raise ValueError(
+            "Training.LocalSGD is not supported with ZeroRedundancyOptimizer"
+        )
+
+    from torch.distributed.algorithms.ddp_comm_hooks import post_localSGD_hook
+    from torch.distributed.algorithms.model_averaging.averagers import (
+        PeriodicModelAverager,
+    )
+
+    warmup_steps = local_sgd["warmup_steps"]
+    synchronization_period = local_sgd["synchronization_period"]
+    state = post_localSGD_hook.PostLocalSGDState(
+        process_group=None,
+        subgroup=None,
+        start_localSGD_iter=warmup_steps,
+        post_local_gradient_allreduce=False,
+    )
+    model.register_comm_hook(state, post_localSGD_hook.post_localSGD_hook)
+
+    averager = PeriodicModelAverager(
+        period=synchronization_period,
+        warmup_steps=warmup_steps,
+        process_group=None,
+    )
+    optimizer = PostLocalSGDOptimizer(optim=optimizer, averager=averager)
+    print_distributed(
+        verbosity,
+        "Post-local SGD enabled: "
+        f"warmup_steps={warmup_steps}, "
+        f"synchronization_period={synchronization_period}, "
+        "optimizer_state=rank-local",
+    )
+    return model, optimizer
+
+
+def synchronize_local_sgd_parameters(optimizer):
+    """Average replicas at an epoch boundary when an average is still pending."""
+    from torch.distributed.optim import PostLocalSGDOptimizer
+
+    if not isinstance(optimizer, PostLocalSGDOptimizer):
+        return False
+
+    averager = optimizer.averager
+    if getattr(optimizer, "_hydragnn_last_forced_sync_step", None) == averager.step:
+        return False
+    last_step = averager.step - 1
+    last_step_was_averaged = last_step >= averager.warmup_steps and (
+        (last_step - averager.warmup_steps) % averager.period == 0
+    )
+    if last_step_was_averaged:
+        return False
+
+    from torch.distributed.algorithms.model_averaging import utils
+
+    process_group = (
+        averager.process_group
+        if averager.process_group is not None
+        else dist.group.WORLD
+    )
+    utils.average_parameters_or_parameter_groups(optimizer.param_groups, process_group)
+    optimizer._hydragnn_last_forced_sync_step = averager.step
+    return True
+
+
 def get_distributed_model(
     model,
     verbosity=0,
@@ -498,6 +613,9 @@ def distributed_model_wrapper(
     bf16=False,
     precision="fp32",
 ):
+    local_sgd = _local_sgd_training_config(config)
+    if local_sgd.get("enabled", False) and use_deepspeed:
+        raise ValueError("Training.LocalSGD is not supported with DeepSpeed")
 
     if hasattr(torch, "xpu") and torch.xpu.is_available():
         print_distributed(
@@ -563,6 +681,14 @@ def distributed_model_wrapper(
             sync_batch_norm=sync_batch_norm,
             find_unused_parameters=find_unused_parameters,
             enhanced_model=enhanced_model_detected,
+        )
+
+        model, optimizer = configure_local_sgd(
+            model,
+            optimizer,
+            config,
+            use_deepspeed=use_deepspeed,
+            verbosity=verbosity,
         )
 
     return model, optimizer

--- a/hydragnn/utils/distributed/distributed.py
+++ b/hydragnn/utils/distributed/distributed.py
@@ -583,6 +583,7 @@ class HydraPostLocalSGDOptimizer(PostLocalSGDOptimizer):
             _synchronize_optimizer_state(self)
         return loss
 
+
 def configure_local_sgd(model, optimizer, config, *, use_deepspeed=False, verbosity=0):
     """Enable PyTorch post-local SGD for an ordinary DDP model.
 

--- a/hydragnn/utils/distributed/distributed.py
+++ b/hydragnn/utils/distributed/distributed.py
@@ -492,6 +492,10 @@ def synchronize_local_sgd_parameters(optimizer):
         return False
 
     averager = optimizer.averager
+    # DDP globally averages gradients throughout warm-up, so replicas are
+    # already identical and an additional parameter collective is redundant.
+    if averager.step <= averager.warmup_steps:
+        return False
     if getattr(optimizer, "_hydragnn_last_forced_sync_step", None) == averager.step:
         return False
     last_step = averager.step - 1

--- a/hydragnn/utils/distributed/distributed.py
+++ b/hydragnn/utils/distributed/distributed.py
@@ -12,12 +12,14 @@
 import os
 import re
 import warnings
+import hashlib
 
 import torch
 import torch.distributed as dist
 from torch.nn.parallel import DistributedDataParallel as DDP
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP, MixedPrecision
 from torch.distributed.fsdp import ShardingStrategy
+from torch.distributed.optim import PostLocalSGDOptimizer
 
 from hydragnn.utils.print.print_utils import print_distributed
 
@@ -413,14 +415,183 @@ def _local_sgd_training_config(config):
     return local_sgd
 
 
+_OPTIMIZER_STATE_REDUCTIONS = {
+    torch.optim.SGD: {"momentum_buffer": "mean"},
+    torch.optim.Adam: {"exp_avg": "mean", "exp_avg_sq": "mean"},
+    torch.optim.AdamW: {"exp_avg": "mean", "exp_avg_sq": "mean"},
+    torch.optim.Adamax: {"exp_avg": "mean", "exp_inf": "max"},
+    torch.optim.Adagrad: {"sum": "mean"},
+    torch.optim.Adadelta: {"square_avg": "mean", "acc_delta": "mean"},
+    torch.optim.RMSprop: {
+        "square_avg": "mean",
+        "momentum_buffer": "mean",
+        "grad_avg": "mean",
+    },
+}
+
+
+def _optimizer_state_reductions(optimizer):
+    reductions = _OPTIMIZER_STATE_REDUCTIONS.get(type(optimizer))
+    if reductions is None:
+        raise ValueError(
+            "synchronized LocalSGD optimizer state is unsupported for "
+            f"{type(optimizer).__name__}; use optimizer_state_policy='local'"
+        )
+    return reductions
+
+
+def _reduce_optimizer_tensor_bucket(tensors, operation, process_group, bucket_bytes):
+    """Reduce state tensors in bounded flat buckets and copy results in place."""
+    if not tensors:
+        return
+    world_size = dist.get_world_size(process_group)
+    current = []
+    current_bytes = 0
+
+    def reduce_current():
+        nonlocal current, current_bytes
+        if not current:
+            return
+        flat = torch.cat(current)
+        reduce_op = dist.ReduceOp.SUM if operation == "mean" else dist.ReduceOp.MAX
+        dist.all_reduce(flat, op=reduce_op, group=process_group)
+        if operation == "mean":
+            flat.div_(world_size)
+        offset = 0
+        for view in current:
+            count = view.numel()
+            view.copy_(flat[offset : offset + count])
+            offset += count
+        current = []
+        current_bytes = 0
+
+    for tensor in tensors:
+        if not tensor.is_contiguous():
+            raise ValueError("optimizer state tensors must be contiguous")
+        flat_tensor = tensor.view(-1)
+        max_elements = max(bucket_bytes // tensor.element_size(), 1)
+        for start in range(0, flat_tensor.numel(), max_elements):
+            view = flat_tensor[start : start + max_elements]
+            view_bytes = view.numel() * view.element_size()
+            if current and current_bytes + view_bytes > bucket_bytes:
+                reduce_current()
+            current.append(view)
+            current_bytes += view_bytes
+    reduce_current()
+
+
+def _synchronize_optimizer_state(optimizer):
+    """Apply the registered optimizer-specific state synchronization policy."""
+    if optimizer.optimizer_state_policy != "synchronize":
+        return
+
+    base_optimizer = optimizer.optim
+    reductions = _optimizer_state_reductions(base_optimizer)
+    process_group = (
+        optimizer.averager.process_group
+        if optimizer.averager.process_group is not None
+        else dist.group.WORLD
+    )
+    parameters = [
+        parameter
+        for group in base_optimizer.param_groups
+        for parameter in group["params"]
+    ]
+    if not parameters:
+        return
+
+    signature = []
+    step_values = []
+    tensors = {}
+    for parameter_index, parameter in enumerate(parameters):
+        state = base_optimizer.state.get(parameter, {})
+        entries = []
+        for key in sorted(state):
+            value = state[key]
+            if torch.is_tensor(value):
+                entries.append((key, tuple(value.shape), str(value.dtype)))
+            else:
+                entries.append((key, type(value).__name__))
+            if key == "step":
+                if not torch.is_tensor(value) or value.numel() != 1:
+                    raise ValueError("optimizer step state must be a scalar tensor")
+                step_values.append(int(value.item()))
+            elif key in reductions:
+                if not torch.is_tensor(value):
+                    raise TypeError(f"optimizer state {key!r} must be a tensor")
+                bucket_key = (reductions[key], value.device, value.dtype)
+                tensors.setdefault(bucket_key, []).append(value)
+        signature.append((parameter_index, tuple(entries)))
+
+    signature_hash = int.from_bytes(
+        hashlib.sha256(repr(signature).encode("utf-8")).digest()[:8], "big"
+    ) & ((1 << 62) - 1)
+    local_step_min = min(step_values, default=-1)
+    local_step_max = max(step_values, default=-1)
+    probe = torch.tensor(
+        [signature_hash, -signature_hash, local_step_max, -local_step_min],
+        dtype=torch.int64,
+        device=parameters[0].device,
+    )
+    dist.all_reduce(probe, op=dist.ReduceOp.MAX, group=process_group)
+    if int(probe[0]) != -int(probe[1]):
+        raise RuntimeError("optimizer state structure differs across ranks")
+    if int(probe[2]) != -int(probe[3]):
+        raise RuntimeError("optimizer step counters differ across ranks")
+
+    allowed_keys = set(reductions) | {"step"}
+    for _, entries in signature:
+        unknown = {entry[0] for entry in entries} - allowed_keys
+        if unknown:
+            raise ValueError(
+                f"unsupported state keys for {type(base_optimizer).__name__}: "
+                f"{sorted(unknown)}"
+            )
+
+    for (operation, _, _), values in tensors.items():
+        _reduce_optimizer_tensor_bucket(
+            values,
+            operation,
+            process_group,
+            optimizer.optimizer_state_bucket_bytes,
+        )
+
+
+class HydraPostLocalSGDOptimizer(PostLocalSGDOptimizer):
+    """Post-local-SGD optimizer with optional strict state synchronization."""
+
+    def __init__(
+        self,
+        optim,
+        averager,
+        optimizer_state_policy="local",
+        optimizer_state_bucket_bytes=25 * 1024 * 1024,
+    ):
+        super().__init__(optim=optim, averager=averager)
+        self.optimizer_state_policy = optimizer_state_policy
+        self.optimizer_state_bucket_bytes = optimizer_state_bucket_bytes
+
+    def step(self):
+        averaging_step = self.averager.step
+        super().step()
+        parameters_were_averaged = (
+            averaging_step >= self.averager.warmup_steps
+            and (averaging_step - self.averager.warmup_steps) % self.averager.period
+            == 0
+        )
+        if parameters_were_averaged:
+            _synchronize_optimizer_state(self)
+
+
 def configure_local_sgd(model, optimizer, config, *, use_deepspeed=False, verbosity=0):
     """Enable PyTorch post-local SGD for an ordinary DDP model.
 
     During ``warmup_steps``, DDP averages gradients globally on every backward
     pass. Afterwards, gradient all-reduce is disabled so each rank takes local
     optimizer steps, while ``PostLocalSGDOptimizer`` averages model parameters
-    globally every ``synchronization_period`` steps. Optimizer state (for
-    example Adam moments) remains rank-local by design.
+    globally every ``synchronization_period`` steps. Optimizer state remains
+    rank-local by default; the optional synchronized policy applies explicit
+    optimizer-specific reductions at the same synchronization points.
 
     The function is deliberately restricted to ordinary DDP. FSDP, DeepSpeed,
     model-parallel wrappers, SyncBatchNorm, and ZeroRedundancyOptimizer have
@@ -443,15 +614,15 @@ def configure_local_sgd(model, optimizer, config, *, use_deepspeed=False, verbos
     if neural_network.get("Architecture", {}).get("SyncBatchNorm", False):
         raise ValueError("Training.LocalSGD is not supported with SyncBatchNorm")
 
-    from torch.distributed.optim import (
-        PostLocalSGDOptimizer,
-        ZeroRedundancyOptimizer,
-    )
+    from torch.distributed.optim import ZeroRedundancyOptimizer
 
     if isinstance(optimizer, ZeroRedundancyOptimizer):
         raise ValueError(
             "Training.LocalSGD is not supported with ZeroRedundancyOptimizer"
         )
+    optimizer_state_policy = local_sgd["optimizer_state_policy"]
+    if optimizer_state_policy == "synchronize":
+        _optimizer_state_reductions(optimizer)
 
     from torch.distributed.algorithms.ddp_comm_hooks import post_localSGD_hook
     from torch.distributed.algorithms.model_averaging.averagers import (
@@ -473,21 +644,24 @@ def configure_local_sgd(model, optimizer, config, *, use_deepspeed=False, verbos
         warmup_steps=warmup_steps,
         process_group=None,
     )
-    optimizer = PostLocalSGDOptimizer(optim=optimizer, averager=averager)
+    optimizer = HydraPostLocalSGDOptimizer(
+        optim=optimizer,
+        averager=averager,
+        optimizer_state_policy=optimizer_state_policy,
+        optimizer_state_bucket_bytes=local_sgd["optimizer_state_bucket_bytes"],
+    )
     print_distributed(
         verbosity,
         "Post-local SGD enabled: "
         f"warmup_steps={warmup_steps}, "
         f"synchronization_period={synchronization_period}, "
-        "optimizer_state=rank-local",
+        f"optimizer_state_policy={optimizer_state_policy}",
     )
     return model, optimizer
 
 
 def synchronize_local_sgd_parameters(optimizer):
     """Average replicas at an epoch boundary when an average is still pending."""
-    from torch.distributed.optim import PostLocalSGDOptimizer
-
     if not isinstance(optimizer, PostLocalSGDOptimizer):
         return False
 
@@ -513,6 +687,8 @@ def synchronize_local_sgd_parameters(optimizer):
         else dist.group.WORLD
     )
     utils.average_parameters_or_parameter_groups(optimizer.param_groups, process_group)
+    if isinstance(optimizer, HydraPostLocalSGDOptimizer):
+        _synchronize_optimizer_state(optimizer)
     optimizer._hydragnn_last_forced_sync_step = averager.step
     return True
 

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -349,6 +349,8 @@ def validate_local_sgd_config(training):
 
     local_sgd.setdefault("warmup_steps", 0)
     local_sgd.setdefault("synchronization_period", 1)
+    local_sgd.setdefault("optimizer_state_policy", "local")
+    local_sgd.setdefault("optimizer_state_bucket_bytes", 25 * 1024 * 1024)
     if (
         isinstance(local_sgd["warmup_steps"], bool)
         or not isinstance(local_sgd["warmup_steps"], int)
@@ -362,6 +364,20 @@ def validate_local_sgd_config(training):
     ):
         raise ValueError(
             "Training.LocalSGD.synchronization_period must be an integer >= 1"
+        )
+    if local_sgd["optimizer_state_policy"] not in {"local", "synchronize"}:
+        raise ValueError(
+            "Training.LocalSGD.optimizer_state_policy must be 'local' or "
+            "'synchronize'"
+        )
+    bucket_bytes = local_sgd["optimizer_state_bucket_bytes"]
+    if (
+        isinstance(bucket_bytes, bool)
+        or not isinstance(bucket_bytes, int)
+        or bucket_bytes < 1
+    ):
+        raise ValueError(
+            "Training.LocalSGD.optimizer_state_bucket_bytes must be an integer >= 1"
         )
 
 

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -70,6 +70,8 @@ def update_config(config, train_loader, val_loader, test_loader):
         if mode == "node_budget" and "max_nodes" not in batching:
             raise ValueError("node_budget batching requires max_nodes")
 
+    validate_local_sgd_config(config["NeuralNetwork"]["Training"])
+
     # update output_heads with latest config rules
     config["NeuralNetwork"]["Architecture"]["output_heads"] = update_multibranch_heads(
         config["NeuralNetwork"]["Architecture"]["output_heads"]
@@ -331,6 +333,35 @@ def validate_equivariant_transformer_config(config):
         raise ValueError(
             "MACE with EquivariantTransformer requires at least two convolution "
             "layers because MACE's final layer contains scalar irreps only"
+        )
+
+
+def validate_local_sgd_config(training):
+    """Validate and fill defaults for optional post-local-SGD training."""
+    local_sgd = training.setdefault("LocalSGD", {"enabled": False})
+    if not isinstance(local_sgd, dict):
+        raise TypeError("Training.LocalSGD must be a JSON object")
+    local_sgd.setdefault("enabled", False)
+    if not isinstance(local_sgd["enabled"], bool):
+        raise TypeError("Training.LocalSGD.enabled must be a boolean")
+    if not local_sgd["enabled"]:
+        return
+
+    local_sgd.setdefault("warmup_steps", 0)
+    local_sgd.setdefault("synchronization_period", 1)
+    if (
+        isinstance(local_sgd["warmup_steps"], bool)
+        or not isinstance(local_sgd["warmup_steps"], int)
+        or local_sgd["warmup_steps"] < 0
+    ):
+        raise ValueError("Training.LocalSGD.warmup_steps must be an integer >= 0")
+    if (
+        isinstance(local_sgd["synchronization_period"], bool)
+        or not isinstance(local_sgd["synchronization_period"], int)
+        or local_sgd["synchronization_period"] < 1
+    ):
+        raise ValueError(
+            "Training.LocalSGD.synchronization_period must be an integer >= 1"
         )
 
 

--- a/tests/_training_workflow.py
+++ b/tests/_training_workflow.py
@@ -19,6 +19,7 @@ from torch.optim.lr_scheduler import ReduceLROnPlateau
 from hydragnn.utils.distributed import (
     setup_ddp,
     get_distributed_model,
+    configure_local_sgd,
 )
 from hydragnn.utils.distributed import print_peak_memory
 from hydragnn.utils.model import (
@@ -93,6 +94,7 @@ def train_and_checkpoint(
         optimizer = select_optimizer(
             model, config["NeuralNetwork"]["Training"]["Optimizer"]
         )
+        model, optimizer = configure_local_sgd(model, optimizer, config)
 
         scheduler = ReduceLROnPlateau(
             optimizer, mode="min", factor=0.5, patience=5, min_lr=0.00001

--- a/tests/test_local_sgd.py
+++ b/tests/test_local_sgd.py
@@ -148,8 +148,9 @@ def _synchronized_optimizer_state_worker(rank, world_size, rendezvous_file):
                     warmup_steps=0,
                     synchronization_period=1,
                     optimizer_state_policy="synchronize",
-                    # Exercise multiple bounded buckets even for this tiny model.
-                    optimizer_state_bucket_bytes=4,
+                    # A sub-element request is clamped to one element and still
+                    # exercises multiple bounded buckets for this tiny model.
+                    optimizer_state_bucket_bytes=1,
                 ),
             )
 

--- a/tests/test_local_sgd.py
+++ b/tests/test_local_sgd.py
@@ -1,0 +1,141 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+import os
+import tempfile
+
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+from hydragnn.utils.distributed import (
+    configure_local_sgd,
+    synchronize_local_sgd_parameters,
+)
+from hydragnn.utils.input_config_parsing.config_utils import (
+    validate_local_sgd_config,
+)
+
+
+def _config(warmup_steps=1, synchronization_period=2):
+    return {
+        "NeuralNetwork": {
+            "Architecture": {"SyncBatchNorm": False},
+            "Training": {
+                "LocalSGD": {
+                    "enabled": True,
+                    "warmup_steps": warmup_steps,
+                    "synchronization_period": synchronization_period,
+                }
+            },
+        }
+    }
+
+
+def _all_parameters_match(model):
+    value = next(model.parameters()).detach().clone()
+    gathered = [torch.empty_like(value) for _ in range(dist.get_world_size())]
+    dist.all_gather(gathered, value)
+    return all(torch.equal(gathered[0], other) for other in gathered[1:])
+
+
+def _local_sgd_worker(rank, world_size, rendezvous_file):
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{rendezvous_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        torch.manual_seed(7)
+        model = DDP(torch.nn.Linear(1, 1, bias=False))
+        base_optimizer = torch.optim.AdamW(model.parameters(), lr=0.1)
+        model, optimizer = configure_local_sgd(model, base_optimizer, _config())
+
+        synchronization = []
+        for _ in range(5):
+            optimizer.zero_grad()
+            inputs = torch.ones(1, 1)
+            targets = torch.tensor([[float(2 * rank)]])
+            loss = torch.nn.functional.mse_loss(model(inputs), targets)
+            loss.backward()
+            optimizer.step()
+            synchronization.append(_all_parameters_match(model))
+
+        # Step 0 uses global DDP gradient averaging. Step 1 is the first local
+        # update and also the first periodic parameter average. Step 2 remains
+        # local, step 3 performs the next parameter average, and step 4 is local.
+        assert synchronization == [True, True, False, True, False]
+        assert synchronize_local_sgd_parameters(optimizer)
+        assert _all_parameters_match(model)
+        assert not synchronize_local_sgd_parameters(optimizer)
+        assert optimizer.state_dict()["step"] == 5
+
+        parameter = next(model.parameters())
+        exp_avg = optimizer.state[parameter]["exp_avg"].detach().clone()
+        gathered_state = [torch.empty_like(exp_avg) for _ in range(world_size)]
+        dist.all_gather(gathered_state, exp_avg)
+        assert not torch.equal(gathered_state[0], gathered_state[1])
+    finally:
+        dist.destroy_process_group()
+
+
+def test_local_sgd_reduces_gradient_sync_and_periodically_averages_parameters():
+    with tempfile.NamedTemporaryFile(delete=False) as rendezvous:
+        rendezvous_file = rendezvous.name
+    try:
+        mp.start_processes(
+            _local_sgd_worker,
+            args=(2, rendezvous_file),
+            nprocs=2,
+            join=True,
+            start_method="spawn",
+        )
+    finally:
+        if os.path.exists(rendezvous_file):
+            os.unlink(rendezvous_file)
+
+
+def test_local_sgd_defaults_preserve_synchronous_training():
+    training = {}
+    validate_local_sgd_config(training)
+    assert training["LocalSGD"] == {"enabled": False}
+
+
+@pytest.mark.parametrize(
+    "local_sgd,error,message",
+    [
+        (True, TypeError, "JSON object"),
+        ({"enabled": 1}, TypeError, "boolean"),
+        (
+            {"enabled": True, "warmup_steps": -1},
+            ValueError,
+            "warmup_steps",
+        ),
+        (
+            {"enabled": True, "synchronization_period": 0},
+            ValueError,
+            "synchronization_period",
+        ),
+    ],
+)
+def test_local_sgd_rejects_invalid_configuration(local_sgd, error, message):
+    with pytest.raises(error, match=message):
+        validate_local_sgd_config({"LocalSGD": local_sgd})
+
+
+def test_local_sgd_rejects_deepspeed_before_distributed_setup():
+    model = torch.nn.Linear(1, 1)
+    optimizer = torch.optim.AdamW(model.parameters())
+    with pytest.raises(ValueError, match="DeepSpeed"):
+        configure_local_sgd(model, optimizer, _config(), use_deepspeed=True)

--- a/tests/test_local_sgd.py
+++ b/tests/test_local_sgd.py
@@ -63,7 +63,7 @@ def _local_sgd_worker(rank, world_size, rendezvous_file):
         model, optimizer = configure_local_sgd(model, base_optimizer, _config())
 
         synchronization = []
-        for _ in range(5):
+        for step in range(5):
             optimizer.zero_grad()
             inputs = torch.ones(1, 1)
             targets = torch.tensor([[float(2 * rank)]])
@@ -71,6 +71,10 @@ def _local_sgd_worker(rank, world_size, rendezvous_file):
             loss.backward()
             optimizer.step()
             synchronization.append(_all_parameters_match(model))
+            if step == 0:
+                # The first step is still in globally synchronized DDP warm-up;
+                # epoch-boundary handling must not add a parameter collective.
+                assert not synchronize_local_sgd_parameters(optimizer)
 
         # Step 0 uses global DDP gradient averaging. Step 1 is the first local
         # update and also the first periodic parameter average. Step 2 remains

--- a/tests/test_local_sgd.py
+++ b/tests/test_local_sgd.py
@@ -27,7 +27,12 @@ from hydragnn.utils.input_config_parsing.config_utils import (
 )
 
 
-def _config(warmup_steps=1, synchronization_period=2):
+def _config(
+    warmup_steps=1,
+    synchronization_period=2,
+    optimizer_state_policy="local",
+    optimizer_state_bucket_bytes=25 * 1024 * 1024,
+):
     return {
         "NeuralNetwork": {
             "Architecture": {"SyncBatchNorm": False},
@@ -36,6 +41,8 @@ def _config(warmup_steps=1, synchronization_period=2):
                     "enabled": True,
                     "warmup_steps": warmup_steps,
                     "synchronization_period": synchronization_period,
+                    "optimizer_state_policy": optimizer_state_policy,
+                    "optimizer_state_bucket_bytes": optimizer_state_bucket_bytes,
                 }
             },
         }
@@ -94,12 +101,152 @@ def _local_sgd_worker(rank, world_size, rendezvous_file):
         dist.destroy_process_group()
 
 
+def _synchronized_optimizer_state_worker(rank, world_size, rendezvous_file):
+    dist.init_process_group(
+        "gloo",
+        init_method=f"file://{rendezvous_file}",
+        rank=rank,
+        world_size=world_size,
+    )
+    try:
+        optimizers = (
+            (torch.optim.SGD, {"momentum": 0.9}),
+            (torch.optim.Adam, {}),
+            (torch.optim.AdamW, {}),
+            (torch.optim.Adamax, {}),
+            (torch.optim.Adagrad, {}),
+            (torch.optim.Adadelta, {}),
+            (torch.optim.RMSprop, {"momentum": 0.9, "centered": True}),
+        )
+        reductions = {
+            torch.optim.SGD: {"momentum_buffer": "mean"},
+            torch.optim.Adam: {"exp_avg": "mean", "exp_avg_sq": "mean"},
+            torch.optim.AdamW: {"exp_avg": "mean", "exp_avg_sq": "mean"},
+            torch.optim.Adamax: {"exp_avg": "mean", "exp_inf": "max"},
+            torch.optim.Adagrad: {"sum": "mean"},
+            torch.optim.Adadelta: {"square_avg": "mean", "acc_delta": "mean"},
+            torch.optim.RMSprop: {
+                "square_avg": "mean",
+                "momentum_buffer": "mean",
+                "grad_avg": "mean",
+            },
+        }
+        for optimizer_type, kwargs in optimizers:
+            torch.manual_seed(11)
+            model = DDP(torch.nn.Linear(2, 1, bias=False))
+            base_optimizer = optimizer_type(model.parameters(), lr=0.1, **kwargs)
+            reference_parameter = torch.nn.Parameter(
+                next(model.parameters()).detach().clone()
+            )
+            reference_optimizer = optimizer_type(
+                [reference_parameter], lr=0.1, **kwargs
+            )
+            model, optimizer = configure_local_sgd(
+                model,
+                base_optimizer,
+                _config(
+                    warmup_steps=0,
+                    synchronization_period=1,
+                    optimizer_state_policy="synchronize",
+                    # Exercise multiple bounded buckets even for this tiny model.
+                    optimizer_state_bucket_bytes=4,
+                ),
+            )
+
+            optimizer.zero_grad()
+            inputs = torch.tensor([[1.0, 2.0]])
+            targets = torch.tensor([[float(3 * rank)]])
+            reference_optimizer.zero_grad()
+            torch.nn.functional.mse_loss(
+                inputs @ reference_parameter.t(), targets
+            ).backward()
+            reference_optimizer.step()
+            torch.nn.functional.mse_loss(model(inputs), targets).backward()
+            optimizer.step()
+
+            assert _all_parameters_match(model)
+            parameter = next(model.parameters())
+            for key, value in optimizer.state[parameter].items():
+                if not torch.is_tensor(value):
+                    continue
+                gathered = [torch.empty_like(value) for _ in range(world_size)]
+                dist.all_gather(gathered, value)
+                assert all(torch.equal(gathered[0], other) for other in gathered[1:]), (
+                    optimizer_type.__name__,
+                    key,
+                )
+                reference_value = reference_optimizer.state[reference_parameter][key]
+                references = [
+                    torch.empty_like(reference_value) for _ in range(world_size)
+                ]
+                dist.all_gather(references, reference_value)
+                if key == "step":
+                    expected = references[0]
+                elif reductions[optimizer_type][key] == "mean":
+                    expected = torch.stack(references).mean(dim=0)
+                else:
+                    expected = torch.stack(references).max(dim=0).values
+                torch.testing.assert_close(value, expected)
+
+        model = DDP(torch.nn.Linear(1, 1))
+        unsupported = torch.optim.LBFGS(model.parameters())
+        with pytest.raises(ValueError, match="LBFGS"):
+            configure_local_sgd(
+                model,
+                unsupported,
+                _config(optimizer_state_policy="synchronize"),
+            )
+
+        model = DDP(torch.nn.Linear(1, 1, bias=False))
+        base_optimizer = torch.optim.Adam(model.parameters(), lr=0.1)
+        parameter = next(model.parameters())
+        base_optimizer.state[parameter].update(
+            {
+                "step": torch.tensor(0.0),
+                "exp_avg": torch.zeros_like(parameter),
+                "exp_avg_sq": torch.zeros_like(parameter),
+                "unknown_history": torch.zeros_like(parameter),
+            }
+        )
+        model, optimizer = configure_local_sgd(
+            model,
+            base_optimizer,
+            _config(
+                warmup_steps=0,
+                synchronization_period=1,
+                optimizer_state_policy="synchronize",
+            ),
+        )
+        optimizer.zero_grad()
+        model(torch.ones(1, 1)).sum().backward()
+        with pytest.raises(ValueError, match="unknown_history"):
+            optimizer.step()
+    finally:
+        dist.destroy_process_group()
+
+
 def test_local_sgd_reduces_gradient_sync_and_periodically_averages_parameters():
     with tempfile.NamedTemporaryFile(delete=False) as rendezvous:
         rendezvous_file = rendezvous.name
     try:
         mp.start_processes(
             _local_sgd_worker,
+            args=(2, rendezvous_file),
+            nprocs=2,
+            join=True,
+            start_method="spawn",
+        )
+    finally:
+        if os.path.exists(rendezvous_file):
+            os.unlink(rendezvous_file)
+
+
+def test_local_sgd_synchronizes_supported_optimizer_state_policies():
+    with tempfile.NamedTemporaryFile(delete=False) as rendezvous:
+        rendezvous_file = rendezvous.name
+    try:
+        mp.start_processes(
+            _synchronized_optimizer_state_worker,
             args=(2, rendezvous_file),
             nprocs=2,
             join=True,
@@ -130,6 +277,16 @@ def test_local_sgd_defaults_preserve_synchronous_training():
             {"enabled": True, "synchronization_period": 0},
             ValueError,
             "synchronization_period",
+        ),
+        (
+            {"enabled": True, "optimizer_state_policy": "copy_rank_zero"},
+            ValueError,
+            "optimizer_state_policy",
+        ),
+        (
+            {"enabled": True, "optimizer_state_bucket_bytes": 0},
+            ValueError,
+            "optimizer_state_bucket_bytes",
         ),
     ],
 )


### PR DESCRIPTION
## Summary

- add an opt-in `Training.LocalSGD` configuration using native PyTorch post-local SGD
- retain globally synchronized DDP during warm-up, then disable gradient all-reduce between periodic global model-parameter averages
- optionally synchronize optimizer history with explicit optimizer-specific policies
- conditionally average parameters and enabled optimizer state at epoch boundaries so validation, checkpoints, and returned models are globally consistent
- reject unsupported FSDP, DeepSpeed, SyncBatchNorm, model/task-parallel, and ZeroRedundancyOptimizer combinations
- pass configuration through the distributed wrapper in maintained examples
- document algorithm semantics, communication tradeoffs, checkpoint behavior, and every JSON parameter

## Configuration

```json
"LocalSGD": {
  "enabled": true,
  "warmup_steps": 100,
  "synchronization_period": 4,
  "optimizer_state_policy": "local",
  "optimizer_state_bucket_bytes": 26214400
}
```

Both intervals count optimizer steps. The default remains disabled and preserves conventional synchronous DDP. `optimizer_state_policy` defaults to `local`, matching native PyTorch. `synchronize` applies strict optimizer-aware state reductions at the same points as model averaging.

## Optimizer-state policies

- SGD: mean momentum buffer
- Adam/AdamW: mean first and second moments; require equal step
- Adamax: mean first moment, elementwise-max infinity accumulator; require equal step
- Adagrad: mean accumulated squared gradients; require equal step
- Adadelta: mean running gradient/update statistics; require equal step
- RMSprop: mean running square, momentum, and centered-gradient statistics; require equal step
- unknown optimizers, FusedLAMB state, and unknown state keys: explicit error

Compatible state tensors are reduced in bounded buckets grouped by operation, device, and dtype. Rank state layouts and step counters are collectively checked before tensor reductions.

## Important semantics

This changes the optimization algorithm; it is not gradient accumulation. After warm-up, replicas take independent local optimizer steps. Parameter-only mode communicates less but leaves optimizer histories local. Synchronized-state mode makes histories identical at averaging points while adding substantial communication, particularly for Adam-like optimizers. Validation/test and preprocessing collectives are unaffected.

## Tests

- real two-rank CPU regression verifies synchronized warm-up, local replica divergence, periodic parameter averaging, rank-local AdamW state, and epoch-boundary synchronization
- two-rank numerical verification of the exact mean/max state reductions for all seven supported standard optimizers
- unsupported optimizer and unknown state-key failure coverage
- configuration default and invalid-value coverage
- checkpoint/load regression
- Python compilation and Black checks for updated examples and modules

Validated locally: `13 passed` across Local-SGD, configuration, and checkpoint/load tests.