### PR TITLE
Use named output schema for OGB plot labels

### DIFF
--- a/examples/ogb/train_gap.py
+++ b/examples/ogb/train_gap.py
@@ -298,8 +298,6 @@ if __name__ == "__main__":
     parser.set_defaults(format="adios")
     args = parser.parse_args()
 
-    graph_feature_names = ["GAP"]
-    graph_feature_dim = [1]
     dirpwd = os.path.dirname(os.path.abspath(__file__))
     datadir = os.path.join(dirpwd, "dataset/")
     ##################################################################################################################
@@ -547,9 +545,7 @@ if __name__ == "__main__":
             ihead = 0
             head_true = np.asarray(true_values[ihead].cpu()).squeeze()
             head_pred = np.asarray(predicted_values[ihead].cpu()).squeeze()
-            ifeat = ihead
-            outtype = var_config["outputs"][ihead]["level"]
-            varname = graph_feature_names[ifeat]
+            varname = var_config["outputs"][ihead]["name"]
 
             ax = axs[isub]
             error_mae = np.mean(np.abs(head_pred - head_true))


### PR DESCRIPTION
## Summary

- derive the OGB inference plot label from the configured named output schema
- remove the redundant hard-coded graph-feature metadata

## Rationale

The named-data contract makes `Variables.outputs` authoritative. Keeping a separate label list can silently mislabel plots when output ordering or names change.

## Validation

- `python -m black --check examples/ogb/train_gap.py`
- `python -m py_compile examples/ogb/train_gap.py`

## Not changed

- The existing `rdkit==2026.3.5` pin is valid and available from PyPI.
- Broader configuration-variable renaming is unrelated cleanup and is intentionally excluded.
