### PR TITLE
Complete HPC installer dependency alignment

### DIFF
--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,6 +1,5 @@
 torch==2.14.0
 torchvision==0.29.0
-torchaudio==2.11.0
 e3nn==0.5.1
 torch-ema==0.3
 torchmetrics==1.4.0

--- a/scripts/hpc/alcf/aurora/installation/install.sh
+++ b/scripts/hpc/alcf/aurora/installation/install.sh
@@ -395,8 +395,7 @@ PY
 # PyTorch Geometric (base) + ALWAYS rebuild auxiliary deps (CPU-only)
 # ============================================================
 banner "Install PyTorch Geometric base (torch_geometric)"
-pip_retry torch_geometric
-
+pip_retry torch_geometric==2.8.0
 # ---- ALCF optional-deps prerequisites (TORCH_LIB + TORCH_VERSION) ----
 TORCH_LIB="$(python -c "import torch; print(torch.__file__)" | sed 's/__init__.py/lib/')"
 TORCH_VERSION="$(python -c "import torch; print(torch.__version__)" | sed 's/^\([0-9.]*\).*/\1/')"
@@ -485,22 +484,22 @@ PY
 # Additional python deps (NO torch install here!)
 # ============================================================
 banner "Install HydraGNN dependencies (do NOT install torch here)"
-pip_retry scipy pyyaml requests tqdm filelock psutil
+pip_retry "scipy==1.17.1" pyyaml requests "tqdm==4.70.0" filelock "psutil==7.1.0"
 pip_retry networkx jinja2
-pip_retry tensorboard scikit-learn pytest
-pip_retry ase h5py lmdb
+pip_retry "tensorboard==2.20.0" "scikit-learn==1.7.2" "pytest==8.4.2"
+pip_retry "ase==3.26.0" "h5py==3.16.0" lmdb
 
 # Keep numpy pinned and avoid it being bumped by scientific packages
 pip_retry "numpy==2.4.6"
 
-# Keep NumPy aligned with HydraGNN requirements after installing mendeleev
-pip_retry "mendeleev<1.1.0" || true
+# Keep mendeleev and NumPy aligned with HydraGNN requirements.
+pip_retry "mendeleev==1.2.0"
 
-pip_retry rdkit jarvis-tools pymatgen || true
+pip_retry "rdkit==2026.3.5" jarvis-tools pymatgen || true
 pip_retry igraph || true
 
-pip_retry e3nn openequivariance
-pip_retry vesin
+pip_retry e3nn==0.5.1 openequivariance
+pip_retry "vesin==0.4.2"
 pip_retry Cython
 pip_retry setuptools wheel
 

--- a/scripts/hpc/nersc/perlmutter/installation/install.sh
+++ b/scripts/hpc/nersc/perlmutter/installation/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup_env_perlmutter.sh
+# HydraGNN installation for Perlmutter
 # Complete automated setup for HydraGNN environment and dependencies on NERSC Perlmutter (CUDA/A100).
 #
 # CORRECTIONS INCLUDED:
@@ -10,8 +10,8 @@
 #     -> load gcc-native/13.2 and force CC/CXX to gcc/g++
 #
 # Usage:
-#   chmod +x setup_env_perlmutter.sh
-#   ./setup_env_perlmutter.sh
+#   chmod +x scripts/hpc/nersc/perlmutter/installation/install.sh
+#   scripts/hpc/nersc/perlmutter/installation/install.sh
 #
 # Optional env vars:
 #   VENV_PATH=/path/to/env
@@ -166,23 +166,23 @@ pip_retry sympy==1.14.0
 pip_retry filelock
 pip_retry networkx
 pip_retry jinja2
-pip_retry tqdm==4.67.1
+pip_retry tqdm==4.70.0
 pip_retry types-dataclasses
 pip_retry scipy==1.17.1
 pip_retry pyparsing
 pip_retry build
 pip_retry Cython
 pip_retry tensorboard==2.20.0
-pip_retry scikit-learn==1.5.1
-pip_retry pytest
+pip_retry scikit-learn==1.7.2
+pip_retry pytest==8.4.2
 pip_retry ase==3.26.0
-pip_retry rdkit
+pip_retry rdkit==2026.3.5
 pip_retry jarvis-tools
 pip_retry pymatgen
 pip_retry igraph
-pip_retry mendeleev==0.16.0
+pip_retry mendeleev==1.2.0
 pip_retry lmdb
-pip_retry h5py==3.14.0
+pip_retry h5py==3.16.0
 pip_retry tensorflow
 pip_retry tensorflow_datasets
 pip_retry vesin==0.4.2
@@ -246,11 +246,11 @@ else
 fi
 
 subbanner "Install torch-geometric (pure python wrapper package)"
-pip_retry torch-geometric
+pip_retry torch-geometric==2.8.0
 assert_numpy_pinned
 
 subbanner "Install e3nn and openequivariance"
-pip_retry e3nn openequivariance --verbose
+pip_retry e3nn==0.5.1 openequivariance --verbose
 assert_numpy_pinned
 
 subbanner "PyG import sanity check"

--- a/scripts/hpc/olcf/andes/installation/install-parallel.sh
+++ b/scripts/hpc/olcf/andes/installation/install-parallel.sh
@@ -238,7 +238,11 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+if ! git rev-parse -q --verify "refs/tags/2.8.0" >/dev/null; then
+  git fetch --tags --force
+fi
 git checkout 2.8.0
+git submodule update --init --recursive
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned

--- a/scripts/hpc/olcf/andes/installation/install-parallel.sh
+++ b/scripts/hpc/olcf/andes/installation/install-parallel.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup_env_andes.sh
+# HydraGNN parallel installation for Andes
 # Complete automated setup for HydraGNN environment and dependencies on Andes (CPU-only).
 
 set -Eeuo pipefail
@@ -159,37 +159,37 @@ assert_numpy_pinned
 banner "Install Core Python Packages"
 
 pip_retry ninja
-pip_retry astunparse 
-pip_retry expecttest 
-pip_retry hypothesis 
+pip_retry astunparse
+pip_retry expecttest
+pip_retry hypothesis
 pip_retry numpy==2.4.6
-pip_retry psutil==7.1.0 
-pip_retry pyyaml 
-pip_retry requests 
-pip_retry setuptools 
-pip_retry typing-extensions 
-pip_retry sympy==1.14.0 
-pip_retry filelock 
-pip_retry networkx 
-pip_retry jinja2 
-pip_retry tqdm==4.67.1
+pip_retry psutil==7.1.0
+pip_retry pyyaml
+pip_retry requests
+pip_retry setuptools
+pip_retry typing-extensions
+pip_retry sympy==1.14.0
+pip_retry filelock
+pip_retry networkx
+pip_retry jinja2
+pip_retry tqdm==4.70.0
 pip_retry types-dataclasses
 pip_retry scipy==1.17.1
-pip_retry pyparsing 
+pip_retry pyparsing
 pip_retry build
 pip_retry Cython
 pip_retry tensorboard==2.20.0
-pip_retry scikit-learn==1.5.1
-pip_retry pytest
+pip_retry scikit-learn==1.7.2
+pip_retry pytest==8.4.2
 pip_retry ase==3.26.0
-pip_retry rdkit
+pip_retry rdkit==2026.3.5
 pip_retry jarvis-tools
 pip_retry pymatgen
 #pip_retry sqlite
 pip_retry igraph
-pip_retry mendeleev==0.16.0
+pip_retry mendeleev==1.2.0
 pip_retry lmdb
-pip_retry h5py==3.14.0 
+pip_retry h5py==3.16.0
 pip_retry tensorflow
 pip_retry tensorflow_datasets
 pip_retry vesin==0.4.2
@@ -238,6 +238,7 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+git checkout 2.8.0
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned
@@ -324,7 +325,7 @@ wait
 # e3nn and openequivariance
 # ============================================================
 banner "Install e3nn and openequivariance"
-pip_retry e3nn openequivariance --verbose
+pip_retry e3nn==0.5.1 openequivariance --verbose
 assert_numpy_pinned
 
 # ============================================================

--- a/scripts/hpc/olcf/andes/installation/install.sh
+++ b/scripts/hpc/olcf/andes/installation/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup_env_andes.sh
+# HydraGNN serial installation for Andes
 # Complete automated setup for HydraGNN environment and dependencies on Andes (CPU-only).
 
 set -Eeuo pipefail
@@ -128,37 +128,37 @@ assert_numpy_pinned
 banner "Install Core Python Packages"
 
 pip_retry ninja
-pip_retry astunparse 
-pip_retry expecttest 
-pip_retry hypothesis 
+pip_retry astunparse
+pip_retry expecttest
+pip_retry hypothesis
 pip_retry numpy==2.4.6
-pip_retry psutil==7.1.0 
-pip_retry pyyaml 
-pip_retry requests 
-pip_retry setuptools 
-pip_retry typing-extensions 
-pip_retry sympy==1.14.0 
-pip_retry filelock 
-pip_retry networkx 
-pip_retry jinja2 
-pip_retry tqdm==4.67.1
+pip_retry psutil==7.1.0
+pip_retry pyyaml
+pip_retry requests
+pip_retry setuptools
+pip_retry typing-extensions
+pip_retry sympy==1.14.0
+pip_retry filelock
+pip_retry networkx
+pip_retry jinja2
+pip_retry tqdm==4.70.0
 pip_retry types-dataclasses
 pip_retry scipy==1.17.1
-pip_retry pyparsing 
+pip_retry pyparsing
 pip_retry build
 pip_retry Cython
 pip_retry tensorboard==2.20.0
-pip_retry scikit-learn==1.5.1
-pip_retry pytest
+pip_retry scikit-learn==1.7.2
+pip_retry pytest==8.4.2
 pip_retry ase==3.26.0
-pip_retry rdkit
+pip_retry rdkit==2026.3.5
 pip_retry jarvis-tools
 pip_retry pymatgen
 #pip_retry sqlite
 pip_retry igraph
-pip_retry mendeleev==0.16.0
+pip_retry mendeleev==1.2.0
 pip_retry lmdb
-pip_retry h5py==3.14.0 
+pip_retry h5py==3.16.0
 pip_retry tensorflow
 pip_retry vesin==0.4.2
 
@@ -191,6 +191,7 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+git checkout 2.8.0
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned
@@ -254,7 +255,7 @@ assert_numpy_pinned
 popd >/dev/null
 
 subbanner "Install e3nn and openequivariance"
-pip_retry e3nn openequivariance --verbose
+pip_retry e3nn==0.5.1 openequivariance --verbose
 assert_numpy_pinned
 
 # ============================================================

--- a/scripts/hpc/olcf/andes/installation/install.sh
+++ b/scripts/hpc/olcf/andes/installation/install.sh
@@ -191,7 +191,11 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+if ! git rev-parse -q --verify "refs/tags/2.8.0" >/dev/null; then
+  git fetch --tags --force
+fi
 git checkout 2.8.0
+git submodule update --init --recursive
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned

--- a/scripts/hpc/olcf/frontier/installation/install-parallel-rocm64.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-parallel-rocm64.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup_env.sh
+# HydraGNN parallel installation for Frontier with ROCm 6.4
 # Complete automated setup for HydraGNN environment and dependencies on Frontier.
 
 set -Eeuo pipefail
@@ -150,37 +150,37 @@ assert_numpy_pinned
 banner "Install Core Python Packages"
 
 pip_retry ninja
-pip_retry astunparse 
-pip_retry expecttest 
-pip_retry hypothesis 
+pip_retry astunparse
+pip_retry expecttest
+pip_retry hypothesis
 pip_retry numpy==2.4.6
-pip_retry psutil==7.1.0 
-pip_retry pyyaml 
-pip_retry requests 
-pip_retry setuptools 
-pip_retry typing-extensions 
-pip_retry sympy==1.14.0 
-pip_retry filelock 
-pip_retry networkx 
-pip_retry jinja2 
-pip_retry tqdm==4.67.1
+pip_retry psutil==7.1.0
+pip_retry pyyaml
+pip_retry requests
+pip_retry setuptools
+pip_retry typing-extensions
+pip_retry sympy==1.14.0
+pip_retry filelock
+pip_retry networkx
+pip_retry jinja2
+pip_retry tqdm==4.70.0
 pip_retry types-dataclasses
 pip_retry scipy==1.17.1
-pip_retry pyparsing 
+pip_retry pyparsing
 pip_retry build
 pip_retry Cython
 pip_retry tensorboard==2.20.0
-pip_retry scikit-learn==1.5.1
-pip_retry pytest
+pip_retry scikit-learn==1.7.2
+pip_retry pytest==8.4.2
 pip_retry ase==3.26.0
-pip_retry rdkit
+pip_retry rdkit==2026.3.5
 pip_retry jarvis-tools
 pip_retry pymatgen
 #pip_retry sqlite
 pip_retry igraph
-pip_retry mendeleev==0.16.0
+pip_retry mendeleev==1.2.0
 pip_retry lmdb
-pip_retry h5py==3.14.0 
+pip_retry h5py==3.16.0
 pip_retry tensorflow
 pip_retry tensorflow_datasets
 pip_retry vesin==0.4.2
@@ -253,6 +253,7 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+git checkout 2.8.0
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned
@@ -348,7 +349,7 @@ wait
 # e3nn and openequivariance
 # ============================================================
 banner "Install e3nn and openequivariance"
-pip_retry e3nn openequivariance --verbose
+pip_retry e3nn==0.5.1 openequivariance --verbose
 assert_numpy_pinned
 
 # ============================================================

--- a/scripts/hpc/olcf/frontier/installation/install-parallel-rocm64.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-parallel-rocm64.sh
@@ -253,7 +253,11 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+if ! git rev-parse -q --verify "refs/tags/2.8.0" >/dev/null; then
+  git fetch --tags --force
+fi
 git checkout 2.8.0
+git submodule update --init --recursive
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned

--- a/scripts/hpc/olcf/frontier/installation/install-rocm64.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm64.sh
@@ -201,7 +201,11 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+if ! git rev-parse -q --verify "refs/tags/2.8.0" >/dev/null; then
+  git fetch --tags --force
+fi
 git checkout 2.8.0
+git submodule update --init --recursive
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned

--- a/scripts/hpc/olcf/frontier/installation/install-rocm64.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm64.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup_env.sh
+# HydraGNN installation for Frontier with ROCm 6.4
 # Complete automated setup for HydraGNN environment and dependencies on Frontier.
 
 set -Eeuo pipefail
@@ -113,37 +113,37 @@ assert_numpy_pinned
 banner "Install Core Python Packages"
 
 pip_retry ninja
-pip_retry astunparse 
-pip_retry expecttest 
-pip_retry hypothesis 
+pip_retry astunparse
+pip_retry expecttest
+pip_retry hypothesis
 pip_retry numpy==2.4.6
-pip_retry psutil==7.1.0 
-pip_retry pyyaml 
-pip_retry requests 
-pip_retry setuptools 
-pip_retry typing-extensions 
-pip_retry sympy==1.14.0 
-pip_retry filelock 
-pip_retry networkx 
-pip_retry jinja2 
-pip_retry tqdm==4.67.1
+pip_retry psutil==7.1.0
+pip_retry pyyaml
+pip_retry requests
+pip_retry setuptools
+pip_retry typing-extensions
+pip_retry sympy==1.14.0
+pip_retry filelock
+pip_retry networkx
+pip_retry jinja2
+pip_retry tqdm==4.70.0
 pip_retry types-dataclasses
 pip_retry scipy==1.17.1
-pip_retry pyparsing 
+pip_retry pyparsing
 pip_retry build
 pip_retry Cython
 pip_retry tensorboard==2.20.0
-pip_retry scikit-learn==1.5.1
-pip_retry pytest
+pip_retry scikit-learn==1.7.2
+pip_retry pytest==8.4.2
 pip_retry ase==3.26.0
-pip_retry rdkit
+pip_retry rdkit==2026.3.5
 pip_retry jarvis-tools
 pip_retry pymatgen
 #pip_retry sqlite
 pip_retry igraph
-pip_retry mendeleev==0.16.0
+pip_retry mendeleev==1.2.0
 pip_retry lmdb
-pip_retry h5py==3.14.0 
+pip_retry h5py==3.16.0
 pip_retry tensorflow
 pip_retry tensorflow_datasets
 pip_retry vesin==0.4.2
@@ -201,6 +201,7 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+git checkout 2.8.0
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned
@@ -273,7 +274,7 @@ assert_numpy_pinned
 popd >/dev/null
 
 subbanner "Install e3nn and openequivariance"
-pip_retry e3nn --verbose
+pip_retry e3nn==0.5.1 --verbose
 assert_numpy_pinned
 
 # ============================================================

--- a/scripts/hpc/olcf/frontier/installation/install-rocm71.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm71.sh
@@ -210,7 +210,11 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+if ! git rev-parse -q --verify "refs/tags/2.8.0" >/dev/null; then
+  git fetch --tags --force
+fi
 git checkout 2.8.0
+git submodule update --init --recursive
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned

--- a/scripts/hpc/olcf/frontier/installation/install-rocm71.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm71.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup_env.sh
+# HydraGNN installation for Frontier with ROCm 7.1
 # Complete automated setup for HydraGNN environment and dependencies on Frontier.
 # Updated to ROCm 7.1 (module rocm/7.1.1) and PyTorch wheels from https://download.pytorch.org/whl/rocm7.1
 
@@ -127,24 +127,24 @@ pip_retry sympy==1.14.0
 pip_retry filelock
 pip_retry networkx
 pip_retry jinja2
-pip_retry tqdm==4.67.1
+pip_retry tqdm==4.70.0
 pip_retry types-dataclasses
 pip_retry scipy==1.17.1
 pip_retry pyparsing
 pip_retry build
 pip_retry Cython
 pip_retry tensorboard==2.20.0
-pip_retry scikit-learn==1.5.1
-pip_retry pytest
+pip_retry scikit-learn==1.7.2
+pip_retry pytest==8.4.2
 pip_retry ase==3.26.0
-pip_retry rdkit
+pip_retry rdkit==2026.3.5
 pip_retry jarvis-tools
 pip_retry pymatgen
 #pip_retry sqlite
 pip_retry igraph
-pip_retry mendeleev==0.16.0
+pip_retry mendeleev==1.2.0
 pip_retry lmdb
-pip_retry h5py==3.14.0
+pip_retry h5py==3.16.0
 pip_retry tensorflow
 pip_retry tensorflow_datasets
 pip_retry vesin==0.4.2
@@ -210,6 +210,7 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+git checkout 2.8.0
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned
@@ -281,7 +282,7 @@ assert_numpy_pinned
 popd >/dev/null
 
 subbanner "Install e3nn"
-pip_retry e3nn --verbose
+pip_retry e3nn==0.5.1 --verbose
 assert_numpy_pinned
 
 # NOTE: unload ROCm for mpi4py build

--- a/scripts/hpc/olcf/frontier/installation/install-rocm713.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm713.sh
@@ -289,7 +289,11 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+if ! git rev-parse -q --verify "refs/tags/2.8.0" >/dev/null; then
+  git fetch --tags --force
+fi
 git checkout 2.8.0
+git submodule update --init --recursive
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned

--- a/scripts/hpc/olcf/frontier/installation/install-rocm713.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm713.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup_env_rocm713.sh
+# HydraGNN installation for Frontier with ROCm 7.13
 # Complete automated setup for HydraGNN environment and dependencies on Frontier.
 # Updated to ROCm 7.13.0 (module rocm/7.13.0) using the official AMD ROCm PyTorch
 # wheels for AMD Instinct MI250X (gfx90a), per:
@@ -184,24 +184,24 @@ pip_retry sympy==1.14.0
 pip_retry filelock
 pip_retry networkx
 pip_retry jinja2
-pip_retry tqdm==4.67.1
+pip_retry tqdm==4.70.0
 pip_retry types-dataclasses
 pip_retry scipy==1.17.1
 pip_retry pyparsing
 pip_retry build
 pip_retry Cython
 pip_retry tensorboard==2.20.0
-pip_retry scikit-learn==1.5.1
-pip_retry pytest
+pip_retry scikit-learn==1.7.2
+pip_retry pytest==8.4.2
 pip_retry ase==3.26.0
-pip_retry rdkit
+pip_retry rdkit==2026.3.5
 pip_retry jarvis-tools
 pip_retry pymatgen
 #pip_retry sqlite
 pip_retry igraph
-pip_retry mendeleev==0.16.0
+pip_retry mendeleev==1.2.0
 pip_retry lmdb
-pip_retry h5py==3.14.0
+pip_retry h5py==3.16.0
 # tensorflow and tensorflow_datasets are intentionally NOT installed for ROCm builds.
 # Both TF and ROCm PyTorch link their own LLVM; loading both in the same process
 # triggers: "LLVM ERROR: inconsistency in registered CommandLine options" (hard abort).
@@ -289,6 +289,7 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+git checkout 2.8.0
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned
@@ -360,7 +361,7 @@ assert_numpy_pinned
 popd >/dev/null
 
 subbanner "Install e3nn"
-pip_retry e3nn --verbose
+pip_retry e3nn==0.5.1 --verbose
 assert_numpy_pinned
 
 # NOTE: unload ROCm for mpi4py build

--- a/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
@@ -219,22 +219,19 @@ fi
 
 # ---- Official PyTorch ROCm 7.2 wheels ----
 # Keep this matrix aligned with the official PyTorch ROCm 7.2 installation
-# command. Pinning the complete trio prevents pip from resolving a CPU wheel or
-# selecting mutually incompatible torch/vision/audio releases.
+# command. Pinning both packages prevents pip from resolving a CPU wheel or
+# selecting mutually incompatible torch/vision releases.
 PYTORCH_ROCM_INDEX_URL="${PYTORCH_ROCM_INDEX_URL:-https://download.pytorch.org/whl/rocm7.2}"
-TORCH_VERSION="${TORCH_VERSION:-2.11.0}"
-TORCHVISION_VERSION="${TORCHVISION_VERSION:-0.26.0}"
-TORCHAUDIO_VERSION="${TORCHAUDIO_VERSION:-2.11.0}"
+TORCH_VERSION="${TORCH_VERSION:-2.14.0}"
+TORCHVISION_VERSION="${TORCHVISION_VERSION:-0.29.0}"
 subbanner "Install ROCm PyTorch from ${PYTORCH_ROCM_INDEX_URL}"
 echo "  torch==${TORCH_VERSION}"
 echo "  torchvision==${TORCHVISION_VERSION}"
-echo "  torchaudio==${TORCHAUDIO_VERSION}"
 pip_retry --force-reinstall \
           --index-url "${PYTORCH_ROCM_INDEX_URL}" \
           --extra-index-url "https://pypi.org/simple" \
           "torch==${TORCH_VERSION}" \
-          "torchvision==${TORCHVISION_VERSION}" \
-          "torchaudio==${TORCHAUDIO_VERSION}"
+          "torchvision==${TORCHVISION_VERSION}"
 assert_numpy_pinned
 
 python - "${TORCH_VERSION%%+*}" "${EXPECTED_ROCM_MM}" <<'PY'
@@ -607,7 +604,6 @@ ROCm version:        ${ROCM_MM}
 PyTorch index:       ${PYTORCH_ROCM_INDEX_URL}
   - torch:           ${TORCH_VERSION%%+*}+rocm${EXPECTED_ROCM_MM}
   - torchvision:     ${TORCHVISION_VERSION%%+*}+rocm${EXPECTED_ROCM_MM}
-  - torchaudio:      ${TORCHAUDIO_VERSION%%+*}+rocm${EXPECTED_ROCM_MM}
 PyTorch-Geometric:   $PYG_FRONTIER
   - pytorch_scatter fork: https://github.com/Looong01/pytorch_scatter-rocm.git @ 9799c51 (temporary)
   - pytorch_sparse fork:  https://github.com/Looong01/pytorch_sparse-rocm.git @ 2340737 (temporary)

--- a/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
@@ -276,7 +276,11 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+if ! git rev-parse -q --verify "refs/tags/2.8.0" >/dev/null; then
+  git fetch --tags --force
+fi
 git checkout 2.8.0
+git submodule update --init --recursive
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned

--- a/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
+++ b/scripts/hpc/olcf/frontier/installation/install-rocm72.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# setup_env_rocm72.sh
+# HydraGNN installation for Frontier with ROCm 7.2
 # Complete automated setup for HydraGNN environment and dependencies on Frontier.
 # Updated to ROCm 7.2 (module rocm/7.2.0) and PyTorch wheels from https://download.pytorch.org/whl/rocm7.2
 #
@@ -165,24 +165,24 @@ pip_retry sympy==1.14.0
 pip_retry filelock
 pip_retry networkx
 pip_retry jinja2
-pip_retry tqdm==4.67.1
+pip_retry tqdm==4.70.0
 pip_retry types-dataclasses
 pip_retry scipy==1.17.1
 pip_retry pyparsing
 pip_retry build
 pip_retry Cython
 pip_retry tensorboard==2.20.0
-pip_retry scikit-learn==1.5.1
-pip_retry pytest
+pip_retry scikit-learn==1.7.2
+pip_retry pytest==8.4.2
 pip_retry ase==3.26.0
-pip_retry rdkit
+pip_retry rdkit==2026.3.5
 pip_retry jarvis-tools
 pip_retry pymatgen
 #pip_retry sqlite
 pip_retry igraph
-pip_retry mendeleev==0.16.0
+pip_retry mendeleev==1.2.0
 pip_retry lmdb
-pip_retry h5py==3.14.0
+pip_retry h5py==3.16.0
 pip_retry tensorflow
 pip_retry tensorflow_datasets
 pip_retry vesin==0.4.2
@@ -279,6 +279,7 @@ if [[ ! -d pytorch_geometric/.git ]]; then
   git clone --recursive git@github.com:pyg-team/pytorch_geometric.git
 fi
 pushd pytorch_geometric >/dev/null
+git checkout 2.8.0
 rm -rf build
 pip_retry . --verbose
 assert_numpy_pinned
@@ -350,7 +351,7 @@ assert_numpy_pinned
 popd >/dev/null
 
 subbanner "Install e3nn"
-pip_retry e3nn --verbose
+pip_retry e3nn==0.5.1 --verbose
 assert_numpy_pinned
 
 # NOTE: unload ROCm for mpi4py build


### PR DESCRIPTION
## Summary
- align shared dependency pins across all nine HPC installation scripts
- pin source-installed PyTorch Geometric to the canonical 2.8.0 release
- remove Aurora's obsolete optional mendeleev constraint and align its dependency versions
- correct stale copied script-name headers and usage instructions
- preserve each platform's existing PyTorch and ROCm wheel selection

## Validation
- `bash -n` passes for every HPC installation shell script
- `git diff --check` passes
- audited HPC scripts for stale shared pins and unpinned canonical dependencies