### PR TITLE
Sanitize schema-derived plot filenames

### DIFF
--- a/examples/csce/train_gap.py
+++ b/examples/csce/train_gap.py
@@ -39,6 +39,7 @@ from hydragnn.utils.descriptors_and_embeddings.smiles_utils import (
     generate_graphdata_from_smilestr,
 )
 from hydragnn.utils.input_config_parsing.variable_schema import parse_variable_schema
+from hydragnn.utils.input_config_parsing import sanitize_filename_component
 from hydragnn.preprocess.graph_samples_checks_and_updates import gather_deg
 from hydragnn.utils.distributed import nsplit
 import hydragnn.utils.profiling_and_tracing.tracer as tr
@@ -482,7 +483,8 @@ if __name__ == "__main__":
                 "MAE: {:.2f}".format(error_mae),
             )
         if rank == 0:
-            fig.savefig(os.path.join("logs", log_name, varname + "_all.png"))
+            filename = sanitize_filename_component(varname) + "_all.png"
+            fig.savefig(os.path.join("logs", log_name, filename))
         plt.close()
 
     if tr.has("GPTLTracer"):

--- a/examples/ogb/train_gap.py
+++ b/examples/ogb/train_gap.py
@@ -34,7 +34,10 @@ from hydragnn.utils.model import print_model
 from hydragnn.utils.descriptors_and_embeddings.smiles_utils import (
     generate_graphdata_from_smilestr,
 )
-from hydragnn.utils.input_config_parsing.config_utils import parse_deepspeed_config
+from hydragnn.utils.input_config_parsing.config_utils import (
+    parse_deepspeed_config,
+    sanitize_filename_component,
+)
 from hydragnn.utils.distributed import get_deepspeed_init_args
 from hydragnn.utils.distributed import nsplit
 
@@ -570,7 +573,8 @@ if __name__ == "__main__":
                 "MAE: {:.2f}".format(error_mae),
             )
         if rank == 0:
-            fig.savefig("./logs/" + log_name + "/" + varname + "_all.png")
+            filename = sanitize_filename_component(varname) + "_all.png"
+            fig.savefig(os.path.join("logs", log_name, filename))
         plt.close()
 
     if args.shmem:

--- a/examples/qm7x/inference.py
+++ b/examples/qm7x/inference.py
@@ -23,7 +23,10 @@ from hydragnn.utils.profiling_and_tracing.time_utils import Timer
 from hydragnn.utils.distributed import get_device
 from hydragnn.utils.model import load_existing_model
 from hydragnn.utils.datasets import SimplePickleDataset
-from hydragnn.utils.input_config_parsing import get_log_name_config
+from hydragnn.utils.input_config_parsing import (
+    get_log_name_config,
+    sanitize_filename_component,
+)
 from hydragnn.models.create import create_model_config
 
 from scipy.interpolate import griddata
@@ -174,7 +177,8 @@ if __name__ == "__main__":
         plt.title(f"{output_name}")
         plt.draw()
         plt.tight_layout()
-        plt.savefig(f"./{output_name}_Scatterplot" + ".png", dpi=400)
+        filename = sanitize_filename_component(output_name) + "_Scatterplot.png"
+        plt.savefig(filename, dpi=400)
 
         print(f"Test MAE {output_name}: ", test_MAE)
 

--- a/hydragnn/postprocess/visualizer.py
+++ b/hydragnn/postprocess/visualizer.py
@@ -17,6 +17,7 @@ from itertools import chain
 import time, pickle
 import numpy as np
 from math import sqrt, floor, ceil
+from hydragnn.utils.input_config_parsing import sanitize_filename_component
 
 plt.rcParams.update({"font.size": 18})
 
@@ -267,9 +268,10 @@ class Visualizer:
             )
 
         if save_plot:
+            filename = sanitize_filename_component(varname)
             fig.savefig(
                 f"./logs/{self.model_with_config_name}/"
-                + varname
+                + filename
                 + "_scatter_condm_err.png"
             )
             plt.close()
@@ -369,16 +371,19 @@ class Visualizer:
                 left=0.05, bottom=0.05, right=0.98, top=0.95, wspace=0.1, hspace=0.25
             )
         if save_plot:
+            filename = sanitize_filename_component(varname)
             if iepoch:
                 fig.savefig(
                     f"./logs/{self.model_with_config_name}/"
-                    + varname
+                    + filename
                     + "_"
                     + str(iepoch).zfill(4)
                     + ".png"
                 )
             else:
-                fig.savefig(f"./logs/{self.model_with_config_name}/" + varname + ".png")
+                fig.savefig(
+                    f"./logs/{self.model_with_config_name}/" + filename + ".png"
+                )
             plt.close()
         return
 
@@ -446,10 +451,11 @@ class Visualizer:
                 left=0.075, bottom=0.1, right=0.98, top=0.9, wspace=0.2, hspace=0.35
             )
             if save_plot:
+                filename = sanitize_filename_component(varname)
                 if iepoch:
                     fig.savefig(
                         f"./logs/{self.model_with_config_name}/"
-                        + varname
+                        + filename
                         + "_error_hist1d_"
                         + str(iepoch).zfill(4)
                         + ".png"
@@ -457,7 +463,7 @@ class Visualizer:
                 else:
                     fig.savefig(
                         f"./logs/{self.model_with_config_name}/"
-                        + varname
+                        + filename
                         + "_error_hist1d.png"
                     )
                 plt.close()
@@ -501,16 +507,19 @@ class Visualizer:
         )
 
         if save_plot:
+            filename = sanitize_filename_component(varname)
             if iepoch:
                 fig.savefig(
                     f"./logs/{self.model_with_config_name}/"
-                    + varname
+                    + filename
                     + "_"
                     + str(iepoch).zfill(4)
                     + ".png"
                 )
             else:
-                fig.savefig(f"./logs/{self.model_with_config_name}/" + varname + ".png")
+                fig.savefig(
+                    f"./logs/{self.model_with_config_name}/" + filename + ".png"
+                )
             plt.close()
 
     # FIXME: this function is currently unused and is explicitly written for 3d vectors.
@@ -597,16 +606,19 @@ class Visualizer:
         )
 
         if save_plot:
+            filename = sanitize_filename_component(varname)
             if iepoch:
                 fig.savefig(
                     f"./logs/{self.model_with_config_name}/"
-                    + varname
+                    + filename
                     + "_"
                     + str(iepoch).zfill(4)
                     + ".png"
                 )
             else:
-                fig.savefig(f"./logs/{self.model_with_config_name}/" + varname + ".png")
+                fig.savefig(
+                    f"./logs/{self.model_with_config_name}/" + filename + ".png"
+                )
             plt.close()
 
     def add_identity(self, axes, *line_args, **line_kwargs):

--- a/hydragnn/utils/input_config_parsing/__init__.py
+++ b/hydragnn/utils/input_config_parsing/__init__.py
@@ -15,6 +15,7 @@ from .config_utils import (
     get_log_name_config,
     save_config,
     parse_deepspeed_config,
+    sanitize_filename_component,
 )
 from .variable_schema import (
     VariableSchema,

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -28,8 +28,13 @@ from .variable_schema import get_variable_schema, schema_dimensions
 _UNSAFE_LOG_COMPONENT = re.compile(r"[^A-Za-z0-9._-]+")
 
 
-def _sanitize_log_component(value, max_length=48):
-    """Return a bounded, filesystem-safe representation of a log component."""
+def sanitize_filename_component(value, max_length=48):
+    """Return a bounded, filesystem-safe representation of one path component.
+
+    The returned value never contains path separators or leading/trailing dots,
+    so configuration-derived labels can safely be used as filenames without
+    changing the original label shown to users in plots and logs.
+    """
     original = str(value)
     sanitized = _UNSAFE_LOG_COMPONENT.sub("-", original).strip("._-")
     if not sanitized:
@@ -466,7 +471,7 @@ def update_config_edge_dim(config):
 
 def get_log_name_config(config):
     input_names = "-".join(
-        _sanitize_log_component(spec.name)
+        sanitize_filename_component(spec.name)
         for spec in get_variable_schema(config).inputs
     )
     return (

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,7 +14,10 @@ import os, json
 import pytest
 
 import hydragnn
-from hydragnn.utils.input_config_parsing import get_log_name_config
+from hydragnn.utils.input_config_parsing import (
+    get_log_name_config,
+    sanitize_filename_component,
+)
 
 
 def test_input_config_parsing_is_exposed_through_utils():
@@ -63,3 +66,15 @@ def test_log_name_sanitizes_named_variables():
     assert ".." not in variable_part
     assert len(variable_part.split("-", 2)[1]) <= 48
     assert not variable_part.endswith("-")
+
+
+def test_filename_component_sanitizes_configured_variable_name():
+    original = "../atomic species\\unsafe"
+    sanitized = sanitize_filename_component(original)
+
+    assert "/" not in sanitized
+    assert "\\" not in sanitized
+    assert ".." not in sanitized
+    assert sanitized != original
+    assert len(sanitized) <= 48
+    assert sanitized == sanitize_filename_component(original)


### PR DESCRIPTION
## Summary

- expose a shared `sanitize_filename_component` utility
- preserve original schema names in plot titles and logs
- sanitize schema-derived filenames in the core visualizer and the OGB, CSCE, and QM7-X examples
- add regression coverage for separators, traversal components, determinism, and length bounds

## Rationale

Named output variables are user-configurable and intentionally retain domain-specific labels. Those labels must not be inserted directly into filesystem paths because separators or traversal components could write plots outside the intended directory. Sanitizing only the filename component preserves readable plot labels while making output paths safe and portable.

## Validation

- `python -m black --check .`
- `python -m py_compile hydragnn/utils/input_config_parsing/config_utils.py hydragnn/postprocess/visualizer.py examples/ogb/train_gap.py examples/csce/train_gap.py examples/qm7x/inference.py`
- `python -m pytest -q tests/test_config.py` (`4 passed`)
