### PR TITLE
Upgrade NumPy and PyTorch requirements

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel meson-python ninja cython
-          python -m pip install numpy==2.2.6
+          python -m pip install numpy==2.4.6
           # Install HydraGNN's pinned PyTorch before fairchem-core (pulled in
           # by requirements-dev.txt) so dependency resolution cannot select a
           # different torch build for the native parity tests.
@@ -67,7 +67,7 @@ jobs:
           # pyg-lib is not published on PyPI. Build the 0.8.0 release from its
           # pinned commit so CI does not depend on the data.pyg.org wheel host.
           python -m pip install --no-build-isolation -v "pyg_lib @ git+https://github.com/pyg-team/pyg-lib.git@26a2d1a06a4714da9bb804c19049afb4796971d7"
-          python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links https://data.pyg.org/whl/torch-2.13.0+cpu.html
+          python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links https://data.pyg.org/whl/torch-2.14.0+cpu.html
           python -m pip install --upgrade --no-build-isolation -v -r requirements-deepspeed.txt || echo "DeepSpeed installation failed, continuing without it"
       - name: Show installed packages
         run: |

--- a/requirements-base.txt
+++ b/requirements-base.txt
@@ -9,7 +9,7 @@ psutil==7.1.0
 sympy==1.14.0
 matscipy
 scikit-learn==1.7.2
-numpy==2.2.6
+numpy==2.4.6
 scipy==1.17.1
 mpi4py==4.1.1
 vesin==0.4.2

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,5 +1,5 @@
-torch==2.13.0
-torchvision==0.28.0
+torch==2.14.0
+torchvision==0.29.0
 torchaudio==2.11.0
 e3nn==0.5.1
 torch-ema==0.3

--- a/scripts/hpc/alcf/aurora/installation/install.sh
+++ b/scripts/hpc/alcf/aurora/installation/install.sh
@@ -145,14 +145,14 @@ PY
 echo "VENV_SITEPKG = $VENV_SITEPKG"
 
 # ============================================================
-# pip helpers + numpy pin (force venv numpy=1.26.4)
+# pip helpers + NumPy pin (force venv NumPy 2.4.6)
 # ============================================================
 banner "pip bootstrap"
 python -m pip install -U pip setuptools wheel
 
 CONSTRAINTS_FILE="${INSTALL_ROOT}/pip-constraints.txt"
 cat > "$CONSTRAINTS_FILE" <<'EOF'
-numpy==1.26.4
+numpy==2.4.6
 EOF
 export PIP_CONSTRAINT="$CONSTRAINTS_FILE"
 echo "PIP_CONSTRAINT = $PIP_CONSTRAINT"
@@ -243,8 +243,8 @@ pip_retry() {
   return 1
 }
 
-banner "Pin NumPy to 1.26.4 inside venv (shadow system-site numpy)"
-pip_retry "numpy==1.26.4"
+banner "Pin NumPy to 2.4.6 inside venv (shadow system-site NumPy)"
+pip_retry "numpy==2.4.6"
 python - <<'PY'
 import numpy as np
 print("numpy.__version__ =", np.__version__)
@@ -491,9 +491,9 @@ pip_retry tensorboard scikit-learn pytest
 pip_retry ase h5py lmdb
 
 # Keep numpy pinned and avoid it being bumped by scientific packages
-pip_retry "numpy==1.26.4"
+pip_retry "numpy==2.4.6"
 
-# Avoid numpy>=2 bump pressure from mendeleev in this environment
+# Keep NumPy aligned with HydraGNN requirements after installing mendeleev
 pip_retry "mendeleev<1.1.0" || true
 
 pip_retry rdkit jarvis-tools pymatgen || true
@@ -504,8 +504,8 @@ pip_retry vesin
 pip_retry Cython
 pip_retry setuptools wheel
 
-banner "Re-check NumPy pin (must be 1.26.4 in venv)"
-pip_retry "numpy==1.26.4"
+banner "Re-check NumPy pin (must be 2.4.6 in venv)"
+pip_retry "numpy==2.4.6"
 python - <<'PY'
 import numpy as np
 print("numpy.__version__ =", np.__version__)
@@ -572,7 +572,7 @@ cat <<EOF
 Base install:        $INSTALL_ROOT
 Venv (system-site):  $VENV_PATH
 Venv site-packages:  $VENV_SITEPKG
-Constraints:         $CONSTRAINTS_FILE (numpy==1.26.4)
+Constraints:         $CONSTRAINTS_FILE (numpy==2.4.6)
 
 ADIOS2:
   - source:   $ADIOS2_SRC @ $ADIOS2_VERSION

--- a/scripts/hpc/nersc/perlmutter/installation/install.sh
+++ b/scripts/hpc/nersc/perlmutter/installation/install.sh
@@ -131,7 +131,7 @@ pip_retry() {
   return 1
 }
 
-assert_numpy_1264() {
+assert_numpy_pinned() {
   python - <<'PY'
 import numpy as np
 expected="2.4.6"
@@ -144,7 +144,7 @@ pip_retry --disable-pip-version-check -U pip setuptools wheel
 
 subbanner "Install and pin numpy==2.4.6"
 pip_retry "numpy==2.4.6"
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # Core scientific Python deps
@@ -198,7 +198,7 @@ PYTORCH_INDEX_URL="https://download.pytorch.org/whl/${TORCH_CUDA_TAG}"
 
 subbanner "Install PyTorch from ${PYTORCH_INDEX_URL}"
 pip_retry --index-url "${PYTORCH_INDEX_URL}" torch torchvision
-assert_numpy_1264
+assert_numpy_pinned
 
 python - <<'PY'
 import torch
@@ -247,11 +247,11 @@ fi
 
 subbanner "Install torch-geometric (pure python wrapper package)"
 pip_retry torch-geometric
-assert_numpy_1264
+assert_numpy_pinned
 
 subbanner "Install e3nn and openequivariance"
 pip_retry e3nn openequivariance --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 subbanner "PyG import sanity check"
 python - <<'PY'
@@ -349,7 +349,7 @@ cd "$DEEPHYPER_PERLMUTTER"
 git clone https://github.com/deephyper/deephyper.git || true
 cd deephyper
 pip_retry -e . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # GPTL

--- a/scripts/hpc/nersc/perlmutter/installation/install.sh
+++ b/scripts/hpc/nersc/perlmutter/installation/install.sh
@@ -115,7 +115,7 @@ fi
 # ============================================================
 # pip helpers + NumPy pin
 # ============================================================
-banner "pip Helpers and NumPy Pin (1.26.4)"
+banner "pip Helpers and NumPy Pin (2.4.6)"
 
 PIP_FLAGS=(--upgrade-strategy only-if-needed)
 
@@ -134,7 +134,7 @@ pip_retry() {
 assert_numpy_1264() {
   python - <<'PY'
 import numpy as np
-expected="1.26.4"
+expected="2.4.6"
 assert np.__version__==expected, f"NumPy is {np.__version__}, expected {expected}"
 PY
 }
@@ -142,8 +142,8 @@ PY
 subbanner "Upgrade pip/setuptools/wheel"
 pip_retry --disable-pip-version-check -U pip setuptools wheel
 
-subbanner "Install and pin numpy==1.26.4"
-pip_retry "numpy==1.26.4"
+subbanner "Install and pin numpy==2.4.6"
+pip_retry "numpy==2.4.6"
 assert_numpy_1264
 
 # ============================================================
@@ -156,7 +156,7 @@ pip_retry cmake
 pip_retry astunparse
 pip_retry expecttest
 pip_retry hypothesis
-pip_retry numpy==1.26.4
+pip_retry numpy==2.4.6
 pip_retry psutil==7.1.0
 pip_retry pyyaml
 pip_retry requests
@@ -168,7 +168,7 @@ pip_retry networkx
 pip_retry jinja2
 pip_retry tqdm==4.67.1
 pip_retry types-dataclasses
-pip_retry scipy==1.14.1
+pip_retry scipy==1.17.1
 pip_retry pyparsing
 pip_retry build
 pip_retry Cython

--- a/scripts/hpc/olcf/andes/installation/install-parallel.sh
+++ b/scripts/hpc/olcf/andes/installation/install-parallel.sh
@@ -123,7 +123,7 @@ python --version
 # ============================================================
 # pip helpers + NumPy pin
 # ============================================================
-banner "pip Helpers and NumPy Pin (1.26.4)"
+banner "pip Helpers and NumPy Pin (2.4.6)"
 PIP_FLAGS=(--upgrade-strategy only-if-needed)
 
 pip_retry() {
@@ -141,7 +141,7 @@ pip_retry() {
 assert_numpy_1264() {
   python - <<'PY'
 import numpy as np
-expected="1.26.4"
+expected="2.4.6"
 assert np.__version__==expected, f"NumPy is {np.__version__}, expected {expected}"
 PY
 }
@@ -149,8 +149,8 @@ PY
 subbanner "Upgrade pip/setuptools/wheel"
 pip_retry --disable-pip-version-check -U pip setuptools wheel
 
-subbanner "Install and pin numpy==1.26.4"
-pip_retry "numpy==1.26.4"
+subbanner "Install and pin numpy==2.4.6"
+pip_retry "numpy==2.4.6"
 assert_numpy_1264
 
 # ============================================================
@@ -162,7 +162,7 @@ pip_retry ninja
 pip_retry astunparse 
 pip_retry expecttest 
 pip_retry hypothesis 
-pip_retry numpy==1.26.4 
+pip_retry numpy==2.4.6
 pip_retry psutil==7.1.0 
 pip_retry pyyaml 
 pip_retry requests 
@@ -174,7 +174,7 @@ pip_retry networkx
 pip_retry jinja2 
 pip_retry tqdm==4.67.1
 pip_retry types-dataclasses
-pip_retry scipy==1.14.1 
+pip_retry scipy==1.17.1
 pip_retry pyparsing 
 pip_retry build
 pip_retry Cython
@@ -468,4 +468,3 @@ echo "  ml miniforge3/23.11.0-0"
 echo "  ml libfabric/1.14.0"
 echo ""
 echo "  source activate ${VENV_PATH}"
-

--- a/scripts/hpc/olcf/andes/installation/install-parallel.sh
+++ b/scripts/hpc/olcf/andes/installation/install-parallel.sh
@@ -138,7 +138,7 @@ pip_retry() {
   return 1
 }
 
-assert_numpy_1264() {
+assert_numpy_pinned() {
   python - <<'PY'
 import numpy as np
 expected="2.4.6"
@@ -151,7 +151,7 @@ pip_retry --disable-pip-version-check -U pip setuptools wheel
 
 subbanner "Install and pin numpy==2.4.6"
 pip_retry "numpy==2.4.6"
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # Core scientific Python dependencies
@@ -215,7 +215,7 @@ popd >/dev/null
 banner "Install CPU-only PyTorch"
 PYTORCH_CPU_INDEX_URL="https://download.pytorch.org/whl/cpu"
 pip_retry --index-url "${PYTORCH_CPU_INDEX_URL}" torch torchvision
-assert_numpy_1264
+assert_numpy_pinned
 
 python - <<'PY'
 import torch
@@ -240,7 +240,7 @@ fi
 pushd pytorch_geometric >/dev/null
 rm -rf build
 pip_retry . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_scatter (official repo & stable ref for CPU) ---
@@ -256,7 +256,7 @@ build_pytorch_scatter() {
   rm -rf build
   CC=mpicc CXX=mpicxx python setup.py build
   CC=mpicc CXX=mpicxx python setup.py install
-  assert_numpy_1264
+  assert_numpy_pinned
   popd >/dev/null
 }
 
@@ -272,7 +272,7 @@ build_pytorch_sparse() {
   rm -rf build
   CC=mpicc CXX=mpicxx python setup.py build
   CC=mpicc CXX=mpicxx python setup.py install
-  assert_numpy_1264
+  assert_numpy_pinned
   popd >/dev/null
 }
 
@@ -288,7 +288,7 @@ build_pytorch_cluster() {
   rm -rf build
   CC=mpicc CXX=mpicxx python setup.py build
   CC=mpicc CXX=mpicxx python setup.py install
-  assert_numpy_1264
+  assert_numpy_pinned
   popd >/dev/null
 }
 
@@ -304,7 +304,7 @@ build_pytorch_spline_conv() {
   rm -rf build
   CC=mpicc CXX=mpicxx python setup.py build
   CC=mpicc CXX=mpicxx python setup.py install
-  assert_numpy_1264
+  assert_numpy_pinned
   popd >/dev/null
 }
 
@@ -325,7 +325,7 @@ wait
 # ============================================================
 banner "Install e3nn and openequivariance"
 pip_retry e3nn openequivariance --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # ADIOS2
@@ -393,7 +393,7 @@ build_deephyper() {
   git clone https://github.com/deephyper/deephyper.git || true
   cd deephyper
   pip_retry -e . --verbose
-  assert_numpy_1264
+  assert_numpy_pinned
 }
 
 # ============================================================

--- a/scripts/hpc/olcf/andes/installation/install.sh
+++ b/scripts/hpc/olcf/andes/installation/install.sh
@@ -92,7 +92,7 @@ python --version
 # ============================================================
 # pip helpers + NumPy pin
 # ============================================================
-banner "pip Helpers and NumPy Pin (1.26.4)"
+banner "pip Helpers and NumPy Pin (2.4.6)"
 PIP_FLAGS=(--upgrade-strategy only-if-needed)
 
 pip_retry() {
@@ -110,7 +110,7 @@ pip_retry() {
 assert_numpy_1264() {
   python - <<'PY'
 import numpy as np
-expected="1.26.4"
+expected="2.4.6"
 assert np.__version__==expected, f"NumPy is {np.__version__}, expected {expected}"
 PY
 }
@@ -118,8 +118,8 @@ PY
 subbanner "Upgrade pip/setuptools/wheel"
 pip_retry --disable-pip-version-check -U pip setuptools wheel
 
-subbanner "Install and pin numpy==1.26.4"
-pip_retry "numpy==1.26.4"
+subbanner "Install and pin numpy==2.4.6"
+pip_retry "numpy==2.4.6"
 assert_numpy_1264
 
 # ============================================================
@@ -131,7 +131,7 @@ pip_retry ninja
 pip_retry astunparse 
 pip_retry expecttest 
 pip_retry hypothesis 
-pip_retry numpy==1.26.4 
+pip_retry numpy==2.4.6
 pip_retry psutil==7.1.0 
 pip_retry pyyaml 
 pip_retry requests 
@@ -143,7 +143,7 @@ pip_retry networkx
 pip_retry jinja2 
 pip_retry tqdm==4.67.1
 pip_retry types-dataclasses
-pip_retry scipy==1.14.1 
+pip_retry scipy==1.17.1
 pip_retry pyparsing 
 pip_retry build
 pip_retry Cython
@@ -392,4 +392,3 @@ echo "  ml miniforge3/23.11.0-0"
 echo "  ml libfabric/1.14.0"
 echo ""
 echo "  source activate ${VENV_PATH}"
-

--- a/scripts/hpc/olcf/andes/installation/install.sh
+++ b/scripts/hpc/olcf/andes/installation/install.sh
@@ -107,7 +107,7 @@ pip_retry() {
   return 1
 }
 
-assert_numpy_1264() {
+assert_numpy_pinned() {
   python - <<'PY'
 import numpy as np
 expected="2.4.6"
@@ -120,7 +120,7 @@ pip_retry --disable-pip-version-check -U pip setuptools wheel
 
 subbanner "Install and pin numpy==2.4.6"
 pip_retry "numpy==2.4.6"
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # Core scientific Python dependencies
@@ -168,7 +168,7 @@ pip_retry vesin==0.4.2
 banner "Install CPU-only PyTorch"
 PYTORCH_CPU_INDEX_URL="https://download.pytorch.org/whl/cpu"
 pip_retry --index-url "${PYTORCH_CPU_INDEX_URL}" torch torchvision
-assert_numpy_1264
+assert_numpy_pinned
 
 python - <<'PY'
 import torch
@@ -193,7 +193,7 @@ fi
 pushd pytorch_geometric >/dev/null
 rm -rf build
 pip_retry . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_scatter (official repo & stable ref for CPU) ---
@@ -208,7 +208,7 @@ git submodule update --init --recursive
 rm -rf build
 CC=mpicc CXX=mpicxx python setup.py build
 CC=mpicc CXX=mpicxx python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_sparse (official pinned) ---
@@ -222,7 +222,7 @@ git checkout 0.6.18-8-gcdbf561
 rm -rf build
 CC=mpicc CXX=mpicxx python setup.py build
 CC=mpicc CXX=mpicxx python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_cluster (official pinned) ---
@@ -236,7 +236,7 @@ git checkout 1.6.3-11-g4126a52
 rm -rf build
 CC=mpicc CXX=mpicxx python setup.py build
 CC=mpicc CXX=mpicxx python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_spline_conv (official pinned) ---
@@ -250,12 +250,12 @@ git checkout 1.2.2-9-ga6d1020
 rm -rf build
 CC=mpicc CXX=mpicxx python setup.py build
 CC=mpicc CXX=mpicxx python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 subbanner "Install e3nn and openequivariance"
 pip_retry e3nn openequivariance --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # mpi4py
@@ -333,7 +333,7 @@ cd "$DEEPHYPER_ANDES"
 git clone https://github.com/deephyper/deephyper.git || true
 cd deephyper
 pip_retry -e . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # GPTL

--- a/scripts/hpc/olcf/frontier/installation/install-parallel-rocm64.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-parallel-rocm64.sh
@@ -114,7 +114,7 @@ python --version
 # ============================================================
 # pip helpers + NumPy pin
 # ============================================================
-banner "pip Helpers and NumPy Pin (1.26.4)"
+banner "pip Helpers and NumPy Pin (2.4.6)"
 PIP_FLAGS=(--upgrade-strategy only-if-needed)
 
 pip_retry() {
@@ -132,7 +132,7 @@ pip_retry() {
 assert_numpy_1264() {
   python - <<'PY'
 import numpy as np
-expected="1.26.4"
+expected="2.4.6"
 assert np.__version__==expected, f"NumPy is {np.__version__}, expected {expected}"
 PY
 }
@@ -140,8 +140,8 @@ PY
 subbanner "Upgrade pip/setuptools/wheel"
 pip_retry --disable-pip-version-check -U pip setuptools wheel
 
-subbanner "Install and pin numpy==1.26.4"
-pip_retry "numpy==1.26.4"
+subbanner "Install and pin numpy==2.4.6"
+pip_retry "numpy==2.4.6"
 assert_numpy_1264
 
 # ============================================================
@@ -153,7 +153,7 @@ pip_retry ninja
 pip_retry astunparse 
 pip_retry expecttest 
 pip_retry hypothesis 
-pip_retry numpy==1.26.4 
+pip_retry numpy==2.4.6
 pip_retry psutil==7.1.0 
 pip_retry pyyaml 
 pip_retry requests 
@@ -165,7 +165,7 @@ pip_retry networkx
 pip_retry jinja2 
 pip_retry tqdm==4.67.1
 pip_retry types-dataclasses
-pip_retry scipy==1.14.1 
+pip_retry scipy==1.17.1
 pip_retry pyparsing 
 pip_retry build
 pip_retry Cython

--- a/scripts/hpc/olcf/frontier/installation/install-parallel-rocm64.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-parallel-rocm64.sh
@@ -129,7 +129,7 @@ pip_retry() {
   return 1
 }
 
-assert_numpy_1264() {
+assert_numpy_pinned() {
   python - <<'PY'
 import numpy as np
 expected="2.4.6"
@@ -142,7 +142,7 @@ pip_retry --disable-pip-version-check -U pip setuptools wheel
 
 subbanner "Install and pin numpy==2.4.6"
 pip_retry "numpy==2.4.6"
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # Core scientific Python dependencies
@@ -230,7 +230,7 @@ fi
 
 subbanner "Install ROCm PyTorch from ${PYTORCH_ROCM_INDEX_URL}"
 pip_retry --index-url "${PYTORCH_ROCM_INDEX_URL}" torch torchvision
-assert_numpy_1264
+assert_numpy_pinned
 
 python - <<PY
 import torch
@@ -255,7 +255,7 @@ fi
 pushd pytorch_geometric >/dev/null
 rm -rf build
 pip_retry . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_scatter (ROCm fork pinned) ---
@@ -275,7 +275,7 @@ build_pytorch_scatter() {
   # If needed: export PYTORCH_ROCM_ARCH=gfx90a
   CC=gcc CXX=g++ python setup.py build
   CC=gcc CXX=g++ python setup.py install
-  assert_numpy_1264
+  assert_numpy_pinned
   echo "pytorch_scatter pinned to commit: $(git rev-parse --short HEAD)"
   popd >/dev/null
 }
@@ -295,7 +295,7 @@ build_pytorch_sparse() {
   rm -rf build
   CC=gcc CXX=g++ python setup.py build
   CC=gcc CXX=g++ python setup.py install
-  assert_numpy_1264
+  assert_numpy_pinned
   echo "pytorch_sparse pinned to commit: $(git rev-parse --short HEAD)"
   popd >/dev/null
 }
@@ -312,7 +312,7 @@ build_pytorch_cluster() {
   rm -rf build
   CC=gcc CXX=g++ python setup.py build
   CC=gcc CXX=g++ python setup.py install
-  assert_numpy_1264
+  assert_numpy_pinned
   popd >/dev/null
 }
 
@@ -328,7 +328,7 @@ build_pytorch_spline_conv() {
   rm -rf build
   CC=gcc CXX=g++ python setup.py build
   CC=gcc CXX=g++ python setup.py install
-  assert_numpy_1264
+  assert_numpy_pinned
   popd >/dev/null
 }
 
@@ -349,7 +349,7 @@ wait
 # ============================================================
 banner "Install e3nn and openequivariance"
 pip_retry e3nn openequivariance --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # ADIOS2
@@ -417,7 +417,7 @@ build_deephyper() {
   git clone https://github.com/deephyper/deephyper.git || true
   cd deephyper
   pip_retry -e . --verbose
-  assert_numpy_1264
+  assert_numpy_pinned
 }
 
 # ============================================================

--- a/scripts/hpc/olcf/frontier/installation/install-rocm64.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm64.sh
@@ -77,7 +77,7 @@ python --version
 # ============================================================
 # pip helpers + NumPy pin
 # ============================================================
-banner "pip Helpers and NumPy Pin (1.26.4)"
+banner "pip Helpers and NumPy Pin (2.4.6)"
 PIP_FLAGS=(--upgrade-strategy only-if-needed)
 
 pip_retry() {
@@ -95,7 +95,7 @@ pip_retry() {
 assert_numpy_1264() {
   python - <<'PY'
 import numpy as np
-expected="1.26.4"
+expected="2.4.6"
 assert np.__version__==expected, f"NumPy is {np.__version__}, expected {expected}"
 PY
 }
@@ -103,8 +103,8 @@ PY
 subbanner "Upgrade pip/setuptools/wheel"
 pip_retry --disable-pip-version-check -U pip setuptools wheel
 
-subbanner "Install and pin numpy==1.26.4"
-pip_retry "numpy==1.26.4"
+subbanner "Install and pin numpy==2.4.6"
+pip_retry "numpy==2.4.6"
 assert_numpy_1264
 
 # ============================================================
@@ -116,7 +116,7 @@ pip_retry ninja
 pip_retry astunparse 
 pip_retry expecttest 
 pip_retry hypothesis 
-pip_retry numpy==1.26.4 
+pip_retry numpy==2.4.6
 pip_retry psutil==7.1.0 
 pip_retry pyyaml 
 pip_retry requests 
@@ -128,7 +128,7 @@ pip_retry networkx
 pip_retry jinja2 
 pip_retry tqdm==4.67.1
 pip_retry types-dataclasses
-pip_retry scipy==1.14.1 
+pip_retry scipy==1.17.1
 pip_retry pyparsing 
 pip_retry build
 pip_retry Cython

--- a/scripts/hpc/olcf/frontier/installation/install-rocm64.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm64.sh
@@ -92,7 +92,7 @@ pip_retry() {
   return 1
 }
 
-assert_numpy_1264() {
+assert_numpy_pinned() {
   python - <<'PY'
 import numpy as np
 expected="2.4.6"
@@ -105,7 +105,7 @@ pip_retry --disable-pip-version-check -U pip setuptools wheel
 
 subbanner "Install and pin numpy==2.4.6"
 pip_retry "numpy==2.4.6"
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # Core scientific Python dependencies
@@ -178,7 +178,7 @@ fi
 
 subbanner "Install ROCm PyTorch from ${PYTORCH_ROCM_INDEX_URL}"
 pip_retry --index-url "${PYTORCH_ROCM_INDEX_URL}" torch torchvision
-assert_numpy_1264
+assert_numpy_pinned
 
 python - <<PY
 import torch
@@ -203,7 +203,7 @@ fi
 pushd pytorch_geometric >/dev/null
 rm -rf build
 pip_retry . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_scatter (ROCm fork pinned) ---
@@ -222,7 +222,7 @@ rm -rf build
 # If needed: export PYTORCH_ROCM_ARCH=gfx90a
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 echo "pytorch_scatter pinned to commit: $(git rev-parse --short HEAD)"
 popd >/dev/null
 
@@ -240,7 +240,7 @@ git checkout "${PYTORCH_SPARSE_ROCM_COMMIT}"
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 echo "pytorch_sparse pinned to commit: $(git rev-parse --short HEAD)"
 popd >/dev/null
 
@@ -255,7 +255,7 @@ git checkout 1.6.3-11-g4126a52
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_spline_conv (official pinned) ---
@@ -269,12 +269,12 @@ git checkout 1.2.2-9-ga6d1020
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 subbanner "Install e3nn and openequivariance"
 pip_retry e3nn --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # mpi4py
@@ -352,7 +352,7 @@ cd "$DEEPHYPER_FRONTIER"
 git clone https://github.com/deephyper/deephyper.git || true
 cd deephyper
 pip_retry . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # GPTL

--- a/scripts/hpc/olcf/frontier/installation/install-rocm71.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm71.sh
@@ -93,7 +93,7 @@ pip_retry() {
   return 1
 }
 
-assert_numpy_1264() {
+assert_numpy_pinned() {
   python - <<'PY'
 import numpy as np
 expected="2.4.6"
@@ -106,7 +106,7 @@ pip_retry --disable-pip-version-check -U pip setuptools wheel
 
 subbanner "Install and pin numpy==2.4.6"
 pip_retry "numpy==2.4.6"
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # Core scientific Python dependencies
@@ -179,7 +179,7 @@ fi
 
 subbanner "Install ROCm PyTorch from ${PYTORCH_ROCM_INDEX_URL}"
 pip_retry --index-url "${PYTORCH_ROCM_INDEX_URL}" torch torchvision
-assert_numpy_1264
+assert_numpy_pinned
 
 python - <<'PY'
 import torch
@@ -212,7 +212,7 @@ fi
 pushd pytorch_geometric >/dev/null
 rm -rf build
 pip_retry . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_scatter (ROCm fork pinned) ---
@@ -230,7 +230,7 @@ git submodule update --init --recursive
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 echo "pytorch_scatter pinned to commit: $(git rev-parse --short HEAD)"
 popd >/dev/null
 
@@ -248,7 +248,7 @@ git checkout "${PYTORCH_SPARSE_ROCM_COMMIT}"
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 echo "pytorch_sparse pinned to commit: $(git rev-parse --short HEAD)"
 popd >/dev/null
 
@@ -263,7 +263,7 @@ git checkout 1.6.3-11-g4126a52
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_spline_conv (official pinned) ---
@@ -277,12 +277,12 @@ git checkout 1.2.2-9-ga6d1020
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 subbanner "Install e3nn"
 pip_retry e3nn --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # NOTE: unload ROCm for mpi4py build
 module unload craype-accel-amd-gfx90a
@@ -365,7 +365,7 @@ cd "$DEEPHYPER_FRONTIER"
 git clone https://github.com/deephyper/deephyper.git || true
 cd deephyper
 pip_retry . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # GPTL

--- a/scripts/hpc/olcf/frontier/installation/install-rocm71.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm71.sh
@@ -78,7 +78,7 @@ python --version
 # ============================================================
 # pip helpers + NumPy pin
 # ============================================================
-banner "pip Helpers and NumPy Pin (1.26.4)"
+banner "pip Helpers and NumPy Pin (2.4.6)"
 PIP_FLAGS=(--upgrade-strategy only-if-needed)
 
 pip_retry() {
@@ -96,7 +96,7 @@ pip_retry() {
 assert_numpy_1264() {
   python - <<'PY'
 import numpy as np
-expected="1.26.4"
+expected="2.4.6"
 assert np.__version__==expected, f"NumPy is {np.__version__}, expected {expected}"
 PY
 }
@@ -104,8 +104,8 @@ PY
 subbanner "Upgrade pip/setuptools/wheel"
 pip_retry --disable-pip-version-check -U pip setuptools wheel
 
-subbanner "Install and pin numpy==1.26.4"
-pip_retry "numpy==1.26.4"
+subbanner "Install and pin numpy==2.4.6"
+pip_retry "numpy==2.4.6"
 assert_numpy_1264
 
 # ============================================================
@@ -117,7 +117,7 @@ pip_retry ninja
 pip_retry astunparse
 pip_retry expecttest
 pip_retry hypothesis
-pip_retry numpy==1.26.4
+pip_retry numpy==2.4.6
 pip_retry psutil==7.1.0
 pip_retry pyyaml
 pip_retry requests
@@ -129,7 +129,7 @@ pip_retry networkx
 pip_retry jinja2
 pip_retry tqdm==4.67.1
 pip_retry types-dataclasses
-pip_retry scipy==1.14.1
+pip_retry scipy==1.17.1
 pip_retry pyparsing
 pip_retry build
 pip_retry Cython

--- a/scripts/hpc/olcf/frontier/installation/install-rocm713.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm713.sh
@@ -150,7 +150,7 @@ pip_retry() {
   return 1
 }
 
-assert_numpy_1264() {
+assert_numpy_pinned() {
   python - <<'PY'
 import numpy as np
 expected="2.4.6"
@@ -163,7 +163,7 @@ pip_retry --disable-pip-version-check -U pip setuptools wheel
 
 subbanner "Install and pin numpy==2.4.6"
 pip_retry "numpy==2.4.6"
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # Core scientific Python dependencies
@@ -258,7 +258,7 @@ pip_retry --index-url "${PYTORCH_ROCM_INDEX_URL}" \
           "torch==${TORCH_VERSION}" \
           "torchvision==${TORCHVISION_VERSION}" \
           "torchaudio==${TORCHAUDIO_VERSION}"
-assert_numpy_1264
+assert_numpy_pinned
 
 python - <<'PY'
 import torch
@@ -291,7 +291,7 @@ fi
 pushd pytorch_geometric >/dev/null
 rm -rf build
 pip_retry . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_scatter (ROCm fork pinned) ---
@@ -309,7 +309,7 @@ git submodule update --init --recursive
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 echo "pytorch_scatter pinned to commit: $(git rev-parse --short HEAD)"
 popd >/dev/null
 
@@ -327,7 +327,7 @@ git checkout 2340737
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 echo "pytorch_sparse pinned to commit: $(git rev-parse --short HEAD)"
 popd >/dev/null
 
@@ -342,7 +342,7 @@ git checkout 1.6.3-11-g4126a52
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_spline_conv (official pinned) ---
@@ -356,12 +356,12 @@ git checkout 1.2.2-9-ga6d1020
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 subbanner "Install e3nn"
 pip_retry e3nn --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # NOTE: unload ROCm for mpi4py build
 module unload craype-accel-amd-gfx90a
@@ -444,7 +444,7 @@ cd "$DEEPHYPER_FRONTIER"
 git clone https://github.com/deephyper/deephyper.git || true
 cd deephyper
 pip_retry . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # GPTL
@@ -525,7 +525,7 @@ else
     subbanner "vLLM ROCm requirements file not found; installing minimal build tooling"
     pip_retry cmake ninja packaging pybind11 setuptools_scm setuptools wheel amdsmi
   fi
-  assert_numpy_1264
+  assert_numpy_pinned
 
   subbanner "Building vLLM for gfx90a (ROCm 7.13.0)"
   cd "$VLLM_SRC_DIR"
@@ -546,7 +546,7 @@ import vllm
 print("vllm.__version__ =", vllm.__version__)
 PY
 
-  assert_numpy_1264
+  assert_numpy_pinned
 
   # Apply flashinfer ROCm patch (no libcudart; use libamdhip64 fallback).
   # vLLM's own cuda_wrapper.py already handles this, but flashinfer/comm/cuda_ipc.py

--- a/scripts/hpc/olcf/frontier/installation/install-rocm713.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm713.sh
@@ -135,7 +135,7 @@ python --version
 # ============================================================
 # pip helpers + NumPy pin
 # ============================================================
-banner "pip Helpers and NumPy Pin (1.26.4)"
+banner "pip Helpers and NumPy Pin (2.4.6)"
 PIP_FLAGS=(--upgrade-strategy only-if-needed)
 
 pip_retry() {
@@ -153,7 +153,7 @@ pip_retry() {
 assert_numpy_1264() {
   python - <<'PY'
 import numpy as np
-expected="1.26.4"
+expected="2.4.6"
 assert np.__version__==expected, f"NumPy is {np.__version__}, expected {expected}"
 PY
 }
@@ -161,8 +161,8 @@ PY
 subbanner "Upgrade pip/setuptools/wheel"
 pip_retry --disable-pip-version-check -U pip setuptools wheel
 
-subbanner "Install and pin numpy==1.26.4"
-pip_retry "numpy==1.26.4"
+subbanner "Install and pin numpy==2.4.6"
+pip_retry "numpy==2.4.6"
 assert_numpy_1264
 
 # ============================================================
@@ -174,7 +174,7 @@ pip_retry ninja
 pip_retry astunparse
 pip_retry expecttest
 pip_retry hypothesis
-pip_retry numpy==1.26.4
+pip_retry numpy==2.4.6
 pip_retry psutil==7.1.0
 pip_retry pyyaml
 pip_retry requests
@@ -186,7 +186,7 @@ pip_retry networkx
 pip_retry jinja2
 pip_retry tqdm==4.67.1
 pip_retry types-dataclasses
-pip_retry scipy==1.14.1
+pip_retry scipy==1.17.1
 pip_retry pyparsing
 pip_retry build
 pip_retry Cython

--- a/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
@@ -116,7 +116,7 @@ python --version
 # ============================================================
 # pip helpers + NumPy pin
 # ============================================================
-banner "pip Helpers and NumPy Pin (1.26.4)"
+banner "pip Helpers and NumPy Pin (2.4.6)"
 PIP_FLAGS=(--upgrade-strategy only-if-needed)
 
 pip_retry() {
@@ -134,7 +134,7 @@ pip_retry() {
 assert_numpy_1264() {
   python - <<'PY'
 import numpy as np
-expected="1.26.4"
+expected="2.4.6"
 assert np.__version__==expected, f"NumPy is {np.__version__}, expected {expected}"
 PY
 }
@@ -142,8 +142,8 @@ PY
 subbanner "Upgrade pip/setuptools/wheel"
 pip_retry --disable-pip-version-check -U pip setuptools wheel
 
-subbanner "Install and pin numpy==1.26.4"
-pip_retry "numpy==1.26.4"
+subbanner "Install and pin numpy==2.4.6"
+pip_retry "numpy==2.4.6"
 assert_numpy_1264
 
 # ============================================================
@@ -155,7 +155,7 @@ pip_retry ninja
 pip_retry astunparse
 pip_retry expecttest
 pip_retry hypothesis
-pip_retry numpy==1.26.4
+pip_retry numpy==2.4.6
 pip_retry psutil==7.1.0
 pip_retry pyyaml
 pip_retry requests
@@ -167,7 +167,7 @@ pip_retry networkx
 pip_retry jinja2
 pip_retry tqdm==4.67.1
 pip_retry types-dataclasses
-pip_retry scipy==1.14.1
+pip_retry scipy==1.17.1
 pip_retry pyparsing
 pip_retry build
 pip_retry Cython

--- a/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
@@ -131,7 +131,7 @@ pip_retry() {
   return 1
 }
 
-assert_numpy_1264() {
+assert_numpy_pinned() {
   python - <<'PY'
 import numpy as np
 expected="2.4.6"
@@ -144,7 +144,7 @@ pip_retry --disable-pip-version-check -U pip setuptools wheel
 
 subbanner "Install and pin numpy==2.4.6"
 pip_retry "numpy==2.4.6"
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # Core scientific Python dependencies
@@ -235,7 +235,7 @@ pip_retry --force-reinstall \
           "torch==${TORCH_VERSION}" \
           "torchvision==${TORCHVISION_VERSION}" \
           "torchaudio==${TORCHAUDIO_VERSION}"
-assert_numpy_1264
+assert_numpy_pinned
 
 python - "${TORCH_VERSION%%+*}" "${EXPECTED_ROCM_MM}" <<'PY'
 import sys
@@ -281,7 +281,7 @@ fi
 pushd pytorch_geometric >/dev/null
 rm -rf build
 pip_retry . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_scatter (ROCm fork pinned) ---
@@ -299,7 +299,7 @@ git submodule update --init --recursive
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 echo "pytorch_scatter pinned to commit: $(git rev-parse --short HEAD)"
 popd >/dev/null
 
@@ -317,7 +317,7 @@ git checkout 2340737
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 echo "pytorch_sparse pinned to commit: $(git rev-parse --short HEAD)"
 popd >/dev/null
 
@@ -332,7 +332,7 @@ git checkout 1.6.3-11-g4126a52
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 # --- pytorch_spline_conv (official pinned) ---
@@ -346,12 +346,12 @@ git checkout 1.2.2-9-ga6d1020
 rm -rf build
 CC=gcc CXX=g++ python setup.py build
 CC=gcc CXX=g++ python setup.py install
-assert_numpy_1264
+assert_numpy_pinned
 popd >/dev/null
 
 subbanner "Install e3nn"
 pip_retry e3nn --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # NOTE: unload ROCm for mpi4py build
 module unload craype-accel-amd-gfx90a
@@ -434,7 +434,7 @@ cd "$DEEPHYPER_FRONTIER"
 git clone https://github.com/deephyper/deephyper.git || true
 cd deephyper
 pip_retry . --verbose
-assert_numpy_1264
+assert_numpy_pinned
 
 # ============================================================
 # GPTL
@@ -515,7 +515,7 @@ else
     subbanner "vLLM ROCm requirements file not found; installing minimal build tooling"
     pip_retry cmake ninja packaging pybind11 setuptools_scm setuptools wheel amdsmi
   fi
-  assert_numpy_1264
+  assert_numpy_pinned
 
   subbanner "Building vLLM for gfx90a (ROCm 7.2)"
   cd "$VLLM_SRC_DIR"
@@ -536,7 +536,7 @@ import vllm
 print("vllm.__version__ =", vllm.__version__)
 PY
 
-  assert_numpy_1264
+  assert_numpy_pinned
 
   # Apply flashinfer ROCm patch (no libcudart; use libamdhip64 fallback).
   # vLLM's own cuda_wrapper.py already handles this, but flashinfer/comm/cuda_ipc.py


### PR DESCRIPTION
## Summary

- upgrade the canonical NumPy requirement from 2.2.6 to 2.4.6
- align all Aurora, Andes, Frontier, and Perlmutter installers on NumPy 2.4.6
- upgrade generic PyTorch requirements to torch 2.14.0 and torchvision 0.29.0
- update CPU CI and its PyG wheel lookup for PyTorch 2.14.0
- align HPC SciPy pins with requirements-base.txt at 1.17.1 for NumPy 2.4 compatibility

The HPC installers retain their existing platform-specific PyTorch wheel or
module selections.

## Validation

- parsed `.github/workflows/CI.yml` as YAML
- ran `bash -n` on every shell script under `scripts/hpc`
- ran `git diff --check`
- verified combined `requirements-base.txt` and `requirements-torch.txt`
  resolution on Python 3.14 using the official PyTorch CPU index
