### PR TITLE
models: use .get() with defaults for allscaip_*/uma_* Architecture keys

### DIFF
--- a/hydragnn/architecture_defaults.py
+++ b/hydragnn/architecture_defaults.py
@@ -1,0 +1,47 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+"""Shared defaults for optional model-specific architecture settings."""
+
+MODEL_SPECIFIC_ARCHITECTURE_DEFAULTS = {
+    "allscaip_num_heads": 8,
+    "allscaip_freq_list": None,
+    "allscaip_atten_name": "math",
+    "allscaip_use_node_path": True,
+    "allscaip_use_sincx_mask": True,
+    "allscaip_use_freq_mask": True,
+    "allscaip_max_num_elements": 119,
+    "allscaip_knn_soft": True,
+    "allscaip_distance_function": "gaussian",
+    "allscaip_normalization": "rmsnorm",
+    "allscaip_mlp_dropout": 0.0,
+    "allscaip_atten_dropout": 0.0,
+    "allscaip_use_residual_scaling": True,
+    "allscaip_regress_stress": False,
+    "allscaip_use_chunked_graph": False,
+    "allscaip_graph_chunk_size": 512,
+    "allscaip_knn_use_low_mem": True,
+    "allscaip_dataset_list": [],
+    "uma_mmax": 2,
+    "uma_grid_resolution": None,
+    "uma_edge_channels": 128,
+    "uma_hidden_channels": None,
+    "uma_norm_type": "rms_norm_sh",
+    "uma_ff_type": "grid",
+    "uma_use_chg_spin": False,
+    "uma_max_num_elements": 100,
+    "uma_variant": "S",
+    "uma_num_experts": None,
+    "uma_moe_dropout": 0.0,
+    "uma_use_composition_embedding": False,
+    "uma_equivariant_vector_head": False,
+    "uma_vector_head_index": None,
+}

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -127,22 +127,38 @@ def create_model_config(
             "equivariant_attn_periodic_replication", 1
         ),
         # AllScAIP-specific
-        allscaip_num_heads=config["Architecture"]["allscaip_num_heads"],
-        allscaip_freq_list=config["Architecture"]["allscaip_freq_list"],
-        allscaip_atten_name=config["Architecture"]["allscaip_atten_name"],
-        allscaip_use_node_path=config["Architecture"]["allscaip_use_node_path"],
-        allscaip_use_sincx_mask=config["Architecture"]["allscaip_use_sincx_mask"],
-        allscaip_use_freq_mask=config["Architecture"]["allscaip_use_freq_mask"],
-        allscaip_max_num_elements=config["Architecture"]["allscaip_max_num_elements"],
-        allscaip_knn_soft=config["Architecture"]["allscaip_knn_soft"],
-        allscaip_distance_function=config["Architecture"]["allscaip_distance_function"],
-        allscaip_normalization=config["Architecture"]["allscaip_normalization"],
-        allscaip_mlp_dropout=config["Architecture"]["allscaip_mlp_dropout"],
-        allscaip_atten_dropout=config["Architecture"]["allscaip_atten_dropout"],
-        allscaip_use_residual_scaling=config["Architecture"][
-            "allscaip_use_residual_scaling"
-        ],
-        allscaip_regress_stress=config["Architecture"]["allscaip_regress_stress"],
+        allscaip_num_heads=config["Architecture"].get("allscaip_num_heads", 8),
+        allscaip_freq_list=config["Architecture"].get("allscaip_freq_list", None),
+        allscaip_atten_name=config["Architecture"].get("allscaip_atten_name", "math"),
+        allscaip_use_node_path=config["Architecture"].get(
+            "allscaip_use_node_path", True
+        ),
+        allscaip_use_sincx_mask=config["Architecture"].get(
+            "allscaip_use_sincx_mask", True
+        ),
+        allscaip_use_freq_mask=config["Architecture"].get(
+            "allscaip_use_freq_mask", True
+        ),
+        allscaip_max_num_elements=config["Architecture"].get(
+            "allscaip_max_num_elements", 119
+        ),
+        allscaip_knn_soft=config["Architecture"].get("allscaip_knn_soft", True),
+        allscaip_distance_function=config["Architecture"].get(
+            "allscaip_distance_function", "gaussian"
+        ),
+        allscaip_normalization=config["Architecture"].get(
+            "allscaip_normalization", "rmsnorm"
+        ),
+        allscaip_mlp_dropout=config["Architecture"].get("allscaip_mlp_dropout", 0.0),
+        allscaip_atten_dropout=config["Architecture"].get(
+            "allscaip_atten_dropout", 0.0
+        ),
+        allscaip_use_residual_scaling=config["Architecture"].get(
+            "allscaip_use_residual_scaling", True
+        ),
+        allscaip_regress_stress=config["Architecture"].get(
+            "allscaip_regress_stress", False
+        ),
         allscaip_use_chunked_graph=config["Architecture"].get(
             "allscaip_use_chunked_graph", False
         ),
@@ -152,26 +168,28 @@ def create_model_config(
         allscaip_knn_use_low_mem=config["Architecture"].get(
             "allscaip_knn_use_low_mem", True
         ),
-        allscaip_dataset_list=config["Architecture"]["allscaip_dataset_list"],
+        allscaip_dataset_list=config["Architecture"].get("allscaip_dataset_list", []),
         # UMA-specific
-        uma_mmax=config["Architecture"]["uma_mmax"],
-        uma_grid_resolution=config["Architecture"]["uma_grid_resolution"],
-        uma_edge_channels=config["Architecture"]["uma_edge_channels"],
-        uma_hidden_channels=config["Architecture"]["uma_hidden_channels"],
-        uma_norm_type=config["Architecture"]["uma_norm_type"],
-        uma_ff_type=config["Architecture"]["uma_ff_type"],
-        uma_use_chg_spin=config["Architecture"]["uma_use_chg_spin"],
-        uma_max_num_elements=config["Architecture"]["uma_max_num_elements"],
-        uma_variant=config["Architecture"]["uma_variant"],
-        uma_num_experts=config["Architecture"]["uma_num_experts"],
-        uma_moe_dropout=config["Architecture"]["uma_moe_dropout"],
-        uma_use_composition_embedding=config["Architecture"][
-            "uma_use_composition_embedding"
-        ],
-        uma_equivariant_vector_head=config["Architecture"][
-            "uma_equivariant_vector_head"
-        ],
-        uma_vector_head_index=config["Architecture"]["uma_vector_head_index"],
+        uma_mmax=config["Architecture"].get("uma_mmax", 2),
+        uma_grid_resolution=config["Architecture"].get("uma_grid_resolution", None),
+        uma_edge_channels=config["Architecture"].get("uma_edge_channels", 128),
+        uma_hidden_channels=config["Architecture"].get("uma_hidden_channels", None),
+        uma_norm_type=config["Architecture"].get("uma_norm_type", "rms_norm_sh"),
+        uma_ff_type=config["Architecture"].get("uma_ff_type", "grid"),
+        uma_use_chg_spin=config["Architecture"].get("uma_use_chg_spin", False),
+        uma_max_num_elements=config["Architecture"].get("uma_max_num_elements", 100),
+        uma_variant=config["Architecture"].get("uma_variant", "S"),
+        uma_num_experts=config["Architecture"].get("uma_num_experts", None),
+        uma_moe_dropout=config["Architecture"].get("uma_moe_dropout", 0.0),
+        uma_use_composition_embedding=config["Architecture"].get(
+            "uma_use_composition_embedding", False
+        ),
+        uma_equivariant_vector_head=config["Architecture"].get(
+            "uma_equivariant_vector_head", False
+        ),
+        uma_vector_head_index=config["Architecture"].get(
+            "uma_vector_head_index", None
+        ),
         verbosity=verbosity,
         use_gpu=use_gpu,
     )

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -16,6 +16,7 @@ from typing import List, Union
 
 import torch_scatter
 
+from hydragnn.architecture_defaults import MODEL_SPECIFIC_ARCHITECTURE_DEFAULTS
 from hydragnn.models.Base import Base
 from hydragnn.models.GINStack import GINStack
 from hydragnn.models.PNAStack import PNAStack
@@ -45,6 +46,7 @@ def create_model_config(
     verbosity: int = 0,
     use_gpu: bool = True,
 ):
+    model_defaults = MODEL_SPECIFIC_ARCHITECTURE_DEFAULTS
     model = create_model(
         mpnn_type=config["Architecture"]["mpnn_type"],
         input_dim=config["Architecture"]["input_dim"],
@@ -127,68 +129,105 @@ def create_model_config(
             "equivariant_attn_periodic_replication", 1
         ),
         # AllScAIP-specific
-        allscaip_num_heads=config["Architecture"].get("allscaip_num_heads", 8),
-        allscaip_freq_list=config["Architecture"].get("allscaip_freq_list", None),
-        allscaip_atten_name=config["Architecture"].get("allscaip_atten_name", "math"),
+        allscaip_num_heads=config["Architecture"].get(
+            "allscaip_num_heads", model_defaults["allscaip_num_heads"]
+        ),
+        allscaip_freq_list=config["Architecture"].get(
+            "allscaip_freq_list", model_defaults["allscaip_freq_list"]
+        ),
+        allscaip_atten_name=config["Architecture"].get(
+            "allscaip_atten_name", model_defaults["allscaip_atten_name"]
+        ),
         allscaip_use_node_path=config["Architecture"].get(
-            "allscaip_use_node_path", True
+            "allscaip_use_node_path", model_defaults["allscaip_use_node_path"]
         ),
         allscaip_use_sincx_mask=config["Architecture"].get(
-            "allscaip_use_sincx_mask", True
+            "allscaip_use_sincx_mask", model_defaults["allscaip_use_sincx_mask"]
         ),
         allscaip_use_freq_mask=config["Architecture"].get(
-            "allscaip_use_freq_mask", True
+            "allscaip_use_freq_mask", model_defaults["allscaip_use_freq_mask"]
         ),
         allscaip_max_num_elements=config["Architecture"].get(
-            "allscaip_max_num_elements", 119
+            "allscaip_max_num_elements",
+            model_defaults["allscaip_max_num_elements"],
         ),
-        allscaip_knn_soft=config["Architecture"].get("allscaip_knn_soft", True),
+        allscaip_knn_soft=config["Architecture"].get(
+            "allscaip_knn_soft", model_defaults["allscaip_knn_soft"]
+        ),
         allscaip_distance_function=config["Architecture"].get(
-            "allscaip_distance_function", "gaussian"
+            "allscaip_distance_function",
+            model_defaults["allscaip_distance_function"],
         ),
         allscaip_normalization=config["Architecture"].get(
-            "allscaip_normalization", "rmsnorm"
+            "allscaip_normalization", model_defaults["allscaip_normalization"]
         ),
-        allscaip_mlp_dropout=config["Architecture"].get("allscaip_mlp_dropout", 0.0),
+        allscaip_mlp_dropout=config["Architecture"].get(
+            "allscaip_mlp_dropout", model_defaults["allscaip_mlp_dropout"]
+        ),
         allscaip_atten_dropout=config["Architecture"].get(
-            "allscaip_atten_dropout", 0.0
+            "allscaip_atten_dropout", model_defaults["allscaip_atten_dropout"]
         ),
         allscaip_use_residual_scaling=config["Architecture"].get(
-            "allscaip_use_residual_scaling", True
+            "allscaip_use_residual_scaling",
+            model_defaults["allscaip_use_residual_scaling"],
         ),
         allscaip_regress_stress=config["Architecture"].get(
-            "allscaip_regress_stress", False
+            "allscaip_regress_stress", model_defaults["allscaip_regress_stress"]
         ),
         allscaip_use_chunked_graph=config["Architecture"].get(
-            "allscaip_use_chunked_graph", False
+            "allscaip_use_chunked_graph", model_defaults["allscaip_use_chunked_graph"]
         ),
         allscaip_graph_chunk_size=config["Architecture"].get(
-            "allscaip_graph_chunk_size", 512
+            "allscaip_graph_chunk_size", model_defaults["allscaip_graph_chunk_size"]
         ),
         allscaip_knn_use_low_mem=config["Architecture"].get(
-            "allscaip_knn_use_low_mem", True
+            "allscaip_knn_use_low_mem", model_defaults["allscaip_knn_use_low_mem"]
         ),
-        allscaip_dataset_list=config["Architecture"].get("allscaip_dataset_list", []),
+        allscaip_dataset_list=config["Architecture"].get(
+            "allscaip_dataset_list", model_defaults["allscaip_dataset_list"].copy()
+        ),
         # UMA-specific
-        uma_mmax=config["Architecture"].get("uma_mmax", 2),
-        uma_grid_resolution=config["Architecture"].get("uma_grid_resolution", None),
-        uma_edge_channels=config["Architecture"].get("uma_edge_channels", 128),
-        uma_hidden_channels=config["Architecture"].get("uma_hidden_channels", None),
-        uma_norm_type=config["Architecture"].get("uma_norm_type", "rms_norm_sh"),
-        uma_ff_type=config["Architecture"].get("uma_ff_type", "grid"),
-        uma_use_chg_spin=config["Architecture"].get("uma_use_chg_spin", False),
-        uma_max_num_elements=config["Architecture"].get("uma_max_num_elements", 100),
-        uma_variant=config["Architecture"].get("uma_variant", "S"),
-        uma_num_experts=config["Architecture"].get("uma_num_experts", None),
-        uma_moe_dropout=config["Architecture"].get("uma_moe_dropout", 0.0),
+        uma_mmax=config["Architecture"].get("uma_mmax", model_defaults["uma_mmax"]),
+        uma_grid_resolution=config["Architecture"].get(
+            "uma_grid_resolution", model_defaults["uma_grid_resolution"]
+        ),
+        uma_edge_channels=config["Architecture"].get(
+            "uma_edge_channels", model_defaults["uma_edge_channels"]
+        ),
+        uma_hidden_channels=config["Architecture"].get(
+            "uma_hidden_channels", model_defaults["uma_hidden_channels"]
+        ),
+        uma_norm_type=config["Architecture"].get(
+            "uma_norm_type", model_defaults["uma_norm_type"]
+        ),
+        uma_ff_type=config["Architecture"].get(
+            "uma_ff_type", model_defaults["uma_ff_type"]
+        ),
+        uma_use_chg_spin=config["Architecture"].get(
+            "uma_use_chg_spin", model_defaults["uma_use_chg_spin"]
+        ),
+        uma_max_num_elements=config["Architecture"].get(
+            "uma_max_num_elements", model_defaults["uma_max_num_elements"]
+        ),
+        uma_variant=config["Architecture"].get(
+            "uma_variant", model_defaults["uma_variant"]
+        ),
+        uma_num_experts=config["Architecture"].get(
+            "uma_num_experts", model_defaults["uma_num_experts"]
+        ),
+        uma_moe_dropout=config["Architecture"].get(
+            "uma_moe_dropout", model_defaults["uma_moe_dropout"]
+        ),
         uma_use_composition_embedding=config["Architecture"].get(
-            "uma_use_composition_embedding", False
+            "uma_use_composition_embedding",
+            model_defaults["uma_use_composition_embedding"],
         ),
         uma_equivariant_vector_head=config["Architecture"].get(
-            "uma_equivariant_vector_head", False
+            "uma_equivariant_vector_head",
+            model_defaults["uma_equivariant_vector_head"],
         ),
         uma_vector_head_index=config["Architecture"].get(
-            "uma_vector_head_index", None
+            "uma_vector_head_index", model_defaults["uma_vector_head_index"]
         ),
         verbosity=verbosity,
         use_gpu=use_gpu,

--- a/hydragnn/utils/input_config_parsing/config_utils.py
+++ b/hydragnn/utils/input_config_parsing/config_utils.py
@@ -23,6 +23,7 @@ import hashlib
 import re
 import torch
 
+from hydragnn.architecture_defaults import MODEL_SPECIFIC_ARCHITECTURE_DEFAULTS
 from .variable_schema import get_variable_schema, schema_dimensions
 
 _UNSAFE_LOG_COMPONENT = re.compile(r"[^A-Za-z0-9._-]+")
@@ -189,72 +190,10 @@ def update_config(config, train_loader, val_loader, test_loader):
         config["NeuralNetwork"]["Architecture"]["node_max_ell"] = None
     if "enable_interatomic_potential" not in config["NeuralNetwork"]["Architecture"]:
         config["NeuralNetwork"]["Architecture"]["enable_interatomic_potential"] = False
-    # AllScAIP-specific defaults (used by AllScAIPStack via create_model).
-    # Backbone depth is taken from the standard ``num_conv_layers`` key.
-    if "allscaip_num_heads" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_num_heads"] = 8
-    if "allscaip_freq_list" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_freq_list"] = None
-    if "allscaip_atten_name" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_atten_name"] = "math"
-    if "allscaip_use_node_path" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_use_node_path"] = True
-    if "allscaip_use_sincx_mask" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_use_sincx_mask"] = True
-    if "allscaip_use_freq_mask" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_use_freq_mask"] = True
-    if "allscaip_max_num_elements" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_max_num_elements"] = 119
-    if "allscaip_knn_soft" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_knn_soft"] = True
-    if "allscaip_distance_function" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"][
-            "allscaip_distance_function"
-        ] = "gaussian"
-    if "allscaip_normalization" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_normalization"] = "rmsnorm"
-    if "allscaip_mlp_dropout" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_mlp_dropout"] = 0.0
-    if "allscaip_atten_dropout" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_atten_dropout"] = 0.0
-    if "allscaip_use_residual_scaling" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_use_residual_scaling"] = True
-    if "allscaip_regress_stress" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_regress_stress"] = False
-    if "allscaip_dataset_list" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["allscaip_dataset_list"] = []
-
-    # UMA-specific defaults (used by UMAStack via create_model).
-    if "uma_mmax" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_mmax"] = 2
-    if "uma_grid_resolution" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_grid_resolution"] = None
-    if "uma_edge_channels" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_edge_channels"] = 128
-    if "uma_hidden_channels" not in config["NeuralNetwork"]["Architecture"]:
-        # Default to None so UMAStack falls back to hidden_dim (sphere_channels).
-        config["NeuralNetwork"]["Architecture"]["uma_hidden_channels"] = None
-    if "uma_norm_type" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_norm_type"] = "rms_norm_sh"
-    if "uma_ff_type" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_ff_type"] = "grid"
-    if "uma_use_chg_spin" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_use_chg_spin"] = False
-    if "uma_max_num_elements" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_max_num_elements"] = 100
-    if "uma_variant" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_variant"] = "S"
-    if "uma_num_experts" not in config["NeuralNetwork"]["Architecture"]:
-        # None -> UMAStack picks the per-variant default (M=8, L=32; S=0).
-        config["NeuralNetwork"]["Architecture"]["uma_num_experts"] = None
-    if "uma_moe_dropout" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_moe_dropout"] = 0.0
-    if "uma_use_composition_embedding" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_use_composition_embedding"] = False
-    if "uma_equivariant_vector_head" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_equivariant_vector_head"] = False
-    if "uma_vector_head_index" not in config["NeuralNetwork"]["Architecture"]:
-        config["NeuralNetwork"]["Architecture"]["uma_vector_head_index"] = None
+    # Model-specific defaults are shared with create_model_config so callers
+    # that bypass this normalization path receive the same values.
+    for key, value in MODEL_SPECIFIC_ARCHITECTURE_DEFAULTS.items():
+        architecture.setdefault(key, deepcopy(value))
 
     config["NeuralNetwork"]["Architecture"] = update_config_edge_dim(
         config["NeuralNetwork"]["Architecture"]

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -11,6 +11,7 @@
 
 from unittest.mock import Mock, patch
 
+from hydragnn.architecture_defaults import MODEL_SPECIFIC_ARCHITECTURE_DEFAULTS
 from hydragnn.models.create import create_model_config
 
 
@@ -72,38 +73,5 @@ def test_create_model_config_accepts_legacy_model_specific_keys():
 
     assert result is model.to.return_value
     kwargs = create_model.call_args.kwargs
-    expected_defaults = {
-        "allscaip_num_heads": 8,
-        "allscaip_freq_list": None,
-        "allscaip_atten_name": "math",
-        "allscaip_use_node_path": True,
-        "allscaip_use_sincx_mask": True,
-        "allscaip_use_freq_mask": True,
-        "allscaip_max_num_elements": 119,
-        "allscaip_knn_soft": True,
-        "allscaip_distance_function": "gaussian",
-        "allscaip_normalization": "rmsnorm",
-        "allscaip_mlp_dropout": 0.0,
-        "allscaip_atten_dropout": 0.0,
-        "allscaip_use_residual_scaling": True,
-        "allscaip_regress_stress": False,
-        "allscaip_use_chunked_graph": False,
-        "allscaip_graph_chunk_size": 512,
-        "allscaip_knn_use_low_mem": True,
-        "allscaip_dataset_list": [],
-        "uma_mmax": 2,
-        "uma_grid_resolution": None,
-        "uma_edge_channels": 128,
-        "uma_hidden_channels": None,
-        "uma_norm_type": "rms_norm_sh",
-        "uma_ff_type": "grid",
-        "uma_use_chg_spin": False,
-        "uma_max_num_elements": 100,
-        "uma_variant": "S",
-        "uma_num_experts": None,
-        "uma_moe_dropout": 0.0,
-        "uma_use_composition_embedding": False,
-        "uma_equivariant_vector_head": False,
-        "uma_vector_head_index": None,
-    }
+    expected_defaults = MODEL_SPECIFIC_ARCHITECTURE_DEFAULTS
     assert {key: kwargs[key] for key in expected_defaults} == expected_defaults

--- a/tests/test_create_model.py
+++ b/tests/test_create_model.py
@@ -1,0 +1,109 @@
+##############################################################################
+# Copyright (c) 2026, Oak Ridge National Laboratory                          #
+# All rights reserved.                                                       #
+#                                                                            #
+# This file is part of HydraGNN and is distributed under a BSD 3-clause      #
+# license. For the licensing terms see the LICENSE file in the top-level     #
+# directory.                                                                 #
+#                                                                            #
+# SPDX-License-Identifier: BSD-3-Clause                                      #
+##############################################################################
+
+from unittest.mock import Mock, patch
+
+from hydragnn.models.create import create_model_config
+
+
+def test_create_model_config_accepts_legacy_model_specific_keys():
+    """Older configs need not contain options added for newer model families."""
+    architecture = {
+        "mpnn_type": "PNA",
+        "input_dim": 1,
+        "hidden_dim": 8,
+        "output_dim": [1],
+        "pe_dim": 0,
+        "global_attn_engine": None,
+        "global_attn_type": None,
+        "global_attn_heads": 1,
+        "output_type": ["graph"],
+        "output_heads": {},
+        "activation_function": "relu",
+        "task_weights": [1.0],
+        "num_conv_layers": 2,
+        "freeze_conv_layers": False,
+        "initial_bias": None,
+        "num_nodes": None,
+        "max_neighbours": 16,
+        "edge_dim": None,
+        "pna_deg": None,
+        "num_before_skip": None,
+        "num_after_skip": None,
+        "num_radial": None,
+        "radial_type": None,
+        "distance_transform": None,
+        "basis_emb_size": None,
+        "int_emb_size": None,
+        "out_emb_size": None,
+        "envelope_exponent": None,
+        "num_spherical": None,
+        "num_gaussians": None,
+        "num_filters": None,
+        "radius": None,
+        "equivariance": False,
+        "correlation": None,
+        "max_ell": None,
+        "node_max_ell": None,
+        "avg_num_neighbors": None,
+    }
+    config = {
+        "Architecture": architecture,
+        "Training": {
+            "loss_function_type": "mse",
+            "conv_checkpointing": False,
+            "precision": "fp32",
+        },
+    }
+
+    model = Mock()
+    with patch(
+        "hydragnn.models.create.create_model", return_value=model
+    ) as create_model:
+        result = create_model_config(config, use_gpu=False)
+
+    assert result is model.to.return_value
+    kwargs = create_model.call_args.kwargs
+    expected_defaults = {
+        "allscaip_num_heads": 8,
+        "allscaip_freq_list": None,
+        "allscaip_atten_name": "math",
+        "allscaip_use_node_path": True,
+        "allscaip_use_sincx_mask": True,
+        "allscaip_use_freq_mask": True,
+        "allscaip_max_num_elements": 119,
+        "allscaip_knn_soft": True,
+        "allscaip_distance_function": "gaussian",
+        "allscaip_normalization": "rmsnorm",
+        "allscaip_mlp_dropout": 0.0,
+        "allscaip_atten_dropout": 0.0,
+        "allscaip_use_residual_scaling": True,
+        "allscaip_regress_stress": False,
+        "allscaip_use_chunked_graph": False,
+        "allscaip_graph_chunk_size": 512,
+        "allscaip_knn_use_low_mem": True,
+        "allscaip_dataset_list": [],
+        "uma_mmax": 2,
+        "uma_grid_resolution": None,
+        "uma_edge_channels": 128,
+        "uma_hidden_channels": None,
+        "uma_norm_type": "rms_norm_sh",
+        "uma_ff_type": "grid",
+        "uma_use_chg_spin": False,
+        "uma_max_num_elements": 100,
+        "uma_variant": "S",
+        "uma_num_experts": None,
+        "uma_moe_dropout": 0.0,
+        "uma_use_composition_embedding": False,
+        "uma_equivariant_vector_head": False,
+        "uma_vector_head_index": None,
+    }
+    assert {key: kwargs[key] for key in expected_defaults} == expected_defaults


### PR DESCRIPTION
create_model() unconditionally builds kwargs for every model type, including AllScAIPStack- and UMAStack-specific options. Most of these were read via unguarded config["Architecture"][key] indexing instead of config["Architecture"].get(key, default), so any config/checkpoint that predates the AllScAIP/UMA integration (or simply never touched those keys, regardless of which model_type it actually requests) raised KeyError: 'allscaip_num_heads' (and, once that's fixed, the next unguarded key in turn: 'uma_mmax', etc.) instead of building the requested model.

hydragnn/utils/input_config_parsing/config_utils.py already defines the exact default value for every one of these keys (used when the config is passed through its normal update/defaulting path); this change makes create_model() itself defensive by using those same defaults directly, so it no longer depends on every caller having routed its config through that defaulting step first.

Reproduced with an older HydraGNN checkpoint/config (predating the AllScAIP/UMA additions) used as the MLIP relaxation backend in matsim-agents' cross-facility portability benchmark on OLCF Frontier; model creation now succeeds and the relaxation runs to completion.

--
Disclosure: this fix was identified and implemented with assistance from Claude Sonnet 5 (Anthropic), used as a coding agent in VS Code. I have reviewed, tested, and take responsibility for the change; disclosing the AI assistance candidly since I think contributors should be upfront about this.