### PR TITLE
Add stress-aware MLIP loss and stress-sign diagnostic

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -967,7 +967,10 @@ HydraGNN supports energy-conserving interatomic potential workflows. When enable
 ```json
 {
     "Architecture": {
-        "enable_interatomic_potential": true
+        "enable_interatomic_potential": true,
+        "energy_weight": 1.0,
+        "force_weight": 10.0,
+        "stress_weight": 1.0
     },
     "Training": {
         "compute_grad_energy": true
@@ -975,7 +978,13 @@ HydraGNN supports energy-conserving interatomic potential workflows. When enable
 }
 ```
 
-With `enable_interatomic_potential`, the training loss includes energy, per-atom energy, and force components. Set `compute_grad_energy` to `true` to derive forces via automatic differentiation of the energy prediction.
+With `enable_interatomic_potential`, the training loss includes energy,
+per-atom energy, and force components. Set `compute_grad_energy` to `true` to
+derive forces via automatic differentiation of the energy prediction. A
+positive `stress_weight` additionally penalizes the stress obtained by
+differentiating energy with respect to symmetric cell strain. Stress training
+requires full `3 x 3` reference tensors in `data.stress` and non-singular cells
+in `data.cell`; stresses use eV/Å³ with tension positive.
 
 Categorical handling is configured on each scalar node input. For example,
 atomic numbers can use a learned embedding:

--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -969,6 +969,7 @@ HydraGNN supports energy-conserving interatomic potential workflows. When enable
     "Architecture": {
         "enable_interatomic_potential": true,
         "energy_weight": 1.0,
+        "energy_peratom_weight": 1.0,
         "force_weight": 10.0,
         "stress_weight": 1.0
     },

--- a/docs/materials_preprocessing.md
+++ b/docs/materials_preprocessing.md
@@ -15,23 +15,25 @@ MPTrj and OMat24 are the first consumers. MPTrj converts VASP stress from kbar
 with compression positive. OMat24 receives ASE stress already expressed in
 eV/Å³ with tension positive.
 
-## Diagnosing an unknown sign convention
+## Checking stress against reference energy–strain derivatives
 
-Use `diagnose_stress_sign` when an energy evaluator is available for strained
-versions of a source structure:
+Use `check_stress_against_energy_strain` when the original reference method or
+labeled strained energies are available for a source structure:
 
 ```python
-from hydragnn.utils.materials import diagnose_stress_sign
+from hydragnn.utils.materials import check_stress_against_energy_strain
 
-diagnostic = diagnose_stress_sign(
+check = check_stress_against_energy_strain(
     data.pos,
     data.cell,
     source_stress,  # symmetric 3 x 3, eV/Å³
-    lambda positions, cell: calculator.energy(positions, cell),
+    reference_energy_fn=lambda positions, cell: reference_calculator.energy(
+        positions, cell
+    ),
 )
-print(diagnostic.inferred_source_sign)
-print(diagnostic.tension_positive_rmse)
-print(diagnostic.compression_positive_rmse)
+print(check.preferred_sign_convention)
+print(check.tension_positive_rmse)
+print(check.compression_positive_rmse)
 ```
 
 The utility applies positive and negative perturbations for all six independent
@@ -39,4 +41,15 @@ symmetric strain components, estimates `dE/dstrain / volume` with central
 finite differences, and compares that tensor with both the reported stress and
 its negation. It returns `ambiguous` for configurations where the two errors are
 too similar, as commonly happens near zero stress. It does not modify the
-reported tensor; pass the inferred convention explicitly to `normalize_stress`.
+reported tensor.
+
+The energy callback is deliberately named `reference_energy_fn`: use the same
+first-principles method that produced the labels, actual labeled strained
+energies, or another independent and sufficiently accurate calculator. Using
+the learned model under evaluation cannot independently establish the label
+convention; it checks only that model's energy–stress consistency, and energy
+errors can reverse the numerical derivative. The preferred convention is
+evidence for one structure rather than proof of dataset-wide metadata. Check
+multiple structures with appreciable stress and multiple strain steps before
+changing a dataset conversion, then pass the verified convention explicitly to
+`normalize_stress`.

--- a/docs/materials_preprocessing.md
+++ b/docs/materials_preprocessing.md
@@ -14,3 +14,29 @@ and report rejected records.
 MPTrj and OMat24 are the first consumers. MPTrj converts VASP stress from kbar
 with compression positive. OMat24 receives ASE stress already expressed in
 eV/Å³ with tension positive.
+
+## Diagnosing an unknown sign convention
+
+Use `diagnose_stress_sign` when an energy evaluator is available for strained
+versions of a source structure:
+
+```python
+from hydragnn.utils.materials import diagnose_stress_sign
+
+diagnostic = diagnose_stress_sign(
+    data.pos,
+    data.cell,
+    source_stress,  # symmetric 3 x 3, eV/Å³
+    lambda positions, cell: calculator.energy(positions, cell),
+)
+print(diagnostic.inferred_source_sign)
+print(diagnostic.tension_positive_rmse)
+print(diagnostic.compression_positive_rmse)
+```
+
+The utility applies positive and negative perturbations for all six independent
+symmetric strain components, estimates `dE/dstrain / volume` with central
+finite differences, and compares that tensor with both the reported stress and
+its negation. It returns `ambiguous` for configurations where the two errors are
+too similar, as commonly happens near zero stress. It does not modify the
+reported tensor; pass the inferred convention explicitly to `normalize_stress`.

--- a/docs/uma_allscaip.md
+++ b/docs/uma_allscaip.md
@@ -19,6 +19,15 @@ Set `enable_interatomic_potential` to `true` when training an energy-conserving
 potential. HydraGNN then obtains conservative forces by differentiating the
 predicted invariant energy with respect to `data.pos`.
 
+Set `stress_weight` to a positive value to add a stress term to the MLIP loss.
+HydraGNN differentiates energy with respect to a symmetric cell strain and
+divides the resulting virial by the undeformed cell volume. Stress training
+requires `data.cell` and `data.stress`; reference stresses must be full `3 x 3`
+tensors in eV/Å³ with tension positive. The complete objective is
+`energy_weight * L_energy + energy_peratom_weight * L_energy_per_atom +
+force_weight * L_forces + stress_weight * L_stress`. A zero `stress_weight`
+(the default) preserves the energy/force-only behavior.
+
 ## UMA
 
 Select UMA with `"mpnn_type": "UMA"` and set `"equivariance": true`. UMA

--- a/hydragnn/models/AllScAIPStack.py
+++ b/hydragnn/models/AllScAIPStack.py
@@ -561,8 +561,8 @@ class AllScAIPStack(Base):
         results = self.allscaip_backbone(adapter)
         # Preserve the autograd strain handle and undeformed cell for the
         # outer MLIP wrapper's optional stress loss.
-        data._hydragnn_stress_displacement = results["displacement"]
-        data._hydragnn_stress_cell = results["orig_cell"]
+        data._hydragnn_stress_displacement = results.get("displacement")
+        data._hydragnn_stress_cell = results.get("orig_cell")
         # ``node_reps`` is shape [N, hidden_dim] (no padding -- AllScAIP
         # always runs unpadded under HydraGNN).
         inv_node_feat = self.allscaip_output_norm(results["node_reps"])

--- a/hydragnn/models/AllScAIPStack.py
+++ b/hydragnn/models/AllScAIPStack.py
@@ -559,6 +559,10 @@ class AllScAIPStack(Base):
 
         adapter = self._build_adapter(data)
         results = self.allscaip_backbone(adapter)
+        # Preserve the autograd strain handle and undeformed cell for the
+        # outer MLIP wrapper's optional stress loss.
+        data._hydragnn_stress_displacement = results["displacement"]
+        data._hydragnn_stress_cell = results["orig_cell"]
         # ``node_reps`` is shape [N, hidden_dim] (no padding -- AllScAIP
         # always runs unpadded under HydraGNN).
         inv_node_feat = self.allscaip_output_norm(results["node_reps"])

--- a/hydragnn/models/AllScAIPStack.py
+++ b/hydragnn/models/AllScAIPStack.py
@@ -561,8 +561,8 @@ class AllScAIPStack(Base):
         results = self.allscaip_backbone(adapter)
         # Preserve the autograd strain handle and undeformed cell for the
         # outer MLIP wrapper's optional stress loss.
-        data._hydragnn_stress_displacement = results.get("displacement")
-        data._hydragnn_stress_cell = results.get("orig_cell")
+        self._hydragnn_stress_displacement = results.get("displacement")
+        self._hydragnn_stress_cell = results.get("orig_cell")
         # ``node_reps`` is shape [N, hidden_dim] (no padding -- AllScAIP
         # always runs unpadded under HydraGNN).
         inv_node_feat = self.allscaip_output_norm(results["node_reps"])

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -1040,9 +1040,11 @@ def create_model(
                 prediction = self.model(data)
                 if self.stress_weight > 0:
                     self._stress_displacement = getattr(
-                        data, "_hydragnn_stress_displacement", None
+                        self.model, "_hydragnn_stress_displacement", None
                     )
-                    self._stress_cell = getattr(data, "_hydragnn_stress_cell", None)
+                    self._stress_cell = getattr(
+                        self.model, "_hydragnn_stress_cell", None
+                    )
                 return prediction
 
             def energy_force_loss(self, pred, data, create_graph=True):

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -97,6 +97,7 @@ def create_model_config(
         energy_weight=config["Architecture"].get("energy_weight", 0.0),
         energy_peratom_weight=config["Architecture"].get("energy_peratom_weight", 0.0),
         force_weight=config["Architecture"].get("force_weight", 0.0),
+        stress_weight=config["Architecture"].get("stress_weight", 0.0),
         use_graph_attr_conditioning=config["Architecture"].get(
             "use_graph_attr_conditioning", False
         ),
@@ -288,6 +289,7 @@ def create_model(
     energy_weight: float = 0.0,
     energy_peratom_weight: float = 0.0,
     force_weight: float = 0.0,
+    stress_weight: float = 0.0,
     use_graph_attr_conditioning: bool = False,
     graph_attr_conditioning_mode: str = "fuse_pool",
     graph_pooling: str = "mean",
@@ -343,6 +345,17 @@ def create_model(
     torch.manual_seed(0)
 
     device = get_device(use_gpu, verbosity_level=verbosity)
+
+    if stress_weight < 0:
+        raise ValueError("stress_weight must be non-negative.")
+    if stress_weight > 0 and not enable_interatomic_potential:
+        raise ValueError(
+            "stress_weight is only valid when enable_interatomic_potential is true."
+        )
+    # The AllScAIP backbone must retain its strain tensor so the outer MLIP
+    # wrapper can differentiate energy with respect to it.
+    if stress_weight > 0 and mpnn_type == "AllScAIP":
+        allscaip_regress_stress = True
 
     # Note: model-specific inputs must come first.
     if mpnn_type == "GIN":
@@ -950,6 +963,7 @@ def create_model(
                 self.energy_weight = energy_weight
                 self.energy_peratom_weight = energy_peratom_weight
                 self.force_weight = force_weight
+                self.stress_weight = stress_weight
 
             def __getattr__(self, name):
                 # First try to get from the wrapper itself
@@ -976,8 +990,54 @@ def create_model(
 
             # ---------- forward ----------
             def forward(self, data):
+                self._stress_displacement = None
+                self._stress_cell = None
 
-                return self.model(data)
+                # AllScAIP owns its differentiable graph construction and
+                # applies strain internally. Other MLIP backbones receive the
+                # same symmetric infinitesimal strain here.
+                if self.stress_weight > 0 and not isinstance(
+                    self.model, AllScAIPStack
+                ):
+                    if getattr(data, "cell", None) is None:
+                        raise ValueError(
+                            "stress_weight > 0 requires data.cell for every graph."
+                        )
+                    num_graphs = int(data.batch.max().item()) + 1
+                    cell = data.cell
+                    if cell.dim() == 2 and cell.shape == (3, 3):
+                        cell = cell.unsqueeze(0).expand(num_graphs, 3, 3).contiguous()
+                    elif cell.dim() == 2 and cell.shape[0] == 3 * num_graphs:
+                        cell = cell.view(num_graphs, 3, 3)
+                    elif cell.dim() != 3:
+                        raise ValueError(
+                            f"Unexpected cell shape {tuple(cell.shape)} for stress loss."
+                        )
+                    displacement = torch.zeros_like(cell, requires_grad=True)
+                    strain = 0.5 * (displacement + displacement.transpose(-1, -2))
+                    original_pos = data.pos
+                    original_cell = data.cell
+                    data.pos = original_pos + torch.bmm(
+                        original_pos.unsqueeze(1), strain[data.batch]
+                    ).squeeze(1)
+                    strained_cell = cell + torch.bmm(cell, strain)
+                    data.cell = strained_cell
+                    try:
+                        prediction = self.model(data)
+                    finally:
+                        data.pos = original_pos
+                        data.cell = original_cell
+                    self._stress_displacement = displacement
+                    self._stress_cell = cell
+                    return prediction
+
+                prediction = self.model(data)
+                if self.stress_weight > 0:
+                    self._stress_displacement = getattr(
+                        data, "_hydragnn_stress_displacement", None
+                    )
+                    self._stress_cell = getattr(data, "_hydragnn_stress_cell", None)
+                return prediction
 
             def energy_force_loss(self, pred, data, create_graph=True):
                 """
@@ -986,6 +1046,7 @@ def create_model(
                 This method is specific to interatomic potentials and computes:
                 1. Energy loss between predicted and true total energies
                 2. Force loss between predicted and true forces (via autograd on positions)
+                3. Optional stress loss from the energy derivative with respect to strain
 
                 Forces are computed as negative gradients of total energy with respect to positions.
                 """
@@ -1033,15 +1094,17 @@ def create_model(
                 energy_loss_weight = self.energy_weight
                 energy_peratom_loss_weight = self.energy_peratom_weight
                 force_loss_weight = self.force_weight
+                stress_loss_weight = self.stress_weight
 
                 # Interatomic potential training requires at least one active loss term
                 if (
                     energy_loss_weight <= 0
                     and energy_peratom_loss_weight <= 0
                     and force_loss_weight <= 0
+                    and stress_loss_weight <= 0
                 ):
                     raise ValueError(
-                        "All interatomic potential loss weights are zero; set at least one of energy_weight, energy_peratom_weight, or force_weight to a positive value."
+                        "All interatomic potential loss weights are zero; set at least one of energy_weight, energy_peratom_weight, force_weight, or stress_weight to a positive value."
                     )
 
                 tot_loss = 0
@@ -1090,6 +1153,33 @@ def create_model(
                     )  # Have force-weight be the complement to energy-weight
                     ## FixMe: current loss functions require the number of heads to be the number of things being predicted
                     ##        so, we need to do loss calculation manually without calling the other functions.
+
+                if stress_loss_weight > 0:
+                    stress_true = getattr(data, "stress", None)
+                    if stress_true is None:
+                        raise ValueError("stress_weight > 0 requires data.stress.")
+                    displacement = self._stress_displacement
+                    cell = self._stress_cell
+                    if displacement is None or cell is None:
+                        raise RuntimeError(
+                            "The selected MLIP backbone did not expose a differentiable "
+                            "cell displacement for stress prediction."
+                        )
+                    virial = torch.autograd.grad(
+                        graph_energy_pred,
+                        displacement,
+                        grad_outputs=torch.ones_like(graph_energy_pred),
+                        retain_graph=graph_energy_pred.requires_grad,
+                        create_graph=create_graph,
+                    )[0]
+                    volume = torch.det(cell).abs().view(-1, 1, 1)
+                    if torch.any(volume <= 0):
+                        raise ValueError("stress loss requires non-singular simulation cells.")
+                    stress_pred = virial / volume
+                    stress_true = stress_true.float().reshape_as(stress_pred)
+                    stress_loss = self.loss_function(stress_pred.float(), stress_true)
+                    tasks_loss.append(stress_loss)
+                    tot_loss += stress_loss * stress_loss_weight
 
                 return tot_loss, tasks_loss
 

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -996,9 +996,7 @@ def create_model(
                 # AllScAIP owns its differentiable graph construction and
                 # applies strain internally. Other MLIP backbones receive the
                 # same symmetric infinitesimal strain here.
-                if self.stress_weight > 0 and not isinstance(
-                    self.model, AllScAIPStack
-                ):
+                if self.stress_weight > 0 and not isinstance(self.model, AllScAIPStack):
                     if getattr(data, "cell", None) is None:
                         raise ValueError(
                             "stress_weight > 0 requires data.cell for every graph."
@@ -1009,7 +1007,15 @@ def create_model(
                         cell = cell.unsqueeze(0).expand(num_graphs, 3, 3).contiguous()
                     elif cell.dim() == 2 and cell.shape[0] == 3 * num_graphs:
                         cell = cell.view(num_graphs, 3, 3)
-                    elif cell.dim() != 3:
+                    elif cell.dim() == 3 and cell.shape[1:] == (3, 3):
+                        if cell.shape[0] == 1 and num_graphs > 1:
+                            cell = cell.expand(num_graphs, 3, 3).contiguous()
+                        elif cell.shape[0] != num_graphs:
+                            raise ValueError(
+                                f"Expected one cell or {num_graphs} cells for stress "
+                                f"loss, got {cell.shape[0]}."
+                            )
+                    else:
                         raise ValueError(
                             f"Unexpected cell shape {tuple(cell.shape)} for stress loss."
                         )
@@ -1173,8 +1179,13 @@ def create_model(
                         create_graph=create_graph,
                     )[0]
                     volume = torch.det(cell).abs().view(-1, 1, 1)
-                    if torch.any(volume <= 0):
-                        raise ValueError("stress loss requires non-singular simulation cells.")
+                    min_volume = torch.finfo(volume.dtype).eps
+                    if not torch.isfinite(volume).all() or torch.any(
+                        volume <= min_volume
+                    ):
+                        raise ValueError(
+                            "stress loss requires finite, non-singular simulation cells."
+                        )
                     stress_pred = virial / volume
                     stress_true = stress_true.float().reshape_as(stress_pred)
                     stress_loss = self.loss_function(stress_pred.float(), stress_true)

--- a/hydragnn/models/create.py
+++ b/hydragnn/models/create.py
@@ -1005,7 +1005,7 @@ def create_model(
                     cell = data.cell
                     if cell.dim() == 2 and cell.shape == (3, 3):
                         cell = cell.unsqueeze(0).expand(num_graphs, 3, 3).contiguous()
-                    elif cell.dim() == 2 and cell.shape[0] == 3 * num_graphs:
+                    elif cell.dim() == 2 and cell.shape == (3 * num_graphs, 3):
                         cell = cell.view(num_graphs, 3, 3)
                     elif cell.dim() == 3 and cell.shape[1:] == (3, 3):
                         if cell.shape[0] == 1 and num_graphs > 1:

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -228,18 +228,19 @@ def train_validate_test(
 
     device = get_device()
     if compute_grad_energy:
-        num_tasks = 3  # [energy, energy per atom, forces]
-        task_dims = [1, 1, 1]
+        include_stress = model.module.stress_weight > 0
+        num_tasks = 4 if include_stress else 3
+        task_dims = [1, 1, 1] + ([9] if include_stress else [])
         task_weights = [
             model.module.energy_weight,
             model.module.energy_peratom_weight,
             model.module.force_weight,
-        ]
+        ] + ([model.module.stress_weight] if include_stress else [])
         output_names = [
             configured_output_names[0],
             "energy_peratom",
             "forces",
-        ]
+        ] + (["stress"] if include_stress else [])
     else:
         num_tasks = model.module.num_heads
         task_dims = model.module.head_dims
@@ -930,7 +931,11 @@ def test(
         import torch_scatter
 
     if num_tasks is None:
-        num_tasks = 3 if compute_grad_energy else model.module.num_heads
+        num_tasks = (
+            4 if compute_grad_energy and model.module.stress_weight > 0
+            else 3 if compute_grad_energy
+            else model.module.num_heads
+        )
 
     total_error = torch.tensor(0.0, device=get_device())
     tasks_error = torch.zeros(num_tasks, device=get_device())
@@ -1098,6 +1103,19 @@ def test(
                             graph_energy_peratom_pred.reshape(-1, 1)
                         )
                         predicted_values[2].append(forces_pred.reshape(-1, 1))
+                        if model.module.stress_weight > 0:
+                            displacement = model.module._stress_displacement
+                            cell = model.module._stress_cell
+                            virial = torch.autograd.grad(
+                                graph_energy_pred,
+                                displacement,
+                                grad_outputs=torch.ones_like(graph_energy_pred),
+                                create_graph=False,
+                            )[0]
+                            stress_pred = virial / torch.det(cell).abs().view(-1, 1, 1)
+                            stress_true = data.stress.float().reshape_as(stress_pred)
+                            true_values[3].append(stress_true.reshape(-1, 1))
+                            predicted_values[3].append(stress_pred.reshape(-1, 1))
             else:
                 head_index = get_head_indices(model, data)
                 ytrue = data.y

--- a/hydragnn/train/train_validate_test.py
+++ b/hydragnn/train/train_validate_test.py
@@ -932,9 +932,9 @@ def test(
 
     if num_tasks is None:
         num_tasks = (
-            4 if compute_grad_energy and model.module.stress_weight > 0
-            else 3 if compute_grad_energy
-            else model.module.num_heads
+            4
+            if compute_grad_energy and model.module.stress_weight > 0
+            else 3 if compute_grad_energy else model.module.num_heads
         )
 
     total_error = torch.tensor(0.0, device=get_device())
@@ -1112,7 +1112,16 @@ def test(
                                 grad_outputs=torch.ones_like(graph_energy_pred),
                                 create_graph=False,
                             )[0]
-                            stress_pred = virial / torch.det(cell).abs().view(-1, 1, 1)
+                            volume = torch.det(cell).abs().view(-1, 1, 1)
+                            min_volume = torch.finfo(volume.dtype).eps
+                            if not torch.isfinite(volume).all() or torch.any(
+                                volume <= min_volume
+                            ):
+                                raise ValueError(
+                                    "stress evaluation requires finite, non-singular "
+                                    "simulation cells."
+                                )
+                            stress_pred = virial / volume
                             stress_true = data.stress.float().reshape_as(stress_pred)
                             true_values[3].append(stress_true.reshape(-1, 1))
                             predicted_values[3].append(stress_pred.reshape(-1, 1))

--- a/hydragnn/utils/materials/__init__.py
+++ b/hydragnn/utils/materials/__init__.py
@@ -9,6 +9,16 @@
 # SPDX-License-Identifier: BSD-3-Clause                                      #
 ##############################################################################
 
-from .preprocessing import normalize_stress, validate_materials_sample
+from .preprocessing import (
+    StressSignDiagnostic,
+    diagnose_stress_sign,
+    normalize_stress,
+    validate_materials_sample,
+)
 
-__all__ = ["normalize_stress", "validate_materials_sample"]
+__all__ = [
+    "StressSignDiagnostic",
+    "diagnose_stress_sign",
+    "normalize_stress",
+    "validate_materials_sample",
+]

--- a/hydragnn/utils/materials/__init__.py
+++ b/hydragnn/utils/materials/__init__.py
@@ -10,15 +10,15 @@
 ##############################################################################
 
 from .preprocessing import (
-    StressSignDiagnostic,
-    diagnose_stress_sign,
+    StressEnergyStrainCheck,
+    check_stress_against_energy_strain,
     normalize_stress,
     validate_materials_sample,
 )
 
 __all__ = [
-    "StressSignDiagnostic",
-    "diagnose_stress_sign",
+    "StressEnergyStrainCheck",
+    "check_stress_against_energy_strain",
     "normalize_stress",
     "validate_materials_sample",
 ]

--- a/hydragnn/utils/materials/preprocessing.py
+++ b/hydragnn/utils/materials/preprocessing.py
@@ -11,7 +11,8 @@
 
 """Dataset-independent preprocessing helpers for atomistic materials data."""
 
-from typing import Literal
+from dataclasses import dataclass
+from typing import Callable, Literal
 
 import torch
 
@@ -19,6 +20,19 @@ GPA_PER_EV_PER_ANGSTROM_CUBED = 160.21766208
 
 StressUnit = Literal["ev_per_angstrom_cubed", "gpa", "kbar"]
 StressSign = Literal["tension_positive", "compression_positive"]
+
+
+@dataclass(frozen=True)
+class StressSignDiagnostic:
+    """Result of comparing reported stress with finite-difference stress."""
+
+    inferred_source_sign: Literal[
+        "tension_positive", "compression_positive", "ambiguous"
+    ]
+    finite_difference_stress: torch.Tensor
+    reported_stress: torch.Tensor
+    tension_positive_rmse: float
+    compression_positive_rmse: float
 
 
 def _voigt_to_full(stress: torch.Tensor) -> torch.Tensor:
@@ -68,6 +82,102 @@ def normalize_stress(
 
     sign = -1.0 if source_sign == "compression_positive" else 1.0
     return value * (sign * unit_scale[source_unit])
+
+
+def diagnose_stress_sign(
+    positions: torch.Tensor,
+    cell: torch.Tensor,
+    reported_stress: torch.Tensor,
+    energy_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor | float],
+    *,
+    strain_step: float = 1.0e-4,
+    ambiguity_rtol: float = 0.05,
+    ambiguity_atol: float = 1.0e-8,
+) -> StressSignDiagnostic:
+    """Infer a source stress sign using central energy finite differences.
+
+    ``energy_fn`` receives strained Cartesian positions and cell vectors and
+    must return one scalar total energy in eV. Positions and cells are strained
+    together, preserving fractional coordinates. The reported stress must be a
+    symmetric ``3 x 3`` tensor in eV/Å³; its sign convention may be unknown.
+
+    The result is ``ambiguous`` when the RMSE values for the reported tensor
+    and its negation differ by no more than the configured tolerance. This is
+    expected for a nearly stress-free configuration.
+    """
+    positions = torch.as_tensor(positions)
+    cell = torch.as_tensor(cell, dtype=positions.dtype, device=positions.device)
+    reported_stress = torch.as_tensor(
+        reported_stress, dtype=positions.dtype, device=positions.device
+    )
+    if positions.ndim != 2 or positions.shape[1] != 3:
+        raise ValueError("positions must have shape [N, 3]")
+    if cell.shape != (3, 3):
+        raise ValueError("cell must have shape [3, 3]")
+    if reported_stress.shape != (3, 3):
+        raise ValueError("reported_stress must have shape [3, 3]")
+    if not torch.isfinite(positions).all() or not torch.isfinite(cell).all():
+        raise ValueError("positions and cell must contain only finite values")
+    if not torch.isfinite(reported_stress).all():
+        raise ValueError("reported_stress contains non-finite values")
+    if not torch.allclose(
+        reported_stress, reported_stress.T, rtol=1.0e-5, atol=1.0e-7
+    ):
+        raise ValueError("reported_stress must be symmetric")
+    if strain_step <= 0:
+        raise ValueError("strain_step must be positive")
+    if ambiguity_rtol < 0 or ambiguity_atol < 0:
+        raise ValueError("ambiguity tolerances must be non-negative")
+
+    volume = torch.det(cell).abs()
+    if not torch.isfinite(volume) or volume <= 0:
+        raise ValueError("stress diagnosis requires a non-singular cell")
+
+    identity = torch.eye(3, dtype=cell.dtype, device=cell.device)
+    numerical_stress = torch.zeros_like(cell)
+
+    def evaluate(strain):
+        transform = identity + strain
+        value = energy_fn(positions @ transform, cell @ transform)
+        value = torch.as_tensor(value, dtype=cell.dtype, device=cell.device)
+        if value.numel() != 1 or not torch.isfinite(value).all():
+            raise ValueError("energy_fn must return one finite scalar energy")
+        return value.reshape(())
+
+    for row in range(3):
+        for col in range(row, 3):
+            basis = torch.zeros_like(cell)
+            basis[row, col] = 1.0
+            basis[col, row] = 1.0
+            energy_plus = evaluate(strain_step * basis)
+            energy_minus = evaluate(-strain_step * basis)
+            derivative = (energy_plus - energy_minus) / (2.0 * strain_step)
+            # An off-diagonal probe changes both symmetric tensor entries.
+            component = derivative / (volume * (2.0 if row != col else 1.0))
+            numerical_stress[row, col] = component
+            numerical_stress[col, row] = component
+
+    tension_rmse = torch.sqrt(torch.mean((reported_stress - numerical_stress) ** 2))
+    compression_rmse = torch.sqrt(
+        torch.mean((-reported_stress - numerical_stress) ** 2)
+    )
+    error_scale = max(
+        float(tension_rmse), float(compression_rmse), float(ambiguity_atol)
+    )
+    if abs(float(tension_rmse - compression_rmse)) <= ambiguity_rtol * error_scale:
+        inferred_sign = "ambiguous"
+    elif tension_rmse < compression_rmse:
+        inferred_sign = "tension_positive"
+    else:
+        inferred_sign = "compression_positive"
+
+    return StressSignDiagnostic(
+        inferred_source_sign=inferred_sign,
+        finite_difference_stress=numerical_stress.detach(),
+        reported_stress=reported_stress.detach(),
+        tension_positive_rmse=float(tension_rmse),
+        compression_positive_rmse=float(compression_rmse),
+    )
 
 
 def validate_materials_sample(data, *, require_stress: bool = False):

--- a/hydragnn/utils/materials/preprocessing.py
+++ b/hydragnn/utils/materials/preprocessing.py
@@ -23,10 +23,10 @@ StressSign = Literal["tension_positive", "compression_positive"]
 
 
 @dataclass(frozen=True)
-class StressSignDiagnostic:
-    """Result of comparing reported stress with finite-difference stress."""
+class StressEnergyStrainCheck:
+    """Evidence from comparing reported stress with reference energy derivatives."""
 
-    inferred_source_sign: Literal[
+    preferred_sign_convention: Literal[
         "tension_positive", "compression_positive", "ambiguous"
     ]
     finite_difference_stress: torch.Tensor
@@ -84,26 +84,36 @@ def normalize_stress(
     return value * (sign * unit_scale[source_unit])
 
 
-def diagnose_stress_sign(
+def check_stress_against_energy_strain(
     positions: torch.Tensor,
     cell: torch.Tensor,
     reported_stress: torch.Tensor,
-    energy_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor | float],
     *,
+    reference_energy_fn: Callable[[torch.Tensor, torch.Tensor], torch.Tensor | float],
     strain_step: float = 1.0e-4,
     ambiguity_rtol: float = 0.05,
     ambiguity_atol: float = 1.0e-8,
-) -> StressSignDiagnostic:
-    """Infer a source stress sign using central energy finite differences.
+) -> StressEnergyStrainCheck:
+    """Check stress consistency with independent reference energy derivatives.
 
-    ``energy_fn`` receives strained Cartesian positions and cell vectors and
-    must return one scalar total energy in eV. Positions and cells are strained
-    together, preserving fractional coordinates. The reported stress must be a
-    symmetric ``3 x 3`` tensor in eV/Å³; its sign convention may be unknown.
+    ``reference_energy_fn`` receives strained Cartesian positions and cell
+    vectors and must return one scalar total energy in eV. It should use the
+    reference method that generated the labels, labeled strained energies, or
+    another independent and sufficiently accurate calculator. Passing the
+    learned model being checked does not independently establish the dataset's
+    sign convention; it measures only that model's energy--stress consistency.
 
-    The result is ``ambiguous`` when the RMSE values for the reported tensor
-    and its negation differ by no more than the configured tolerance. This is
-    expected for a nearly stress-free configuration.
+    Positions and cells are strained together, preserving fractional
+    coordinates. The reported stress must be a symmetric ``3 x 3`` tensor in
+    eV/Å³; its sign convention may be unknown.
+
+    ``preferred_sign_convention`` reports which sign agrees better with the
+    supplied reference energy derivatives; it is evidence from this structure,
+    not proof of dataset-wide metadata. The result is ``ambiguous`` when the
+    RMSE values for the reported tensor and its negation differ by no more than
+    the configured tolerance. This is expected for a nearly stress-free
+    configuration. Check multiple stressed structures and strain steps before
+    changing a dataset conversion.
     """
     positions = torch.as_tensor(positions)
     cell = torch.as_tensor(cell, dtype=positions.dtype, device=positions.device)
@@ -136,10 +146,10 @@ def diagnose_stress_sign(
 
     def evaluate(strain):
         transform = identity + strain
-        value = energy_fn(positions @ transform, cell @ transform)
+        value = reference_energy_fn(positions @ transform, cell @ transform)
         value = torch.as_tensor(value, dtype=cell.dtype, device=cell.device)
         if value.numel() != 1 or not torch.isfinite(value).all():
-            raise ValueError("energy_fn must return one finite scalar energy")
+            raise ValueError("reference_energy_fn must return one finite scalar energy")
         return value.reshape(())
 
     for row in range(3):
@@ -169,8 +179,8 @@ def diagnose_stress_sign(
     else:
         inferred_sign = "compression_positive"
 
-    return StressSignDiagnostic(
-        inferred_source_sign=inferred_sign,
+    return StressEnergyStrainCheck(
+        preferred_sign_convention=inferred_sign,
         finite_difference_stress=numerical_stress.detach(),
         reported_stress=reported_stress.detach(),
         tension_positive_rmse=float(tension_rmse),

--- a/hydragnn/utils/materials/preprocessing.py
+++ b/hydragnn/utils/materials/preprocessing.py
@@ -120,9 +120,7 @@ def diagnose_stress_sign(
         raise ValueError("positions and cell must contain only finite values")
     if not torch.isfinite(reported_stress).all():
         raise ValueError("reported_stress contains non-finite values")
-    if not torch.allclose(
-        reported_stress, reported_stress.T, rtol=1.0e-5, atol=1.0e-7
-    ):
+    if not torch.allclose(reported_stress, reported_stress.T, rtol=1.0e-5, atol=1.0e-7):
         raise ValueError("reported_stress must be symmetric")
     if strain_step <= 0:
         raise ValueError("strain_step must be positive")

--- a/tests/_prediction_workflow.py
+++ b/tests/_prediction_workflow.py
@@ -66,8 +66,7 @@ def load_checkpoint_and_test(config, test_loader, use_deepspeed=False):
     num_tasks = (
         4
         if enable_interatomic_potential and model.module.stress_weight > 0
-        else 3 if enable_interatomic_potential
-        else model.module.num_heads
+        else 3 if enable_interatomic_potential else model.module.num_heads
     )
 
     (

--- a/tests/_prediction_workflow.py
+++ b/tests/_prediction_workflow.py
@@ -63,7 +63,12 @@ def load_checkpoint_and_test(config, test_loader, use_deepspeed=False):
     enable_interatomic_potential = config["NeuralNetwork"]["Architecture"].get(
         "enable_interatomic_potential", False
     )
-    num_tasks = 3 if enable_interatomic_potential else model.module.num_heads
+    num_tasks = (
+        4
+        if enable_interatomic_potential and model.module.stress_weight > 0
+        else 3 if enable_interatomic_potential
+        else model.module.num_heads
+    )
 
     (
         error,

--- a/tests/test_interatomic_potential.py
+++ b/tests/test_interatomic_potential.py
@@ -64,6 +64,9 @@ def create_mock_molecular_data(num_atoms=10, num_graphs=2):
     # Create mock energy and forces for training
     energy = torch.randn(num_graphs, 1)  # Energy per molecule
     forces = torch.randn(num_atoms * num_graphs, 3)  # Forces per atom
+    cell = torch.eye(3).repeat(num_graphs, 1, 1) * 10.0
+    stress = torch.randn(num_graphs, 3, 3)
+    stress = 0.5 * (stress + stress.transpose(-1, -2))
 
     # Create positional encodings (random for testing)
     pe = torch.randn(num_atoms * num_graphs, 6)  # 6D positional encoding
@@ -79,6 +82,8 @@ def create_mock_molecular_data(num_atoms=10, num_graphs=2):
         batch=batch,
         energy=energy,
         forces=forces,
+        cell=cell,
+        stress=stress,
         pe=pe,
         edge_shifts=torch.zeros(
             edge_index.size(1), 3
@@ -86,6 +91,94 @@ def create_mock_molecular_data(num_atoms=10, num_graphs=2):
     )
 
     return data
+
+
+@pytest.mark.mpi_skip()
+def test_energy_force_stress_loss():
+    """Stress contributes to MLIP loss through an energy/strain derivative."""
+    from hydragnn.models.create import create_model
+    from hydragnn.utils.model.model import update_multibranch_heads
+
+    output_heads = {
+        "node": {
+            "num_sharedlayers": 1,
+            "dim_sharedlayers": 16,
+            "num_headlayers": 1,
+            "dim_headlayers": [1],
+            "type": "mlp",
+        }
+    }
+    model = create_model(
+        mpnn_type="EGNN",
+        input_dim=1,
+        hidden_dim=32,
+        output_dim=[1],
+        pe_dim=6,
+        global_attn_engine="",
+        global_attn_type="",
+        global_attn_heads=1,
+        output_type=["node"],
+        output_heads=update_multibranch_heads(output_heads),
+        activation_function="relu",
+        loss_function_type="mse",
+        task_weights=[1.0],
+        num_conv_layers=2,
+        num_nodes=10,
+        enable_interatomic_potential=True,
+        energy_weight=1.0,
+        force_weight=1.0,
+        stress_weight=2.0,
+        use_gpu=False,
+    )
+    data = create_mock_molecular_data(num_atoms=5, num_graphs=2)
+    prediction = model(data)
+    loss, task_losses = model.energy_force_loss(prediction, data)
+
+    assert len(task_losses) == 4
+    assert all(torch.isfinite(value) for value in task_losses)
+    assert torch.isfinite(loss)
+    loss.backward()
+
+
+@pytest.mark.mpi_skip()
+def test_stress_loss_requires_cell():
+    """A clear error is raised instead of silently omitting stress."""
+    from hydragnn.models.create import create_model
+    from hydragnn.utils.model.model import update_multibranch_heads
+
+    output_heads = {
+        "node": {
+            "num_sharedlayers": 1,
+            "dim_sharedlayers": 8,
+            "num_headlayers": 1,
+            "dim_headlayers": [1],
+            "type": "mlp",
+        }
+    }
+    model = create_model(
+        mpnn_type="EGNN",
+        input_dim=1,
+        hidden_dim=16,
+        output_dim=[1],
+        pe_dim=6,
+        global_attn_engine="",
+        global_attn_type="",
+        global_attn_heads=1,
+        output_type=["node"],
+        output_heads=update_multibranch_heads(output_heads),
+        activation_function="relu",
+        loss_function_type="mse",
+        task_weights=[1.0],
+        num_conv_layers=1,
+        num_nodes=5,
+        enable_interatomic_potential=True,
+        stress_weight=1.0,
+        use_gpu=False,
+    )
+    data = create_mock_molecular_data(num_atoms=5, num_graphs=1)
+    del data.cell
+    with pytest.raises(ValueError, match="requires data.cell"):
+        model(data)
 
 
 @pytest.mark.mpi_skip()

--- a/tests/test_interatomic_potential.py
+++ b/tests/test_interatomic_potential.py
@@ -186,6 +186,11 @@ def test_stress_loss_requires_cell():
     with pytest.raises(ValueError, match="Expected one cell or 2 cells"):
         model(data)
 
+    data = create_mock_molecular_data(num_atoms=5, num_graphs=2)
+    data.cell = torch.zeros(6, 2)
+    with pytest.raises(ValueError, match="Unexpected cell shape"):
+        model(data)
+
 
 @pytest.mark.mpi_skip()
 def test_model_creation_with_enhancement():

--- a/tests/test_interatomic_potential.py
+++ b/tests/test_interatomic_potential.py
@@ -131,6 +131,7 @@ def test_energy_force_stress_loss():
         use_gpu=False,
     )
     data = create_mock_molecular_data(num_atoms=5, num_graphs=2)
+    data.cell = data.cell[:1]  # One shared cell is expanded across the batch.
     prediction = model(data)
     loss, task_losses = model.energy_force_loss(prediction, data)
 
@@ -178,6 +179,11 @@ def test_stress_loss_requires_cell():
     data = create_mock_molecular_data(num_atoms=5, num_graphs=1)
     del data.cell
     with pytest.raises(ValueError, match="requires data.cell"):
+        model(data)
+
+    data = create_mock_molecular_data(num_atoms=5, num_graphs=2)
+    data.cell = torch.eye(3).repeat(3, 1, 1)
+    with pytest.raises(ValueError, match="Expected one cell or 2 cells"):
         model(data)
 
 

--- a/tests/test_materials_preprocessing.py
+++ b/tests/test_materials_preprocessing.py
@@ -13,7 +13,11 @@ import pytest
 import torch
 from torch_geometric.data import Data
 
-from hydragnn.utils.materials import normalize_stress, validate_materials_sample
+from hydragnn.utils.materials import (
+    diagnose_stress_sign,
+    normalize_stress,
+    validate_materials_sample,
+)
 from hydragnn.utils.materials.preprocessing import (
     GPA_PER_EV_PER_ANGSTROM_CUBED,
 )
@@ -58,6 +62,53 @@ def test_normalize_stress_preserves_ase_convention():
         source_sign="tension_positive",
     )
     torch.testing.assert_close(output, stress)
+
+
+@pytest.mark.parametrize(
+    ("reported_sign", "expected"),
+    [(1.0, "tension_positive"), (-1.0, "compression_positive")],
+)
+def test_diagnose_stress_sign(reported_sign, expected):
+    dtype = torch.float64
+    positions = torch.tensor([[0.1, 0.2, 0.3], [0.7, 0.6, 0.5]], dtype=dtype)
+    cell = torch.diag(torch.tensor([2.0, 3.0, 4.0], dtype=dtype))
+    reference = torch.tensor(
+        [[1.2, 0.3, -0.2], [0.3, -0.7, 0.4], [-0.2, 0.4, 0.9]],
+        dtype=dtype,
+    )
+    volume = torch.det(cell)
+
+    def energy_fn(_positions, strained_cell):
+        deformation = torch.linalg.solve(cell, strained_cell)
+        strain = deformation - torch.eye(3, dtype=dtype)
+        return volume * torch.sum(reference * strain)
+
+    result = diagnose_stress_sign(
+        positions,
+        cell,
+        reported_sign * reference,
+        energy_fn,
+        strain_step=1.0e-5,
+    )
+
+    assert result.inferred_source_sign == expected
+    torch.testing.assert_close(
+        result.finite_difference_stress, reference, rtol=1.0e-9, atol=1.0e-9
+    )
+
+
+def test_diagnose_stress_sign_reports_ambiguous_zero_stress():
+    positions = torch.zeros(1, 3, dtype=torch.float64)
+    cell = torch.eye(3, dtype=torch.float64)
+
+    result = diagnose_stress_sign(
+        positions,
+        cell,
+        torch.zeros(3, 3, dtype=torch.float64),
+        lambda _positions, _cell: 2.0,
+    )
+
+    assert result.inferred_source_sign == "ambiguous"
 
 
 @pytest.mark.parametrize(

--- a/tests/test_materials_preprocessing.py
+++ b/tests/test_materials_preprocessing.py
@@ -14,7 +14,7 @@ import torch
 from torch_geometric.data import Data
 
 from hydragnn.utils.materials import (
-    diagnose_stress_sign,
+    check_stress_against_energy_strain,
     normalize_stress,
     validate_materials_sample,
 )
@@ -68,7 +68,7 @@ def test_normalize_stress_preserves_ase_convention():
     ("reported_sign", "expected"),
     [(1.0, "tension_positive"), (-1.0, "compression_positive")],
 )
-def test_diagnose_stress_sign(reported_sign, expected):
+def test_check_stress_against_energy_strain(reported_sign, expected):
     dtype = torch.float64
     positions = torch.tensor([[0.1, 0.2, 0.3], [0.7, 0.6, 0.5]], dtype=dtype)
     cell = torch.diag(torch.tensor([2.0, 3.0, 4.0], dtype=dtype))
@@ -78,37 +78,37 @@ def test_diagnose_stress_sign(reported_sign, expected):
     )
     volume = torch.det(cell)
 
-    def energy_fn(_positions, strained_cell):
+    def reference_energy_fn(_positions, strained_cell):
         deformation = torch.linalg.solve(cell, strained_cell)
         strain = deformation - torch.eye(3, dtype=dtype)
         return volume * torch.sum(reference * strain)
 
-    result = diagnose_stress_sign(
+    result = check_stress_against_energy_strain(
         positions,
         cell,
         reported_sign * reference,
-        energy_fn,
+        reference_energy_fn=reference_energy_fn,
         strain_step=1.0e-5,
     )
 
-    assert result.inferred_source_sign == expected
+    assert result.preferred_sign_convention == expected
     torch.testing.assert_close(
         result.finite_difference_stress, reference, rtol=1.0e-9, atol=1.0e-9
     )
 
 
-def test_diagnose_stress_sign_reports_ambiguous_zero_stress():
+def test_energy_strain_check_reports_ambiguous_zero_stress():
     positions = torch.zeros(1, 3, dtype=torch.float64)
     cell = torch.eye(3, dtype=torch.float64)
 
-    result = diagnose_stress_sign(
+    result = check_stress_against_energy_strain(
         positions,
         cell,
         torch.zeros(3, 3, dtype=torch.float64),
-        lambda _positions, _cell: 2.0,
+        reference_energy_fn=lambda _positions, _cell: 2.0,
     )
 
-    assert result.inferred_source_sign == "ambiguous"
+    assert result.preferred_sign_convention == "ambiguous"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add an optional `stress_weight` term to energy-conserving MLIP training
- derive symmetric stress from the energy/cell-strain gradient and expose stress metrics during evaluation
- connect AllScAIP strain tracking to HydraGNN's MLIP wrapper
- add `diagnose_stress_sign` using six-component central finite differences
- document the stress data contract and sign-diagnostic workflow

## Validation
- `python3 -m compileall -q hydragnn tests/test_materials_preprocessing.py tests/test_interatomic_potential.py tests/_prediction_workflow.py`
- `git diff --check`
- Runtime pytest execution was not available in the local workspace because PyTorch and pytest are not installed.

## Configuration
```json
{
  "Architecture": {
    "enable_interatomic_potential": true,
    "energy_weight": 1.0,
    "energy_peratom_weight": 1.0,
    "force_weight": 10.0,
    "stress_weight": 1.0
  }
}
```