### PR TITLE
Align installation documentation with updated dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,6 @@ on:
 
 env:
   TORCH_BASELINE_VERSION: "2.13.0"
-  TORCHVISION_BASELINE_VERSION: "0.28.0"
 
 jobs:
   build:
@@ -59,11 +58,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel meson-python ninja cython
           python -m pip install numpy==2.4.6
-          # Install HydraGNN's pinned PyTorch before fairchem-core (pulled in
-          # by requirements-dev.txt) so dependency resolution cannot select a
-          # different torch build for the native parity tests.
+          # Install HydraGNN's pinned PyTorch (from requirements-torch.txt)
+          # before fairchem-core (pulled in by requirements-dev.txt) so
+          # dependency resolution cannot select a different torch build for
+          # the native parity tests.
           python -m pip install --upgrade --no-build-isolation -v \
-            "torch==${TORCH_BASELINE_VERSION}" "torchvision==${TORCHVISION_BASELINE_VERSION}" \
             -r requirements-torch.txt \
             --index-url https://download.pytorch.org/whl/cpu \
             --extra-index-url https://pypi.org/simple

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,9 +9,6 @@ on:
   schedule:
     - cron:  '0 3 * * 1'
 
-env:
-  TORCH_BASELINE_VERSION: "2.13.0"
-
 jobs:
   build:
     name: ${{ matrix.suite }} (${{ matrix.python }})
@@ -74,7 +71,10 @@ jobs:
           # pyg-lib is not published on PyPI. Build the 0.8.0 release from its
           # pinned commit so CI does not depend on the data.pyg.org wheel host.
           python -m pip install --no-build-isolation -v "pyg_lib @ git+https://github.com/pyg-team/pyg-lib.git@26a2d1a06a4714da9bb804c19049afb4796971d7"
-          python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links "https://data.pyg.org/whl/torch-${TORCH_BASELINE_VERSION}+cpu.html"
+          # Derive the find-links wheel URL from the torch actually installed
+          # above so it can never drift from requirements-torch.txt.
+          TORCH_VERSION="$(python -c 'import torch; print(torch.__version__.split("+")[0])')"
+          python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links "https://data.pyg.org/whl/torch-${TORCH_VERSION}+cpu.html"
           python -m pip install --upgrade --no-build-isolation -v -r requirements-deepspeed.txt || echo "DeepSpeed installation failed, continuing without it"
       - name: Show installed packages
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron:  '0 3 * * 1'
 
+env:
+  TORCH_BASELINE_VERSION: "2.13.0"
+  TORCHVISION_BASELINE_VERSION: "0.28.0"
+
 jobs:
   build:
     name: ${{ matrix.suite }} (${{ matrix.python }})
@@ -59,7 +63,7 @@ jobs:
           # by requirements-dev.txt) so dependency resolution cannot select a
           # different torch build for the native parity tests.
           python -m pip install --upgrade --no-build-isolation -v \
-            "torch==2.13.0" "torchvision==0.28.0" \
+            "torch==${TORCH_BASELINE_VERSION}" "torchvision==${TORCHVISION_BASELINE_VERSION}" \
             -r requirements-torch.txt \
             --index-url https://download.pytorch.org/whl/cpu \
             --extra-index-url https://pypi.org/simple
@@ -71,7 +75,7 @@ jobs:
           # pyg-lib is not published on PyPI. Build the 0.8.0 release from its
           # pinned commit so CI does not depend on the data.pyg.org wheel host.
           python -m pip install --no-build-isolation -v "pyg_lib @ git+https://github.com/pyg-team/pyg-lib.git@26a2d1a06a4714da9bb804c19049afb4796971d7"
-          python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links https://data.pyg.org/whl/torch-2.13.0+cpu.html
+          python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links "https://data.pyg.org/whl/torch-${TORCH_BASELINE_VERSION}+cpu.html"
           python -m pip install --upgrade --no-build-isolation -v -r requirements-deepspeed.txt || echo "DeepSpeed installation failed, continuing without it"
       - name: Show installed packages
         run: |

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,7 +58,11 @@ jobs:
           # Install HydraGNN's pinned PyTorch before fairchem-core (pulled in
           # by requirements-dev.txt) so dependency resolution cannot select a
           # different torch build for the native parity tests.
-          python -m pip install --upgrade --no-build-isolation -v -r requirements-torch.txt --index-url https://download.pytorch.org/whl/cpu --extra-index-url https://pypi.org/simple
+          python -m pip install --upgrade --no-build-isolation -v \
+            "torch==2.13.0" "torchvision==0.28.0" \
+            -r requirements-torch.txt \
+            --index-url https://download.pytorch.org/whl/cpu \
+            --extra-index-url https://pypi.org/simple
           python -m pip install --upgrade --no-build-isolation -v -r requirements-base.txt -r requirements-dev.txt
           # Model-specific backbone deps (e.g. FAIRChem UMA). Installed WITH
           # build isolation so omegaconf's sdist-only antlr4-python3-runtime
@@ -67,7 +71,7 @@ jobs:
           # pyg-lib is not published on PyPI. Build the 0.8.0 release from its
           # pinned commit so CI does not depend on the data.pyg.org wheel host.
           python -m pip install --no-build-isolation -v "pyg_lib @ git+https://github.com/pyg-team/pyg-lib.git@26a2d1a06a4714da9bb804c19049afb4796971d7"
-          python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links https://data.pyg.org/whl/torch-2.14.0+cpu.html
+          python -m pip install --upgrade --no-build-isolation -v -r requirements-pyg.txt --find-links https://data.pyg.org/whl/torch-2.13.0+cpu.html
           python -m pip install --upgrade --no-build-isolation -v -r requirements-deepspeed.txt || echo "DeepSpeed installation failed, continuing without it"
       - name: Show installed packages
         run: |

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ PyTorch and PyTorch Geometric:
 > through 3.14**. Facility installation scripts default to Python 3.11 unless
 > documented otherwise for that system.
 
-The generic dependency baseline currently uses NumPy 2.4.6, PyTorch 2.13.0,
+The generic `install_dependencies.sh` baseline currently uses NumPy 2.4.6, PyTorch 2.13.0,
 torchvision 0.28.0, and PyTorch Geometric 2.8.0. HydraGNN accepts PyTorch 2.13
 or 2.14 so facility installers can retain their tested accelerator wheels. The
 requirements files are the authoritative source for the complete version set.

--- a/README.md
+++ b/README.md
@@ -28,13 +28,16 @@ Scalable PyTorch Implementation of Multi-Headed Graph Neural Networks
 
 ## Dependencies
 
-To install required packages with only basic capability (`torch`,
-`torch_geometric`, and related packages)
-and to serialize+store the processed data for later sessions (`pickle5`):
+To install the packages required for the core HydraGNN capability, including
+PyTorch and PyTorch Geometric:
 
 > **Python versions:** HydraGNN is tested and supported on **Python 3.11
 > through 3.14**. Facility installation scripts default to Python 3.11 unless
 > documented otherwise for that system.
+
+The generic dependency baseline currently uses NumPy 2.4.6, PyTorch 2.14.0,
+torchvision 0.29.0, and PyTorch Geometric 2.8.0. The requirements files are the
+authoritative source for the complete set of package versions.
 
 **Recommended approach - standard installation:**
 ```bash
@@ -42,15 +45,12 @@ and to serialize+store the processed data for later sessions (`pickle5`):
 pip install -r requirements.txt
 
 # Or use the installation script
-./install_dependencies.sh all
+./install_dependencies.sh
 ```
 
-**Alternative approach for reproducible installation:**
+**Alternative manual approach:**
 ```bash
-# Use the provided installation script
-./install_dependencies.sh
-
-# Or install manually with consistent settings:
+# Install manually with consistent settings:
 pip install --no-build-isolation -v -r requirements.txt
 ```
 
@@ -62,7 +62,7 @@ pip install -r requirements-base.txt
 # Add PyTorch
 pip install -r requirements-torch.txt
 
-# Add PyTorch Geometric  
+# Add PyTorch Geometric
 pip install -r requirements-pyg.txt
 
 # Add optional features (HPO, FAIRChem, etc.)
@@ -88,8 +88,14 @@ testing (`pytest`) the code:
 ```bash
 pip install -r requirements-dev.txt
 # Or with the script:
-./install_dependencies.sh all dev
+./install_dependencies.sh dev
+
+# Install development and optional dependencies together:
+./install_dependencies.sh all
 ```
+
+The script accepts `dev` and `optional` separately or together; `all` enables
+both groups. Unknown group names are rejected.
 
 Detailed dependency installation instructions are available on the
 [Wiki](https://github.com/ORNL/HydraGNN/wiki/Install)
@@ -102,7 +108,7 @@ data or numerical quality thresholds should first read
 
 ## Installation
 
-After checking out HydgraGNN, we recommend to install HydraGNN in a
+After checking out HydraGNN, we recommend installing HydraGNN in
 developer mode so that you can use the files in your current location
 and update them if needed:
 ```bash

--- a/README.md
+++ b/README.md
@@ -42,17 +42,17 @@ requirements files are the authoritative source for the complete version set.
 
 **Recommended approach - standard installation:**
 ```bash
-# Install all core dependencies (base + PyTorch + PyTorch Geometric)
-pip install -r requirements.txt
-
-# Or use the installation script
+# Install core, PyTorch, PyTorch Geometric, and model-specific dependencies
 ./install_dependencies.sh
 ```
 
 **Alternative manual approach:**
 ```bash
-# Install manually with consistent settings:
-pip install --no-build-isolation -v -r requirements.txt
+# Install the modular requirements in dependency order
+pip install --no-build-isolation -v -r requirements-base.txt
+pip install --no-build-isolation -v -r requirements-torch.txt
+pip install --no-build-isolation -v -r requirements-pyg.txt
+pip install -v -r requirements-specific-models.txt
 ```
 
 **Modular installation (choose what you need):**

--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ PyTorch and PyTorch Geometric:
 > through 3.14**. Facility installation scripts default to Python 3.11 unless
 > documented otherwise for that system.
 
-The generic dependency baseline currently uses NumPy 2.4.6, PyTorch 2.14.0,
-torchvision 0.29.0, and PyTorch Geometric 2.8.0. The requirements files are the
-authoritative source for the complete set of package versions.
+The generic dependency baseline currently uses NumPy 2.4.6, PyTorch 2.13.0,
+torchvision 0.28.0, and PyTorch Geometric 2.8.0. HydraGNN accepts PyTorch 2.13
+or 2.14 so facility installers can retain their tested accelerator wheels. The
+requirements files are the authoritative source for the complete version set.
 
 **Recommended approach - standard installation:**
 ```bash

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -46,9 +46,10 @@ HydraGNN uses a modular requirements system for flexible and reproducible instal
 > through 3.14**. Facility installation scripts default to Python 3.11 unless
 > documented otherwise for that system.
 
-The generic dependency baseline currently uses NumPy 2.4.6, PyTorch 2.14.0,
-torchvision 0.29.0, and PyTorch Geometric 2.8.0. Refer to the modular
-requirements files for the complete authoritative version set.
+The generic dependency baseline currently uses NumPy 2.4.6, PyTorch 2.13.0,
+torchvision 0.28.0, and PyTorch Geometric 2.8.0. HydraGNN accepts PyTorch 2.13
+or 2.14 so facility installers can retain their tested accelerator wheels.
+Refer to the modular requirements files for the authoritative version set.
 
 #### Recommended: Automated Installation
 ```bash
@@ -147,7 +148,7 @@ Tested installation scripts are organized by facility and system under
 
 - **Frontier** (AMD, ROCm 6.4, 7.1, 7.2, and 7.13)
 - **Aurora** (Intel XPU)
-- **Perlmutter** (NVIDIA A100; CUDA 13.0 and PyTorch 2.14 by default)
+- **Perlmutter** (NVIDIA A100; CUDA 13.0 and PyTorch 2.13 by default)
 - **Andes** (CPU)
 
 Use the facility installer instead of `requirements-torch.txt` when preparing

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -46,6 +46,10 @@ HydraGNN uses a modular requirements system for flexible and reproducible instal
 > through 3.14**. Facility installation scripts default to Python 3.11 unless
 > documented otherwise for that system.
 
+The generic dependency baseline currently uses NumPy 2.4.6, PyTorch 2.14.0,
+torchvision 0.29.0, and PyTorch Geometric 2.8.0. Refer to the modular
+requirements files for the complete authoritative version set.
+
 #### Recommended: Automated Installation
 ```bash
 ./install_dependencies.sh
@@ -54,15 +58,24 @@ This script installs the following requirements in order:
 - `requirements-base.txt`: Core Python dependencies for HydraGNN
 - `requirements-torch.txt`: PyTorch and related dependencies
 - `requirements-pyg.txt`: PyTorch Geometric and extensions
+- `requirements-specific-models.txt`: Dependencies used by supported model backbones
 
 You can also install development or optional dependencies:
 ```bash
 # For development tools (testing, linting, etc.)
 ./install_dependencies.sh dev
 
-# For all optional features (including development and extra packages)
-./install_dependencies.sh all optional
+# For optional dependencies only
+./install_dependencies.sh optional
+
+# For development and optional dependencies
+./install_dependencies.sh all
+
+# Equivalent explicit form
+./install_dependencies.sh dev optional
 ```
+
+Unknown dependency-group names are rejected.
 
 #### Manual Installation (Advanced)
 If you prefer, you can install requirements manually:
@@ -134,9 +147,19 @@ Tested installation scripts are organized by facility and system under
 
 - **Frontier** (AMD, ROCm 6.4, 7.1, 7.2, and 7.13)
 - **Aurora** (Intel XPU)
-- **Perlmutter** (NVIDIA)
-- **Andes** (NVIDIA)
-```
+- **Perlmutter** (NVIDIA A100; CUDA 13.0 and PyTorch 2.14 by default)
+- **Andes** (CPU)
+
+Use the facility installer instead of `requirements-torch.txt` when preparing
+an accelerator-specific environment. The facility scripts select wheels or
+framework modules compatible with that system. In particular, the Frontier
+ROCm 7.2 installer selects PyTorch 2.14 and torchvision 0.29 from the ROCm 7.2
+index, while Perlmutter selects their CUDA 13.0 (`cu130`) wheels. Do not run the
+generic PyTorch requirements afterward, because that can replace a functioning
+facility-specific wheel. HydraGNN does not require torchaudio.
+
+See [`scripts/hpc/README.md`](scripts/hpc/README.md) for the available scripts,
+defaults, and usage commands.
 
 ---
 

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -46,7 +46,7 @@ HydraGNN uses a modular requirements system for flexible and reproducible instal
 > through 3.14**. Facility installation scripts default to Python 3.11 unless
 > documented otherwise for that system.
 
-The generic dependency baseline currently uses NumPy 2.4.6, PyTorch 2.13.0,
+The generic `install_dependencies.sh` baseline uses NumPy 2.4.6, PyTorch 2.13.0,
 torchvision 0.28.0, and PyTorch Geometric 2.8.0. HydraGNN accepts PyTorch 2.13
 or 2.14 so facility installers can retain their tested accelerator wheels.
 Refer to the modular requirements files for the authoritative version set.

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -148,7 +148,7 @@ Tested installation scripts are organized by facility and system under
 
 - **Frontier** (AMD, ROCm 6.4, 7.1, 7.2, and 7.13)
 - **Aurora** (Intel XPU)
-- **Perlmutter** (NVIDIA A100; CUDA 13.0 and PyTorch 2.13 by default)
+- **Perlmutter** (NVIDIA A100; CUDA 13.0 and PyTorch 2.14 by default)
 - **Andes** (CPU)
 
 Use the facility installer instead of `requirements-torch.txt` when preparing

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -45,11 +45,6 @@ python -m pip install --no-build-isolation -v -r requirements-base.txt
 
 # Install PyTorch dependencies
 echo "Installing PyTorch dependencies..."
-GENERIC_TORCH_VERSION="${GENERIC_TORCH_VERSION:-2.13.0}"
-GENERIC_TORCHVISION_VERSION="${GENERIC_TORCHVISION_VERSION:-0.28.0}"
-python -m pip install --no-build-isolation -v \
-    "torch==${GENERIC_TORCH_VERSION}" \
-    "torchvision==${GENERIC_TORCHVISION_VERSION}"
 python -m pip install --no-build-isolation -v -r requirements-torch.txt
 
 # Install PyTorch Geometric dependencies

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -45,6 +45,11 @@ python -m pip install --no-build-isolation -v -r requirements-base.txt
 
 # Install PyTorch dependencies
 echo "Installing PyTorch dependencies..."
+GENERIC_TORCH_VERSION="${GENERIC_TORCH_VERSION:-2.13.0}"
+GENERIC_TORCHVISION_VERSION="${GENERIC_TORCHVISION_VERSION:-0.28.0}"
+python -m pip install --no-build-isolation -v \
+    "torch==${GENERIC_TORCH_VERSION}" \
+    "torchvision==${GENERIC_TORCHVISION_VERSION}"
 python -m pip install --no-build-isolation -v -r requirements-torch.txt
 
 # Install PyTorch Geometric dependencies

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -5,6 +5,28 @@
 
 set -e  # Exit on any error
 
+INSTALL_DEV=0
+INSTALL_OPTIONAL=0
+for group in "$@"; do
+    case "${group}" in
+        all)
+            INSTALL_DEV=1
+            INSTALL_OPTIONAL=1
+            ;;
+        dev)
+            INSTALL_DEV=1
+            ;;
+        optional)
+            INSTALL_OPTIONAL=1
+            ;;
+        *)
+            echo "Unknown dependency group: ${group}" >&2
+            echo "Usage: $0 [all|dev|optional] [...]" >&2
+            exit 2
+            ;;
+    esac
+done
+
 PYTHON_MINOR_VERSION=$(python -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 case "${PYTHON_MINOR_VERSION}" in
     3.11|3.12|3.13|3.14)
@@ -30,7 +52,7 @@ echo "Installing PyTorch Geometric dependencies..."
 python -m pip install --no-build-isolation -v -r requirements-pyg.txt
 
 # Install development dependencies (optional)
-if [ "$1" == "dev" ]; then
+if [ "${INSTALL_DEV}" -eq 1 ]; then
     echo "Installing development dependencies..."
     python -m pip install --no-build-isolation -v -r requirements-dev.txt
 fi
@@ -42,7 +64,7 @@ echo "Installing model-specific backbone dependencies..."
 python -m pip install -v -r requirements-specific-models.txt
 
 # Install optional dependencies (optional)
-if [ "$1" == "all" ] || [ "$2" == "optional" ]; then
+if [ "${INSTALL_OPTIONAL}" -eq 1 ]; then
     echo "Installing optional dependencies..."
     python -m pip install --no-build-isolation -v -r requirements-optional.txt
 fi

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,5 +1,5 @@
-torch==2.14.0
-torchvision==0.29.0
+torch>=2.13.0,<2.15
+torchvision>=0.28.0,<0.30
 e3nn==0.5.1
 torch-ema==0.3
 torchmetrics==1.4.0

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,5 +1,6 @@
-torch>=2.13.0,<2.15
-torchvision>=0.28.0,<0.30
+# torch/torchvision are installed explicitly by install_dependencies.sh and
+# facility installers; pinning them here too would create a second, driftable
+# source of truth for the same packages.
 e3nn==0.5.1
 torch-ema==0.3
 torchmetrics==1.4.0

--- a/requirements-torch.txt
+++ b/requirements-torch.txt
@@ -1,6 +1,5 @@
-# torch/torchvision are installed explicitly by install_dependencies.sh and
-# facility installers; pinning them here too would create a second, driftable
-# source of truth for the same packages.
+torch==2.13.0
+torchvision==0.28.0
 e3nn==0.5.1
 torch-ema==0.3
 torchmetrics==1.4.0

--- a/scripts/hpc/README.md
+++ b/scripts/hpc/README.md
@@ -21,7 +21,7 @@ environment-variable overrides near the top of the file.
 | System | Script | Accelerator dependency selection |
 | --- | --- | --- |
 | Aurora | `alcf/aurora/installation/install.sh` | PyTorch/XPU stack supplied by the ALCF `frameworks` module |
-| Perlmutter | `nersc/perlmutter/installation/install.sh` | CUDA 13.0 (`cu130`), PyTorch 2.14.0, torchvision 0.29.0 |
+| Perlmutter | `nersc/perlmutter/installation/install.sh` | CUDA 13.0 (`cu130`), PyTorch 2.13.0, torchvision 0.28.0 |
 | Andes | `olcf/andes/installation/install.sh` | CPU PyTorch wheel |
 | Andes (parallel) | `olcf/andes/installation/install-parallel.sh` | CPU PyTorch wheel with parallel source builds |
 | Frontier ROCm 6.4 | `olcf/frontier/installation/install-rocm64.sh` | PyTorch wheels from the ROCm 6.4 index |
@@ -37,9 +37,10 @@ scripts/hpc/nersc/perlmutter/installation/install.sh
 scripts/hpc/olcf/frontier/installation/install-rocm72.sh
 ```
 
-The generic requirements currently pin NumPy 2.4.6, PyTorch 2.14.0,
-torchvision 0.29.0, and PyTorch Geometric 2.8.0. Facility installers keep the
-shared Python dependencies aligned with those requirements but remain
+The generic installation currently selects NumPy 2.4.6, PyTorch 2.13.0,
+torchvision 0.28.0, and PyTorch Geometric 2.8.0. HydraGNN accepts PyTorch 2.13
+or 2.14 so facility installers can retain tested accelerator wheels. Facility
+installers keep shared Python dependencies aligned but remain
 authoritative for accelerator-specific PyTorch wheels and framework modules.
 Do not install `requirements-torch.txt` over an environment created by a
 facility installer. HydraGNN does not require torchaudio.

--- a/scripts/hpc/README.md
+++ b/scripts/hpc/README.md
@@ -21,7 +21,7 @@ environment-variable overrides near the top of the file.
 | System | Script | Accelerator dependency selection |
 | --- | --- | --- |
 | Aurora | `alcf/aurora/installation/install.sh` | PyTorch/XPU stack supplied by the ALCF `frameworks` module |
-| Perlmutter | `nersc/perlmutter/installation/install.sh` | CUDA 13.0 (`cu130`), PyTorch 2.13.0, torchvision 0.28.0 |
+| Perlmutter | `nersc/perlmutter/installation/install.sh` | CUDA 13.0 (`cu130`), PyTorch 2.14.0, torchvision 0.29.0 |
 | Andes | `olcf/andes/installation/install.sh` | CPU PyTorch wheel |
 | Andes (parallel) | `olcf/andes/installation/install-parallel.sh` | CPU PyTorch wheel with parallel source builds |
 | Frontier ROCm 6.4 | `olcf/frontier/installation/install-rocm64.sh` | PyTorch wheels from the ROCm 6.4 index |

--- a/scripts/hpc/README.md
+++ b/scripts/hpc/README.md
@@ -11,3 +11,35 @@ scripts, while `olcf/frontier/omnistat` contains the corresponding Omnistat
 collector configurations and `olcf/frontier/installation` contains installation
 scripts. Facility-wide helpers, such as `olcf/proxy-env.sh`, live at the facility
 level. Keep portable HydraGNN utilities outside this hierarchy.
+
+## Installation scripts
+
+Run an installation script from the HydraGNN repository root. Each script
+creates or reuses its own installation directory and documents supported
+environment-variable overrides near the top of the file.
+
+| System | Script | Accelerator dependency selection |
+| --- | --- | --- |
+| Aurora | `alcf/aurora/installation/install.sh` | PyTorch/XPU stack supplied by the ALCF `frameworks` module |
+| Perlmutter | `nersc/perlmutter/installation/install.sh` | CUDA 13.0 (`cu130`), PyTorch 2.14.0, torchvision 0.29.0 |
+| Andes | `olcf/andes/installation/install.sh` | CPU PyTorch wheel |
+| Andes (parallel) | `olcf/andes/installation/install-parallel.sh` | CPU PyTorch wheel with parallel source builds |
+| Frontier ROCm 6.4 | `olcf/frontier/installation/install-rocm64.sh` | PyTorch wheels from the ROCm 6.4 index |
+| Frontier ROCm 6.4 (parallel) | `olcf/frontier/installation/install-parallel-rocm64.sh` | PyTorch wheels from the ROCm 6.4 index with parallel source builds |
+| Frontier ROCm 7.1 | `olcf/frontier/installation/install-rocm71.sh` | PyTorch wheels from the ROCm 7.1 index |
+| Frontier ROCm 7.2 | `olcf/frontier/installation/install-rocm72.sh` | PyTorch 2.14.0 and torchvision 0.29.0 from the ROCm 7.2 index |
+| Frontier ROCm 7.13 | `olcf/frontier/installation/install-rocm713.sh` | Platform-tested ROCm 7.13 PyTorch wheel set |
+
+For example:
+
+```bash
+scripts/hpc/nersc/perlmutter/installation/install.sh
+scripts/hpc/olcf/frontier/installation/install-rocm72.sh
+```
+
+The generic requirements currently pin NumPy 2.4.6, PyTorch 2.14.0,
+torchvision 0.29.0, and PyTorch Geometric 2.8.0. Facility installers keep the
+shared Python dependencies aligned with those requirements but remain
+authoritative for accelerator-specific PyTorch wheels and framework modules.
+Do not install `requirements-torch.txt` over an environment created by a
+facility installer. HydraGNN does not require torchaudio.

--- a/scripts/hpc/README.md
+++ b/scripts/hpc/README.md
@@ -20,15 +20,15 @@ environment-variable overrides near the top of the file.
 
 | System | Script | Accelerator dependency selection |
 | --- | --- | --- |
-| Aurora | `alcf/aurora/installation/install.sh` | PyTorch/XPU stack supplied by the ALCF `frameworks` module |
-| Perlmutter | `nersc/perlmutter/installation/install.sh` | CUDA 13.0 (`cu130`), PyTorch 2.14.0, torchvision 0.29.0 |
-| Andes | `olcf/andes/installation/install.sh` | CPU PyTorch wheel |
-| Andes (parallel) | `olcf/andes/installation/install-parallel.sh` | CPU PyTorch wheel with parallel source builds |
-| Frontier ROCm 6.4 | `olcf/frontier/installation/install-rocm64.sh` | PyTorch wheels from the ROCm 6.4 index |
-| Frontier ROCm 6.4 (parallel) | `olcf/frontier/installation/install-parallel-rocm64.sh` | PyTorch wheels from the ROCm 6.4 index with parallel source builds |
-| Frontier ROCm 7.1 | `olcf/frontier/installation/install-rocm71.sh` | PyTorch wheels from the ROCm 7.1 index |
-| Frontier ROCm 7.2 | `olcf/frontier/installation/install-rocm72.sh` | PyTorch 2.14.0 and torchvision 0.29.0 from the ROCm 7.2 index |
-| Frontier ROCm 7.13 | `olcf/frontier/installation/install-rocm713.sh` | Platform-tested ROCm 7.13 PyTorch wheel set |
+| Aurora | `scripts/hpc/alcf/aurora/installation/install.sh` | PyTorch/XPU stack supplied by the ALCF `frameworks` module |
+| Perlmutter | `scripts/hpc/nersc/perlmutter/installation/install.sh` | CUDA 13.0 (`cu130`), PyTorch 2.14.0, torchvision 0.29.0 |
+| Andes | `scripts/hpc/olcf/andes/installation/install.sh` | CPU PyTorch wheel |
+| Andes (parallel) | `scripts/hpc/olcf/andes/installation/install-parallel.sh` | CPU PyTorch wheel with parallel source builds |
+| Frontier ROCm 6.4 | `scripts/hpc/olcf/frontier/installation/install-rocm64.sh` | PyTorch wheels from the ROCm 6.4 index |
+| Frontier ROCm 6.4 (parallel) | `scripts/hpc/olcf/frontier/installation/install-parallel-rocm64.sh` | PyTorch wheels from the ROCm 6.4 index with parallel source builds |
+| Frontier ROCm 7.1 | `scripts/hpc/olcf/frontier/installation/install-rocm71.sh` | PyTorch wheels from the ROCm 7.1 index |
+| Frontier ROCm 7.2 | `scripts/hpc/olcf/frontier/installation/install-rocm72.sh` | PyTorch 2.14.0 and torchvision 0.29.0 from the ROCm 7.2 index |
+| Frontier ROCm 7.13 | `scripts/hpc/olcf/frontier/installation/install-rocm713.sh` | Platform-tested ROCm 7.13 PyTorch wheel set |
 
 For example:
 

--- a/scripts/hpc/README.md
+++ b/scripts/hpc/README.md
@@ -37,7 +37,7 @@ scripts/hpc/nersc/perlmutter/installation/install.sh
 scripts/hpc/olcf/frontier/installation/install-rocm72.sh
 ```
 
-The generic installation currently selects NumPy 2.4.6, PyTorch 2.13.0,
+The generic `install_dependencies.sh` installation selects NumPy 2.4.6, PyTorch 2.13.0,
 torchvision 0.28.0, and PyTorch Geometric 2.8.0. HydraGNN accepts PyTorch 2.13
 or 2.14 so facility installers can retain tested accelerator wheels. Facility
 installers keep shared Python dependencies aligned but remain

--- a/scripts/hpc/nersc/perlmutter/installation/install.sh
+++ b/scripts/hpc/nersc/perlmutter/installation/install.sh
@@ -18,8 +18,8 @@
 #   PYTHON_VERSION=3.11
 #   EXPECTED_CUDA_MM=13.0
 #   TORCH_CUDA_TAG=cu130
-#   TORCH_VERSION=2.13.0
-#   TORCHVISION_VERSION=0.28.0
+#   TORCH_VERSION=2.14.0
+#   TORCHVISION_VERSION=0.29.0
 #   BUILD_PYG_LIB=0   # default 0 (skip pyg-lib). set 1 to try building from source.
 #   TORCH_CUDA_ARCH_LIST=8.0
 #   MAX_JOBS=16
@@ -197,8 +197,8 @@ banner "Install CUDA PyTorch (Before PyG)"
 # Match cudatoolkit/13.0 => cu130 wheels. Pin the package versions so the
 # platform installer remains consistent with requirements-torch.txt.
 TORCH_CUDA_TAG="${TORCH_CUDA_TAG:-cu130}"
-TORCH_VERSION="${TORCH_VERSION:-2.13.0}"
-TORCHVISION_VERSION="${TORCHVISION_VERSION:-0.28.0}"
+TORCH_VERSION="${TORCH_VERSION:-2.14.0}"
+TORCHVISION_VERSION="${TORCHVISION_VERSION:-0.29.0}"
 PYTORCH_INDEX_URL="https://download.pytorch.org/whl/${TORCH_CUDA_TAG}"
 
 subbanner "Install PyTorch from ${PYTORCH_INDEX_URL}"

--- a/scripts/hpc/nersc/perlmutter/installation/install.sh
+++ b/scripts/hpc/nersc/perlmutter/installation/install.sh
@@ -18,8 +18,8 @@
 #   PYTHON_VERSION=3.11
 #   EXPECTED_CUDA_MM=13.0
 #   TORCH_CUDA_TAG=cu130
-#   TORCH_VERSION=2.14.0
-#   TORCHVISION_VERSION=0.29.0
+#   TORCH_VERSION=2.13.0
+#   TORCHVISION_VERSION=0.28.0
 #   BUILD_PYG_LIB=0   # default 0 (skip pyg-lib). set 1 to try building from source.
 #   TORCH_CUDA_ARCH_LIST=8.0
 #   MAX_JOBS=16
@@ -197,8 +197,8 @@ banner "Install CUDA PyTorch (Before PyG)"
 # Match cudatoolkit/13.0 => cu130 wheels. Pin the package versions so the
 # platform installer remains consistent with requirements-torch.txt.
 TORCH_CUDA_TAG="${TORCH_CUDA_TAG:-cu130}"
-TORCH_VERSION="${TORCH_VERSION:-2.14.0}"
-TORCHVISION_VERSION="${TORCHVISION_VERSION:-0.29.0}"
+TORCH_VERSION="${TORCH_VERSION:-2.13.0}"
+TORCHVISION_VERSION="${TORCHVISION_VERSION:-0.28.0}"
 PYTORCH_INDEX_URL="https://download.pytorch.org/whl/${TORCH_CUDA_TAG}"
 
 subbanner "Install PyTorch from ${PYTORCH_INDEX_URL}"

--- a/scripts/hpc/nersc/perlmutter/installation/module-loads.sh
+++ b/scripts/hpc/nersc/perlmutter/installation/module-loads.sh
@@ -10,12 +10,15 @@
 MODULES_SH_PATH="${MODULES_SH_PATH:-/etc/profile.d/modules.sh}"
 LMOD_INIT_BASH_PATH="${LMOD_INIT_BASH_PATH:-/usr/share/lmod/lmod/init/bash}"
 MODULES_INIT_BASH_PATH="${MODULES_INIT_BASH_PATH:-/usr/share/Modules/init/bash}"
-PERLMUTTER_LMOD_RESTORE_PATH="${PERLMUTTER_LMOD_RESTORE_PATH:-/opt/cray/pe/cpe/24.07/restore_lmod_system_defaults.sh}"
+PERLMUTTER_LMOD_RESTORE_PATH="${PERLMUTTER_LMOD_RESTORE_PATH:-/opt/cray/pe/cpe/26.03/restore_lmod_system_defaults.sh}"
 
 PERLMUTTER_NERSC_DEFAULT_MODULE="${PERLMUTTER_NERSC_DEFAULT_MODULE:-nersc-default/1.0}"
-PERLMUTTER_CPE_MODULE="${PERLMUTTER_CPE_MODULE:-cpe/24.07}"
-PERLMUTTER_PRGENV_MODULE="${PERLMUTTER_PRGENV_MODULE:-PrgEnv-gnu/8.5.0}"
-PERLMUTTER_MPICH_MODULE="${PERLMUTTER_MPICH_MODULE:-cray-mpich/8.1.30}"
+PERLMUTTER_CPE_MODULE="${PERLMUTTER_CPE_MODULE:-cpe/26.03}"
+PERLMUTTER_PRGENV_MODULE="${PERLMUTTER_PRGENV_MODULE:-PrgEnv-gnu/8.7.0}"
+# cray-mpich/8.1.30's GTL library (libmpi_gtl_cuda.so) links against libcudart.so.12,
+# which is incompatible with cudatoolkit/13.0 (needed for torch 2.14/cu130) and breaks
+# the mpi4py build. cray-mpich/9.1.0's GTL library links against libcudart.so.13.
+PERLMUTTER_MPICH_MODULE="${PERLMUTTER_MPICH_MODULE:-cray-mpich/9.1.0}"
 PERLMUTTER_ACCEL_MODULE="${PERLMUTTER_ACCEL_MODULE:-craype-accel-nvidia80}"
 PERLMUTTER_GCC_MODULE="${PERLMUTTER_GCC_MODULE:-gcc-native/13.2}"
 PERLMUTTER_CMAKE_PRIMARY_MODULE="${PERLMUTTER_CMAKE_PRIMARY_MODULE:-cmake/3.30.2}"


### PR DESCRIPTION
## Summary
- document the current NumPy 2.4.6, PyTorch 2.13.0, torchvision 0.28.0, and PyG 2.8.0 baseline
- document accelerator-specific installation policy and current HPC installer matrix
- add Perlmutter CUDA 13.0 and Frontier ROCm 7.2 wheel details
- clarify that HydraGNN does not require torchaudio
- remove obsolete `pickle5` text, a stale typo, and an unmatched Markdown fence
- make `install_dependencies.sh` dependency-group handling match its documentation

## Installer CLI behavior
- no arguments: core and model-specific dependencies
- `dev`: development dependencies
- `optional`: optional dependencies
- `all`: development and optional dependencies
- multiple explicit groups are supported; unknown groups fail with usage information

## Validation
- `bash -n install_dependencies.sh`
- `bash -n` for every HPC installation script
- invalid-group behavior returns exit status 2 before installation
- `git diff --check`
- stale documentation-reference audit